### PR TITLE
test: add comprehensive integration tests for all 4 dialog components

### DIFF
--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -1,0 +1,522 @@
+/**
+ * Azure DevOps Dialog Integration Tests
+ *
+ * Tests the lv-azure-devops-dialog Lit component for rendering, connection,
+ * tab navigation, data display, and error handling with mocked Tauri backend.
+ */
+
+// Mock Tauri API before importing any modules that use it
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeHistory: Array<{ command: string; args: unknown }> = [];
+const tokenStore = new Map<string, number[]>();
+
+(globalThis as unknown as { __TAURI_INTERNALS__: { invoke: MockInvoke } })
+  .__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    return mockInvoke(command, args);
+  },
+};
+
+import { expect, fixture, html } from '@open-wc/testing';
+import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
+import { createEmptyIntegrationAccount } from '../../../types/unified-profile.types.ts';
+import type { IntegrationAccount } from '../../../types/unified-profile.types.ts';
+import '../lv-azure-devops-dialog.ts';
+import type { LvAzureDevOpsDialog } from '../lv-azure-devops-dialog.ts';
+
+// --- Test Data ---
+
+const mockAdoUser = {
+  id: 'ado-user-id-1',
+  displayName: 'ADO User',
+  uniqueName: 'adouser@myorg.com',
+  imageUrl: null,
+};
+
+const mockConnectedStatus = {
+  connected: true,
+  user: mockAdoUser,
+  organization: 'testorg',
+};
+
+const mockDisconnectedStatus = {
+  connected: false,
+  user: null,
+  organization: null,
+};
+
+const mockDetectedRepo = {
+  organization: 'testorg',
+  project: 'test-project',
+  repository: 'test-repo',
+  remoteName: 'origin',
+};
+
+const mockPullRequests = [
+  {
+    pullRequestId: 101,
+    title: 'Add authentication module',
+    description: 'Implements OAuth2 authentication',
+    status: 'active',
+    createdBy: mockAdoUser,
+    creationDate: '2025-01-15T10:00:00Z',
+    sourceRefName: 'refs/heads/feature/auth',
+    targetRefName: 'refs/heads/main',
+    isDraft: false,
+    url: 'https://dev.azure.com/testorg/test-project/_git/test-repo/pullrequest/101',
+  },
+  {
+    pullRequestId: 100,
+    title: 'Fix build pipeline',
+    description: null,
+    status: 'completed',
+    createdBy: mockAdoUser,
+    creationDate: '2025-01-10T10:00:00Z',
+    sourceRefName: 'refs/heads/fix/build',
+    targetRefName: 'refs/heads/main',
+    isDraft: false,
+    url: 'https://dev.azure.com/testorg/test-project/_git/test-repo/pullrequest/100',
+  },
+];
+
+const mockWorkItems = [
+  {
+    id: 501,
+    title: 'Implement user dashboard',
+    workItemType: 'User Story',
+    state: 'Active',
+    assignedTo: mockAdoUser,
+    createdDate: '2025-01-12T10:00:00Z',
+    url: 'https://dev.azure.com/testorg/test-project/_workitems/edit/501',
+  },
+  {
+    id: 502,
+    title: 'Login button not responding',
+    workItemType: 'Bug',
+    state: 'New',
+    assignedTo: null,
+    createdDate: '2025-01-14T10:00:00Z',
+    url: 'https://dev.azure.com/testorg/test-project/_workitems/edit/502',
+  },
+];
+
+const mockPipelineRuns = [
+  {
+    id: 301,
+    name: 'Build & Test',
+    state: 'completed',
+    result: 'succeeded',
+    createdDate: '2025-01-15T10:00:00Z',
+    finishedDate: '2025-01-15T10:05:00Z',
+    sourceBranch: 'refs/heads/main',
+    url: 'https://dev.azure.com/testorg/test-project/_build/results?buildId=301',
+  },
+];
+
+function createTestAccount(
+  overrides: Partial<IntegrationAccount> & { id: string }
+): IntegrationAccount {
+  const base = createEmptyIntegrationAccount(overrides.integrationType ?? 'azure-devops');
+  return {
+    ...base,
+    name: 'Test Account',
+    isDefault: true,
+    cachedUser: null,
+    ...overrides,
+  } as IntegrationAccount;
+}
+
+function encodeToken(token: string): number[] {
+  return Array.from(new TextEncoder().encode(token));
+}
+
+async function waitForLoad(el: LvAzureDevOpsDialog): Promise<void> {
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+}
+
+// --- Mock Setup ---
+
+const mockAccount = createTestAccount({
+  id: 'ado-acc-1',
+  name: 'Work Azure DevOps',
+  integrationType: 'azure-devops',
+  config: { type: 'azure-devops', organization: 'testorg' },
+  isDefault: true,
+  cachedUser: {
+    username: 'adouser@myorg.com',
+    displayName: 'ADO User',
+    avatarUrl: null,
+    email: 'adouser@myorg.com',
+  },
+});
+
+let connectionResponse: unknown = mockDisconnectedStatus;
+let detectedRepoResponse: unknown = mockDetectedRepo;
+
+function setupMockInvoke(): void {
+  tokenStore.clear();
+  tokenStore.set('azure-devops_token_ado-acc-1', encodeToken('ado-pat-testtoken123456'));
+
+  mockInvoke = async (command: string, args?: unknown) => {
+    const params = args as Record<string, unknown> | undefined;
+
+    // Stronghold / credential service
+    if (command === 'plugin:path|resolve_directory') return '/mock/app/data';
+    if (command === 'plugin:stronghold|initialize') return null;
+    if (command === 'plugin:stronghold|load_client') return null;
+    if (command === 'plugin:stronghold|create_client') return null;
+    if (command === 'plugin:stronghold|save') return null;
+    if (command === 'migrate_vault_if_needed') return null;
+
+    if (command === 'plugin:stronghold|get_store_record') {
+      const recordPath = (params?.recordPath ?? params?.record_path) as string | undefined;
+      if (recordPath && tokenStore.has(recordPath)) {
+        return tokenStore.get(recordPath);
+      }
+      return null;
+    }
+
+    // Unified profile commands
+    if (command === 'get_unified_profiles_config') {
+      return {
+        version: 3,
+        profiles: [],
+        accounts: [mockAccount],
+        repositoryAssignments: {},
+      };
+    }
+    if (command === 'load_unified_profile_for_repository') return null;
+    if (command === 'save_global_account') return params;
+    if (command === 'update_global_account_cached_user') return null;
+
+    // Azure DevOps-specific commands
+    if (command === 'check_ado_connection') return connectionResponse;
+    if (command === 'check_ado_connection_with_token') return connectionResponse;
+    if (command === 'detect_ado_repo') return detectedRepoResponse;
+    if (command === 'list_ado_pull_requests') return mockPullRequests;
+    if (command === 'query_ado_work_items') return mockWorkItems;
+    if (command === 'list_ado_pipeline_runs') return mockPipelineRuns;
+    if (command === 'create_ado_pull_request') return mockPullRequests[0];
+    if (command === 'sync_git_credential_for_ado') return null;
+
+    return null;
+  };
+}
+
+describe('lv-azure-devops-dialog', () => {
+  beforeEach(() => {
+    invokeHistory.length = 0;
+    connectionResponse = mockDisconnectedStatus;
+    detectedRepoResponse = mockDetectedRepo;
+    unifiedProfileStore.getState().reset();
+    setupMockInvoke();
+  });
+
+  describe('Rendering & Modal', () => {
+    it('renders lv-modal when open=true', async () => {
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      const modal = el.shadowRoot!.querySelector('lv-modal');
+      expect(modal).to.not.be.null;
+    });
+
+    it('shows 4 tab buttons', async () => {
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      expect(tabs.length).to.equal(4);
+
+      const tabTexts = Array.from(tabs).map((t) => t.textContent?.trim());
+      expect(tabTexts).to.include('Connection');
+      expect(tabTexts).to.include('Pull Requests');
+      expect(tabTexts).to.include('Work Items');
+      expect(tabTexts).to.include('Pipelines');
+    });
+
+    it('shows detected repo info (org/project/repo)', async () => {
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      const repoName = el.shadowRoot!.querySelector('.repo-name');
+      if (repoName) {
+        expect(repoName.textContent).to.include('testorg');
+        expect(repoName.textContent).to.include('test-project');
+        expect(repoName.textContent).to.include('test-repo');
+      }
+    });
+
+    it('shows account selector when accounts exist', async () => {
+      unifiedProfileStore.getState().setAccounts([mockAccount]);
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      const selector = el.shadowRoot!.querySelector('lv-account-selector');
+      expect(selector).to.not.be.null;
+    });
+  });
+
+  describe('Connection Tab', () => {
+    it('shows organization input and PAT input when disconnected', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      const tokenForm = el.shadowRoot!.querySelector('.token-form');
+      expect(tokenForm).to.not.be.null;
+
+      // Should have organization input and PAT input
+      const inputs = el.shadowRoot!.querySelectorAll('input');
+      expect(inputs.length).to.be.greaterThan(0);
+
+      const passwordInput = el.shadowRoot!.querySelector('input[type="password"]');
+      expect(passwordInput).to.not.be.null;
+    });
+
+    it('shows user info (displayName, organization) when connected', async () => {
+      connectionResponse = mockConnectedStatus;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      const connectionStatus = el.shadowRoot!.querySelector('.connection-status');
+      expect(connectionStatus).to.not.be.null;
+
+      const userName = el.shadowRoot!.querySelector('.user-name');
+      expect(userName).to.not.be.null;
+      expect(userName!.textContent).to.include('ADO User');
+
+      const userOrg = el.shadowRoot!.querySelector('.user-org');
+      expect(userOrg).to.not.be.null;
+      expect(userOrg!.textContent).to.include('testorg');
+    });
+
+    it('shows disconnect button when connected', async () => {
+      connectionResponse = mockConnectedStatus;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      const disconnectBtn = el.shadowRoot!.querySelector('.btn-danger');
+      expect(disconnectBtn).to.not.be.null;
+      expect(disconnectBtn!.textContent?.trim()).to.include('Disconnect');
+    });
+  });
+
+  describe('Pull Requests Tab', () => {
+    it('shows empty state when not connected', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const emptyState = el.shadowRoot!.querySelector('.empty-state');
+      expect(emptyState).to.not.be.null;
+      expect(emptyState!.textContent).to.include('Connect to Azure DevOps');
+    });
+
+    it('renders PR items with ID, title, status, and branches', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const prItems = el.shadowRoot!.querySelectorAll('.pr-item');
+      expect(prItems.length).to.equal(2);
+
+      const firstPr = prItems[0];
+      expect(firstPr.querySelector('.pr-number')?.textContent).to.include('101');
+      expect(firstPr.querySelector('.pr-title')?.textContent).to.include('Add authentication module');
+      expect(firstPr.querySelector('.pr-branch')?.textContent).to.include('refs/heads/feature/auth');
+      expect(firstPr.querySelector('.pr-branch')?.textContent).to.include('refs/heads/main');
+    });
+
+    it('shows filter dropdown and New PR button', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const filterSelect = el.shadowRoot!.querySelector('.filter-select');
+      expect(filterSelect).to.not.be.null;
+
+      const newPrBtn = Array.from(el.shadowRoot!.querySelectorAll('.btn')).find(
+        (b) => b.textContent?.trim().includes('New PR')
+      );
+      expect(newPrBtn).to.not.be.undefined;
+    });
+  });
+
+  describe('Work Items Tab', () => {
+    it('renders work items with #id, title, type badge, and state', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Work Items tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const wiTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Work Items') as HTMLButtonElement;
+      wiTab.click();
+      await waitForLoad(el);
+
+      const workItems = el.shadowRoot!.querySelectorAll('.work-item');
+      expect(workItems.length).to.equal(2);
+
+      const firstItem = workItems[0];
+      expect(firstItem.querySelector('.work-item-id')?.textContent).to.include('501');
+      expect(firstItem.querySelector('.work-item-title')?.textContent).to.include('Implement user dashboard');
+      expect(firstItem.querySelector('.work-item-type')?.textContent).to.include('User Story');
+      expect(firstItem.querySelector('.work-item-state')?.textContent).to.include('Active');
+
+      const secondItem = workItems[1];
+      expect(secondItem.querySelector('.work-item-type')?.textContent).to.include('Bug');
+    });
+  });
+
+  describe('Pipelines Tab', () => {
+    it('renders pipeline runs with status indicator, name, and branch', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pipelines tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const pipelinesTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pipelines') as HTMLButtonElement;
+      pipelinesTab.click();
+      await waitForLoad(el);
+
+      const pipelineItems = el.shadowRoot!.querySelectorAll('.pipeline-item');
+      expect(pipelineItems.length).to.equal(1);
+
+      const firstPipeline = pipelineItems[0];
+      expect(firstPipeline.querySelector('.pipeline-name')?.textContent).to.include('Build & Test');
+      expect(firstPipeline.querySelector('.pipeline-branch')?.textContent).to.include('refs/heads/main');
+
+      // Status indicator should exist
+      const statusDot = firstPipeline.querySelector('.pipeline-status');
+      expect(statusDot).to.not.be.null;
+    });
+  });
+
+  describe('Tab Navigation', () => {
+    it('clicking tab button changes displayed content', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Initially on Connection tab - verify token form visible
+      const tokenForm = el.shadowRoot!.querySelector('.token-form');
+      expect(tokenForm).to.not.be.null;
+
+      // Click Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      // Token form should be gone
+      const tokenFormAfter = el.shadowRoot!.querySelector('.token-form');
+      expect(tokenFormAfter).to.be.null;
+
+      // Empty state should be visible (not connected)
+      const emptyState = el.shadowRoot!.querySelector('.empty-state');
+      expect(emptyState).to.not.be.null;
+    });
+
+    it('active tab has correct styling', async () => {
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const connectionTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Connection');
+      expect(connectionTab?.classList.contains('active')).to.be.true;
+
+      // Click Pull Requests tab
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await el.updateComplete;
+
+      expect(prTab.classList.contains('active')).to.be.true;
+      expect(connectionTab?.classList.contains('active')).to.be.false;
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('displays error message when error state is set', async () => {
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Set error state directly to test error rendering
+      (el as unknown as { error: string | null }).error = 'Organization not found';
+      await el.updateComplete;
+
+      const errorMsg = el.shadowRoot!.querySelector('.error');
+      expect(errorMsg).to.not.be.null;
+      expect(errorMsg!.textContent).to.include('Organization not found');
+    });
+  });
+});

--- a/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Bitbucket Dialog Integration Tests
+ *
+ * Tests the lv-bitbucket-dialog Lit component for rendering, connection,
+ * tab navigation, data display, and error handling with mocked Tauri backend.
+ */
+
+// Mock Tauri API before importing any modules that use it
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeHistory: Array<{ command: string; args: unknown }> = [];
+const tokenStore = new Map<string, number[]>();
+
+(globalThis as unknown as { __TAURI_INTERNALS__: { invoke: MockInvoke } })
+  .__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    return mockInvoke(command, args);
+  },
+};
+
+import { expect, fixture, html } from '@open-wc/testing';
+import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
+import { createEmptyIntegrationAccount } from '../../../types/unified-profile.types.ts';
+import type { IntegrationAccount } from '../../../types/unified-profile.types.ts';
+import '../lv-bitbucket-dialog.ts';
+import type { LvBitbucketDialog } from '../lv-bitbucket-dialog.ts';
+
+// --- Test Data ---
+
+const mockBitbucketUser = {
+  uuid: '{bb-uuid-12345}',
+  username: 'bbuser',
+  displayName: 'BB User',
+  avatarUrl: 'https://example.com/bb-avatar.png',
+};
+
+const mockConnectedStatus = {
+  connected: true,
+  user: mockBitbucketUser,
+};
+
+const mockDisconnectedStatus = {
+  connected: false,
+  user: null,
+};
+
+const mockDetectedRepo = {
+  workspace: 'test-workspace',
+  repoSlug: 'test-repo',
+  remoteName: 'origin',
+};
+
+const mockPullRequests = [
+  {
+    id: 25,
+    title: 'Add README documentation',
+    description: 'Adds comprehensive README',
+    state: 'OPEN',
+    author: mockBitbucketUser,
+    createdOn: '2025-01-15T10:00:00Z',
+    sourceBranch: 'feature/readme',
+    destinationBranch: 'main',
+    url: 'https://bitbucket.org/test-workspace/test-repo/pull-requests/25',
+  },
+  {
+    id: 24,
+    title: 'Update CI config',
+    description: null,
+    state: 'MERGED',
+    author: mockBitbucketUser,
+    createdOn: '2025-01-10T10:00:00Z',
+    sourceBranch: 'fix/ci',
+    destinationBranch: 'main',
+    url: 'https://bitbucket.org/test-workspace/test-repo/pull-requests/24',
+  },
+];
+
+const mockIssues = [
+  {
+    id: 10,
+    title: 'Build fails on Windows',
+    content: 'The build process fails on Windows machines',
+    state: 'new',
+    priority: 'critical',
+    kind: 'bug',
+    reporter: mockBitbucketUser,
+    assignee: null,
+    createdOn: '2025-01-12T10:00:00Z',
+    url: 'https://bitbucket.org/test-workspace/test-repo/issues/10',
+  },
+];
+
+const mockPipelines = [
+  {
+    uuid: '{pipe-uuid-1}',
+    buildNumber: 42,
+    stateName: 'COMPLETED',
+    resultName: 'SUCCESSFUL',
+    targetBranch: 'main',
+    createdOn: '2025-01-15T10:00:00Z',
+    completedOn: '2025-01-15T10:05:00Z',
+    url: 'https://bitbucket.org/test-workspace/test-repo/addon/pipelines/home#!/results/42',
+  },
+];
+
+function createTestAccount(
+  overrides: Partial<IntegrationAccount> & { id: string }
+): IntegrationAccount {
+  const base = createEmptyIntegrationAccount(overrides.integrationType ?? 'bitbucket');
+  return {
+    ...base,
+    name: 'Test Account',
+    isDefault: true,
+    cachedUser: null,
+    ...overrides,
+  } as IntegrationAccount;
+}
+
+function encodeToken(token: string): number[] {
+  return Array.from(new TextEncoder().encode(token));
+}
+
+async function waitForLoad(el: LvBitbucketDialog): Promise<void> {
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+}
+
+// --- Mock Setup ---
+
+const mockAccount = createTestAccount({
+  id: 'bb-acc-1',
+  name: 'Work Bitbucket',
+  integrationType: 'bitbucket',
+  config: { type: 'bitbucket', workspace: 'test-workspace' },
+  isDefault: true,
+  cachedUser: {
+    username: 'bbuser',
+    displayName: 'BB User',
+    avatarUrl: 'https://example.com/bb-avatar.png',
+    email: 'bb@example.com',
+  },
+});
+
+let connectionResponse: unknown = mockDisconnectedStatus;
+let detectedRepoResponse: unknown = mockDetectedRepo;
+
+function setupMockInvoke(): void {
+  tokenStore.clear();
+  tokenStore.set('bitbucket_token_bb-acc-1', encodeToken('bb-app-password-test'));
+
+  mockInvoke = async (command: string, args?: unknown) => {
+    const params = args as Record<string, unknown> | undefined;
+
+    // Stronghold / credential service
+    if (command === 'plugin:path|resolve_directory') return '/mock/app/data';
+    if (command === 'plugin:stronghold|initialize') return null;
+    if (command === 'plugin:stronghold|load_client') return null;
+    if (command === 'plugin:stronghold|create_client') return null;
+    if (command === 'plugin:stronghold|save') return null;
+    if (command === 'migrate_vault_if_needed') return null;
+
+    if (command === 'plugin:stronghold|get_store_record') {
+      const recordPath = (params?.recordPath ?? params?.record_path) as string | undefined;
+      if (recordPath && tokenStore.has(recordPath)) {
+        return tokenStore.get(recordPath);
+      }
+      return null;
+    }
+
+    // Unified profile commands
+    if (command === 'get_unified_profiles_config') {
+      return {
+        version: 3,
+        profiles: [],
+        accounts: [mockAccount],
+        repositoryAssignments: {},
+      };
+    }
+    if (command === 'load_unified_profile_for_repository') return null;
+    if (command === 'save_global_account') return params;
+    if (command === 'update_global_account_cached_user') return null;
+
+    // Bitbucket-specific commands
+    if (command === 'check_bitbucket_connection') return connectionResponse;
+    if (command === 'check_bitbucket_connection_with_token') return connectionResponse;
+    if (command === 'detect_bitbucket_repo') return detectedRepoResponse;
+    if (command === 'list_bitbucket_pull_requests') return mockPullRequests;
+    if (command === 'list_bitbucket_issues') return mockIssues;
+    if (command === 'list_bitbucket_pipelines') return mockPipelines;
+    if (command === 'create_bitbucket_pull_request') return mockPullRequests[0];
+    if (command === 'store_bitbucket_credentials') return null;
+    if (command === 'delete_bitbucket_credentials') return null;
+
+    // OAuth
+    if (command === 'get_oauth_client_id') return null;
+
+    return null;
+  };
+}
+
+describe('lv-bitbucket-dialog', () => {
+  beforeEach(() => {
+    invokeHistory.length = 0;
+    connectionResponse = mockDisconnectedStatus;
+    detectedRepoResponse = mockDetectedRepo;
+    unifiedProfileStore.getState().reset();
+    setupMockInvoke();
+  });
+
+  describe('Rendering & Modal', () => {
+    it('renders lv-modal when open=true', async () => {
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      const modal = el.shadowRoot!.querySelector('lv-modal');
+      expect(modal).to.not.be.null;
+    });
+
+    it('shows 4 tab buttons', async () => {
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      expect(tabs.length).to.equal(4);
+
+      const tabTexts = Array.from(tabs).map((t) => t.textContent?.trim());
+      expect(tabTexts).to.include('Connection');
+      expect(tabTexts).to.include('Pull Requests');
+      expect(tabTexts).to.include('Issues');
+      expect(tabTexts).to.include('Pipelines');
+    });
+
+    it('shows detected repo info (workspace/repoSlug)', async () => {
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      const repoName = el.shadowRoot!.querySelector('.repo-name');
+      if (repoName) {
+        expect(repoName.textContent).to.include('test-workspace');
+        expect(repoName.textContent).to.include('test-repo');
+      }
+    });
+
+    it('shows account selector when accounts exist', async () => {
+      unifiedProfileStore.getState().setAccounts([mockAccount]);
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      const selector = el.shadowRoot!.querySelector('lv-account-selector');
+      expect(selector).to.not.be.null;
+    });
+  });
+
+  describe('Connection Tab', () => {
+    it('shows username and app password inputs when disconnected', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      const tokenForm = el.shadowRoot!.querySelector('.token-form');
+      expect(tokenForm).to.not.be.null;
+
+      // Should have username and app password inputs
+      const inputs = el.shadowRoot!.querySelectorAll('input');
+      expect(inputs.length).to.be.greaterThan(0);
+
+      const passwordInput = el.shadowRoot!.querySelector('input[type="password"]');
+      expect(passwordInput).to.not.be.null;
+    });
+
+    it('shows user info (displayName, @username) when connected', async () => {
+      connectionResponse = mockConnectedStatus;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      const connectionStatus = el.shadowRoot!.querySelector('.connection-status');
+      expect(connectionStatus).to.not.be.null;
+
+      const userName = el.shadowRoot!.querySelector('.user-name');
+      expect(userName).to.not.be.null;
+      expect(userName!.textContent).to.include('BB User');
+
+      const userLogin = el.shadowRoot!.querySelector('.user-login');
+      expect(userLogin).to.not.be.null;
+      expect(userLogin!.textContent).to.include('bbuser');
+    });
+
+    it('shows disconnect button when connected', async () => {
+      connectionResponse = mockConnectedStatus;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      const disconnectBtn = el.shadowRoot!.querySelector('.btn-danger');
+      expect(disconnectBtn).to.not.be.null;
+      expect(disconnectBtn!.textContent?.trim()).to.include('Disconnect');
+    });
+  });
+
+  describe('Pull Requests Tab', () => {
+    it('shows empty state when not connected', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const emptyState = el.shadowRoot!.querySelector('.empty-state');
+      expect(emptyState).to.not.be.null;
+      expect(emptyState!.textContent).to.include('pull requests');
+    });
+
+    it('renders PR items with #id, title, UPPERCASE state, and branches', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const prItems = el.shadowRoot!.querySelectorAll('.pr-item');
+      expect(prItems.length).to.equal(2);
+
+      const firstPr = prItems[0];
+      expect(firstPr.querySelector('.pr-number')?.textContent).to.include('25');
+      expect(firstPr.querySelector('.pr-title')?.textContent).to.include('Add README documentation');
+      expect(firstPr.querySelector('.pr-state')?.textContent).to.include('OPEN');
+      expect(firstPr.querySelector('.pr-branch')?.textContent).to.include('feature/readme');
+      expect(firstPr.querySelector('.pr-branch')?.textContent).to.include('main');
+    });
+
+    it('shows filter dropdown and New PR button', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const filterSelect = el.shadowRoot!.querySelector('.filter-select');
+      expect(filterSelect).to.not.be.null;
+
+      const newPrBtn = Array.from(el.shadowRoot!.querySelectorAll('.btn')).find(
+        (b) => b.textContent?.trim().includes('New PR')
+      );
+      expect(newPrBtn).to.not.be.undefined;
+    });
+  });
+
+  describe('Issues Tab', () => {
+    it('renders issue items with #id, title, kind, and priority', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Issues tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const issuesTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Issues') as HTMLButtonElement;
+      issuesTab.click();
+      await waitForLoad(el);
+
+      const issueItems = el.shadowRoot!.querySelectorAll('.issue-item');
+      expect(issueItems.length).to.equal(1);
+
+      const firstIssue = issueItems[0];
+      expect(firstIssue.querySelector('.issue-number')?.textContent).to.include('10');
+      expect(firstIssue.querySelector('.issue-title')?.textContent).to.include('Build fails on Windows');
+
+      const metaText = firstIssue.querySelector('.issue-meta')?.textContent;
+      expect(metaText).to.include('bug');
+      expect(metaText).to.include('critical');
+    });
+  });
+
+  describe('Pipelines Tab', () => {
+    it('renders pipeline items with status dot, build number, and branch', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pipelines tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const pipelinesTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pipelines') as HTMLButtonElement;
+      pipelinesTab.click();
+      await waitForLoad(el);
+
+      const pipelineItems = el.shadowRoot!.querySelectorAll('.pipeline-item');
+      expect(pipelineItems.length).to.equal(1);
+
+      const firstPipeline = pipelineItems[0];
+      expect(firstPipeline.querySelector('.pipeline-name')?.textContent).to.include('42');
+      expect(firstPipeline.querySelector('.pipeline-branch')?.textContent).to.include('main');
+
+      // Status indicator should exist
+      const statusDot = firstPipeline.querySelector('.pipeline-status');
+      expect(statusDot).to.not.be.null;
+    });
+  });
+
+  describe('Tab Navigation', () => {
+    it('clicking tab button changes displayed content', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Initially on Connection tab - verify token form visible
+      const tokenForm = el.shadowRoot!.querySelector('.token-form');
+      expect(tokenForm).to.not.be.null;
+
+      // Click Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      // Token form should be gone
+      const tokenFormAfter = el.shadowRoot!.querySelector('.token-form');
+      expect(tokenFormAfter).to.be.null;
+
+      // Empty state should be visible (not connected)
+      const emptyState = el.shadowRoot!.querySelector('.empty-state');
+      expect(emptyState).to.not.be.null;
+    });
+
+    it('active tab has correct styling', async () => {
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const connectionTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Connection');
+      expect(connectionTab?.classList.contains('active')).to.be.true;
+
+      // Click Pull Requests tab
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await el.updateComplete;
+
+      expect(prTab.classList.contains('active')).to.be.true;
+      expect(connectionTab?.classList.contains('active')).to.be.false;
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('displays error message when error state is set', async () => {
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Set error state directly to test error rendering
+      (el as unknown as { error: string | null }).error = 'Bitbucket API rate limited';
+      await el.updateComplete;
+
+      const errorMsg = el.shadowRoot!.querySelector('.error');
+      expect(errorMsg).to.not.be.null;
+      expect(errorMsg!.textContent).to.include('Bitbucket API rate limited');
+    });
+  });
+});

--- a/src/components/dialogs/__tests__/lv-github-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-github-dialog.test.ts
@@ -1,90 +1,609 @@
-import { expect } from '@open-wc/testing';
+/**
+ * GitHub Dialog Integration Tests
+ *
+ * Tests the lv-github-dialog Lit component for rendering, connection,
+ * tab navigation, data display, and error handling with mocked Tauri backend.
+ */
 
 // Mock Tauri API before importing any modules that use it
-const mockInvoke = (command: string): Promise<unknown> => {
-  switch (command) {
-    case 'get_github_token':
-      return Promise.resolve(null);
-    case 'check_github_connection':
-      return Promise.resolve({
-        connected: false,
-        user: null,
-        scopes: [],
-      });
-    case 'detect_github_repo':
-      return Promise.resolve({
-        owner: 'test-owner',
-        repo: 'test-repo',
-        defaultBranch: 'main',
-      });
-    default:
-      return Promise.resolve(null);
-  }
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeHistory: Array<{ command: string; args: unknown }> = [];
+const tokenStore = new Map<string, number[]>();
+
+(globalThis as unknown as { __TAURI_INTERNALS__: { invoke: MockInvoke } })
+  .__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    return mockInvoke(command, args);
+  },
 };
 
-// Mock the Tauri invoke function globally
-(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
-  invoke: mockInvoke,
+import { expect, fixture, html } from '@open-wc/testing';
+import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
+import { createEmptyIntegrationAccount } from '../../../types/unified-profile.types.ts';
+import type { IntegrationAccount } from '../../../types/unified-profile.types.ts';
+import '../lv-github-dialog.ts';
+import type { LvGitHubDialog } from '../lv-github-dialog.ts';
+
+// --- Test Data ---
+
+const mockGitHubUser = {
+  login: 'octocat',
+  id: 12345,
+  avatarUrl: 'https://example.com/avatar.png',
+  name: 'The Octocat',
+  email: 'octocat@github.com',
 };
 
-describe('GitHub Dialog Data Structures', () => {
-  describe('GitHubConnectionStatus', () => {
-    it('should have correct structure for connected state', () => {
-      const status = {
-        connected: true,
-        user: {
-          login: 'octocat',
-          id: 12345,
-          avatarUrl: 'https://example.com/avatar.png',
-          name: 'The Octocat',
-          email: 'octocat@github.com',
-        },
-        scopes: ['repo', 'read:user'],
+const mockConnectedStatus = {
+  connected: true,
+  user: mockGitHubUser,
+  scopes: ['repo', 'read:user'],
+};
+
+const mockDisconnectedStatus = {
+  connected: false,
+  user: null,
+  scopes: [],
+};
+
+const mockDetectedRepo = {
+  owner: 'test-owner',
+  repo: 'test-repo',
+  remoteName: 'origin',
+};
+
+const mockPullRequests = [
+  {
+    number: 42,
+    title: 'Add new feature',
+    state: 'open',
+    user: mockGitHubUser,
+    createdAt: '2025-01-15T10:00:00Z',
+    updatedAt: '2025-01-16T10:00:00Z',
+    mergedAt: null,
+    headRef: 'feature/new-thing',
+    headSha: 'abc1234',
+    baseRef: 'main',
+    draft: false,
+    mergeable: true,
+    htmlUrl: 'https://github.com/test-owner/test-repo/pull/42',
+    additions: 150,
+    deletions: 30,
+    changedFiles: 5,
+  },
+  {
+    number: 41,
+    title: 'Fix bug in login',
+    state: 'closed',
+    user: mockGitHubUser,
+    createdAt: '2025-01-10T10:00:00Z',
+    updatedAt: '2025-01-12T10:00:00Z',
+    mergedAt: '2025-01-12T10:00:00Z',
+    headRef: 'fix/login-bug',
+    headSha: 'def5678',
+    baseRef: 'main',
+    draft: false,
+    mergeable: null,
+    htmlUrl: 'https://github.com/test-owner/test-repo/pull/41',
+    additions: 10,
+    deletions: 5,
+    changedFiles: 2,
+  },
+];
+
+const mockIssues = [
+  {
+    number: 100,
+    title: 'Bug: Login fails on mobile',
+    state: 'open',
+    user: mockGitHubUser,
+    labels: [
+      { id: 1, name: 'bug', color: 'd73a4a', description: 'Something is broken' },
+      { id: 2, name: 'priority: high', color: 'e11d48', description: null },
+    ],
+    assignees: [],
+    comments: 3,
+    createdAt: '2025-01-10T10:00:00Z',
+    updatedAt: '2025-01-11T10:00:00Z',
+    closedAt: null,
+    htmlUrl: 'https://github.com/test-owner/test-repo/issues/100',
+  },
+];
+
+const mockWorkflowRuns = [
+  {
+    id: 1001,
+    name: 'CI',
+    headBranch: 'main',
+    headSha: 'abc1234',
+    status: 'completed',
+    conclusion: 'success',
+    workflowId: 10,
+    htmlUrl: 'https://github.com/test-owner/test-repo/actions/runs/1001',
+    createdAt: '2025-01-15T10:00:00Z',
+    updatedAt: '2025-01-15T10:05:00Z',
+    runNumber: 55,
+    event: 'push',
+  },
+];
+
+const mockReleases = [
+  {
+    id: 2001,
+    tagName: 'v1.0.0',
+    name: 'Version 1.0.0',
+    body: 'First stable release',
+    draft: false,
+    prerelease: false,
+    createdAt: '2025-01-01T10:00:00Z',
+    publishedAt: '2025-01-01T12:00:00Z',
+    htmlUrl: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0',
+    author: mockGitHubUser,
+    assetsCount: 2,
+  },
+];
+
+const mockLabels = [
+  { id: 1, name: 'bug', color: 'd73a4a', description: 'Something is broken' },
+  { id: 2, name: 'enhancement', color: 'a2eeef', description: 'New feature' },
+];
+
+function createTestAccount(
+  overrides: Partial<IntegrationAccount> & { id: string }
+): IntegrationAccount {
+  const base = createEmptyIntegrationAccount(overrides.integrationType ?? 'github');
+  return {
+    ...base,
+    name: 'Test Account',
+    isDefault: true,
+    cachedUser: null,
+    ...overrides,
+  } as IntegrationAccount;
+}
+
+function encodeToken(token: string): number[] {
+  return Array.from(new TextEncoder().encode(token));
+}
+
+async function waitForLoad(el: LvGitHubDialog): Promise<void> {
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 300));
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 100));
+  await el.updateComplete;
+}
+
+// --- Mock Setup ---
+
+const mockAccount = createTestAccount({
+  id: 'gh-acc-1',
+  name: 'Work GitHub',
+  integrationType: 'github',
+  isDefault: true,
+  cachedUser: {
+    username: 'octocat',
+    displayName: 'The Octocat',
+    avatarUrl: 'https://example.com/avatar.png',
+    email: 'octocat@github.com',
+  },
+});
+
+let connectionResponse: unknown = mockDisconnectedStatus;
+let detectedRepoResponse: unknown = mockDetectedRepo;
+
+function setupMockInvoke(): void {
+  tokenStore.clear();
+  tokenStore.set('github_token_gh-acc-1', encodeToken('ghp_testtoken123456'));
+
+  mockInvoke = async (command: string, args?: unknown) => {
+    const params = args as Record<string, unknown> | undefined;
+
+    // Stronghold / credential service
+    if (command === 'plugin:path|resolve_directory') return '/mock/app/data';
+    if (command === 'plugin:stronghold|initialize') return null;
+    if (command === 'plugin:stronghold|load_client') return null;
+    if (command === 'plugin:stronghold|create_client') return null;
+    if (command === 'plugin:stronghold|save') return null;
+    if (command === 'migrate_vault_if_needed') return null;
+
+    if (command === 'plugin:stronghold|get_store_record') {
+      const recordPath = (params?.recordPath ?? params?.record_path) as string | undefined;
+      if (recordPath && tokenStore.has(recordPath)) {
+        return tokenStore.get(recordPath);
+      }
+      return null;
+    }
+
+    // Unified profile commands
+    if (command === 'get_unified_profiles_config') {
+      return {
+        version: 3,
+        profiles: [],
+        accounts: [mockAccount],
+        repositoryAssignments: {},
       };
+    }
+    if (command === 'load_unified_profile_for_repository') return null;
+    if (command === 'save_global_account') return params;
+    if (command === 'update_global_account_cached_user') return null;
 
-      expect(status.connected).to.be.true;
-      expect(status.user).to.not.be.null;
-      expect(status.user?.login).to.equal('octocat');
-      expect(status.scopes).to.have.length(2);
+    // GitHub-specific commands
+    if (command === 'check_github_connection') return connectionResponse;
+    if (command === 'check_github_connection_with_token') return connectionResponse;
+    if (command === 'detect_github_repo') return detectedRepoResponse;
+    if (command === 'list_pull_requests') return mockPullRequests;
+    if (command === 'list_issues' || command === 'list_github_issues') return mockIssues;
+    if (command === 'get_workflow_runs') return mockWorkflowRuns;
+    if (command === 'list_releases') return mockReleases;
+    if (command === 'get_github_labels' || command === 'get_repo_labels') return mockLabels;
+    if (command === 'create_pull_request') return mockPullRequests[0];
+    if (command === 'create_issue' || command === 'create_github_issue') return mockIssues[0];
+    if (command === 'create_release' || command === 'create_github_release') return mockReleases[0];
+
+    // OAuth
+    if (command === 'get_oauth_client_id') return null;
+
+    return null;
+  };
+}
+
+describe('lv-github-dialog', () => {
+  beforeEach(() => {
+    invokeHistory.length = 0;
+    connectionResponse = mockDisconnectedStatus;
+    detectedRepoResponse = mockDetectedRepo;
+    unifiedProfileStore.getState().reset();
+    setupMockInvoke();
+  });
+
+  describe('Rendering & Modal', () => {
+    it('renders lv-modal when open=true', async () => {
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      const modal = el.shadowRoot!.querySelector('lv-modal');
+      expect(modal).to.not.be.null;
     });
 
-    it('should have correct structure for disconnected state', () => {
-      const status = {
-        connected: false,
-        user: null,
-        scopes: [],
-      };
+    it('shows all 5 tab buttons', async () => {
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
 
-      expect(status.connected).to.be.false;
-      expect(status.user).to.be.null;
-      expect(status.scopes).to.have.length(0);
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      expect(tabs.length).to.equal(5);
+
+      const tabTexts = Array.from(tabs).map((t) => t.textContent?.trim());
+      expect(tabTexts).to.include('Connection');
+      expect(tabTexts).to.include('Pull Requests');
+      expect(tabTexts).to.include('Issues');
+      expect(tabTexts).to.include('Releases');
+      expect(tabTexts).to.include('Actions');
+    });
+
+    it('shows detected repo info after load', async () => {
+      connectionResponse = mockDisconnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      const repoName = el.shadowRoot!.querySelector('.repo-name');
+      if (repoName) {
+        expect(repoName.textContent).to.include('test-owner');
+        expect(repoName.textContent).to.include('test-repo');
+      }
+    });
+
+    it('shows account selector when accounts exist', async () => {
+      unifiedProfileStore.getState().setAccounts([mockAccount]);
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      const selector = el.shadowRoot!.querySelector('lv-account-selector');
+      expect(selector).to.not.be.null;
     });
   });
 
-  describe('DetectedGitHubRepo', () => {
-    it('should have owner and repo properties', () => {
-      const repo = {
-        owner: 'test-owner',
-        repo: 'test-repo',
-        defaultBranch: 'main',
-      };
+  describe('Connection Tab', () => {
+    it('shows auth form when not connected', async () => {
+      connectionResponse = mockDisconnectedStatus;
 
-      expect(repo.owner).to.equal('test-owner');
-      expect(repo.repo).to.equal('test-repo');
-      expect(repo.defaultBranch).to.equal('main');
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      // When disconnected, the token-form or auth-method-toggle should be present
+      const tokenForm = el.shadowRoot!.querySelector('.token-form');
+      const authToggle = el.shadowRoot!.querySelector('.auth-method-toggle');
+      const oauthSection = el.shadowRoot!.querySelector('.oauth-section');
+      expect(tokenForm !== null || authToggle !== null || oauthSection !== null).to.be.true;
+    });
+
+    it('shows user info when connected', async () => {
+      connectionResponse = mockConnectedStatus;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      const connectionStatus = el.shadowRoot!.querySelector('.connection-status');
+      expect(connectionStatus).to.not.be.null;
+
+      const userName = el.shadowRoot!.querySelector('.user-name');
+      expect(userName).to.not.be.null;
+      expect(userName!.textContent).to.include('The Octocat');
+
+      const userLogin = el.shadowRoot!.querySelector('.user-login');
+      expect(userLogin).to.not.be.null;
+      expect(userLogin!.textContent).to.include('octocat');
+    });
+
+    it('shows scopes when connected', async () => {
+      connectionResponse = mockConnectedStatus;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      const scopeBadges = el.shadowRoot!.querySelectorAll('.scope-badge');
+      expect(scopeBadges.length).to.equal(2);
+      const scopeTexts = Array.from(scopeBadges).map((s) => s.textContent?.trim());
+      expect(scopeTexts).to.include('repo');
+      expect(scopeTexts).to.include('read:user');
+    });
+
+    it('shows disconnect button when connected', async () => {
+      connectionResponse = mockConnectedStatus;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      const disconnectBtn = el.shadowRoot!.querySelector('.btn-danger');
+      expect(disconnectBtn).to.not.be.null;
+      expect(disconnectBtn!.textContent?.trim()).to.include('Disconnect');
     });
   });
 
-  describe('GitHub token format', () => {
-    it('should recognize classic PAT format', () => {
-      const token = 'ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
-      expect(token.startsWith('ghp_')).to.be.true;
-      expect(token.length).to.equal(40);
+  describe('Pull Requests Tab', () => {
+    it('shows empty state when not connected', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const emptyState = el.shadowRoot!.querySelector('.empty-state');
+      expect(emptyState).to.not.be.null;
+      expect(emptyState!.textContent).to.include('Connect to GitHub');
     });
 
-    it('should recognize fine-grained PAT format', () => {
-      const token = 'github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
-      expect(token.startsWith('github_pat_')).to.be.true;
+    it('renders PR items with number, title, state, and branches', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const prItems = el.shadowRoot!.querySelectorAll('.pr-item');
+      expect(prItems.length).to.equal(2);
+
+      const firstPr = prItems[0];
+      expect(firstPr.querySelector('.pr-number')?.textContent).to.include('42');
+      expect(firstPr.querySelector('.pr-title')?.textContent).to.include('Add new feature');
+      expect(firstPr.querySelector('.pr-branch')?.textContent).to.include('feature/new-thing');
+      expect(firstPr.querySelector('.pr-branch')?.textContent).to.include('main');
+    });
+
+    it('shows filter dropdown and New PR button', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const filterSelect = el.shadowRoot!.querySelector('.filter-select');
+      expect(filterSelect).to.not.be.null;
+
+      const newPrBtn = Array.from(el.shadowRoot!.querySelectorAll('.btn')).find(
+        (b) => b.textContent?.trim().includes('New PR')
+      );
+      expect(newPrBtn).to.not.be.undefined;
+    });
+  });
+
+  describe('Issues Tab', () => {
+    it('renders issue items with number, title, and labels', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Issues tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const issuesTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Issues') as HTMLButtonElement;
+      issuesTab.click();
+      await waitForLoad(el);
+
+      const issueItems = el.shadowRoot!.querySelectorAll('.issue-item');
+      expect(issueItems.length).to.equal(1);
+
+      const firstIssue = issueItems[0];
+      expect(firstIssue.querySelector('.issue-number')?.textContent).to.include('100');
+      expect(firstIssue.querySelector('.issue-title')?.textContent).to.include('Bug: Login fails on mobile');
+
+      const labels = firstIssue.querySelectorAll('.issue-label');
+      expect(labels.length).to.equal(2);
+      expect(labels[0].textContent?.trim()).to.equal('bug');
+    });
+  });
+
+  describe('Releases Tab', () => {
+    it('renders release items with tag name and badges', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Releases tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const releasesTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Releases') as HTMLButtonElement;
+      releasesTab.click();
+      await waitForLoad(el);
+
+      const releaseItems = el.shadowRoot!.querySelectorAll('.release-item');
+      expect(releaseItems.length).to.equal(1);
+
+      const firstRelease = releaseItems[0];
+      expect(firstRelease.querySelector('.release-tag')?.textContent).to.include('v1.0.0');
+      expect(firstRelease.querySelector('.release-title')?.textContent).to.include('Version 1.0.0');
+
+      // First non-draft, non-prerelease should get "Latest" badge
+      const latestBadge = firstRelease.querySelector('.release-badge.latest');
+      expect(latestBadge).to.not.be.null;
+    });
+  });
+
+  describe('Actions Tab', () => {
+    it('renders workflow runs with status indicators', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Actions tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const actionsTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Actions') as HTMLButtonElement;
+      actionsTab.click();
+      await waitForLoad(el);
+
+      const workflowItems = el.shadowRoot!.querySelectorAll('.workflow-item');
+      expect(workflowItems.length).to.equal(1);
+
+      const firstRun = workflowItems[0];
+      expect(firstRun.querySelector('.workflow-name')?.textContent).to.include('CI');
+      expect(firstRun.querySelector('.workflow-branch')?.textContent).to.include('main');
+
+      // Status indicator should exist
+      const statusDot = firstRun.querySelector('.workflow-status');
+      expect(statusDot).to.not.be.null;
+    });
+  });
+
+  describe('Tab Navigation', () => {
+    it('clicking tab button changes displayed content', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Initially on Connection tab - verify connection content visible
+      const connectionStatus = el.shadowRoot!.querySelector('.connection-status');
+      expect(connectionStatus).to.not.be.null;
+
+      // Click Pull Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      // Connection status should be gone, PR content visible
+      const connectionAfter = el.shadowRoot!.querySelector('.connection-status');
+      expect(connectionAfter).to.be.null;
+
+      const prList = el.shadowRoot!.querySelector('.pr-list, .filter-row, .empty-state');
+      expect(prList).to.not.be.null;
+    });
+
+    it('active tab has correct styling', async () => {
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const connectionTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Connection');
+      expect(connectionTab?.classList.contains('active')).to.be.true;
+
+      // Click Pull Requests tab
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await el.updateComplete;
+
+      expect(prTab.classList.contains('active')).to.be.true;
+      expect(connectionTab?.classList.contains('active')).to.be.false;
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('displays error message when error state is set', async () => {
+      // Make connection check throw an error
+      const origMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'check_github_connection_with_token' || command === 'check_github_connection') {
+          throw new Error('Network timeout');
+        }
+        return origMock(command, args);
+      };
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      const errorMsg = el.shadowRoot!.querySelector('.error-message');
+      expect(errorMsg).to.not.be.null;
+      expect(errorMsg!.textContent).to.include('Network timeout');
     });
   });
 });

--- a/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
@@ -1,0 +1,523 @@
+/**
+ * GitLab Dialog Integration Tests
+ *
+ * Tests the lv-gitlab-dialog Lit component for rendering, connection,
+ * tab navigation, data display, and error handling with mocked Tauri backend.
+ */
+
+// Mock Tauri API before importing any modules that use it
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeHistory: Array<{ command: string; args: unknown }> = [];
+const tokenStore = new Map<string, number[]>();
+
+(globalThis as unknown as { __TAURI_INTERNALS__: { invoke: MockInvoke } })
+  .__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    return mockInvoke(command, args);
+  },
+};
+
+import { expect, fixture, html } from '@open-wc/testing';
+import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
+import { createEmptyIntegrationAccount } from '../../../types/unified-profile.types.ts';
+import type { IntegrationAccount } from '../../../types/unified-profile.types.ts';
+import '../lv-gitlab-dialog.ts';
+import type { LvGitLabDialog } from '../lv-gitlab-dialog.ts';
+
+// --- Test Data ---
+
+const mockGitLabUser = {
+  id: 54321,
+  username: 'gluser',
+  name: 'GL User',
+  avatarUrl: 'https://example.com/gl-avatar.png',
+  webUrl: 'https://gitlab.com/gluser',
+};
+
+const mockConnectedStatus = {
+  connected: true,
+  user: mockGitLabUser,
+  instanceUrl: 'https://gitlab.com',
+};
+
+const mockDisconnectedStatus = {
+  connected: false,
+  user: null,
+  instanceUrl: 'https://gitlab.com',
+};
+
+const mockDetectedRepo = {
+  instanceUrl: 'https://gitlab.com',
+  projectPath: 'test-group/test-project',
+  remoteName: 'origin',
+};
+
+const mockMergeRequests = [
+  {
+    iid: 15,
+    title: 'Add CI pipeline config',
+    description: 'Adds .gitlab-ci.yml',
+    state: 'opened',
+    author: mockGitLabUser,
+    createdAt: '2025-01-15T10:00:00Z',
+    sourceBranch: 'feature/ci-setup',
+    targetBranch: 'main',
+    draft: false,
+    webUrl: 'https://gitlab.com/test-group/test-project/-/merge_requests/15',
+  },
+  {
+    iid: 14,
+    title: 'Fix deploy script',
+    description: null,
+    state: 'merged',
+    author: mockGitLabUser,
+    createdAt: '2025-01-10T10:00:00Z',
+    sourceBranch: 'fix/deploy',
+    targetBranch: 'main',
+    draft: false,
+    webUrl: 'https://gitlab.com/test-group/test-project/-/merge_requests/14',
+  },
+];
+
+const mockIssues = [
+  {
+    iid: 42,
+    title: 'Performance regression in API',
+    description: 'API calls are slow',
+    state: 'opened',
+    author: mockGitLabUser,
+    assignees: [],
+    labels: ['bug', 'performance'],
+    createdAt: '2025-01-12T10:00:00Z',
+    webUrl: 'https://gitlab.com/test-group/test-project/-/issues/42',
+  },
+];
+
+const mockPipelines = [
+  {
+    id: 1001,
+    iid: 55,
+    status: 'success',
+    source: 'push',
+    ref: 'main',
+    sha: 'abc1234567890def',
+    createdAt: '2025-01-15T10:00:00Z',
+    updatedAt: '2025-01-15T10:05:00Z',
+    webUrl: 'https://gitlab.com/test-group/test-project/-/pipelines/1001',
+  },
+];
+
+const mockLabels = ['bug', 'enhancement', 'performance'];
+
+function createTestAccount(
+  overrides: Partial<IntegrationAccount> & { id: string }
+): IntegrationAccount {
+  const base = createEmptyIntegrationAccount(overrides.integrationType ?? 'gitlab');
+  return {
+    ...base,
+    name: 'Test Account',
+    isDefault: true,
+    cachedUser: null,
+    ...overrides,
+  } as IntegrationAccount;
+}
+
+function encodeToken(token: string): number[] {
+  return Array.from(new TextEncoder().encode(token));
+}
+
+async function waitForLoad(el: LvGitLabDialog): Promise<void> {
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+}
+
+// --- Mock Setup ---
+
+const mockAccount = createTestAccount({
+  id: 'gl-acc-1',
+  name: 'Work GitLab',
+  integrationType: 'gitlab',
+  config: { type: 'gitlab', instanceUrl: 'https://gitlab.com' },
+  isDefault: true,
+  cachedUser: {
+    username: 'gluser',
+    displayName: 'GL User',
+    avatarUrl: 'https://example.com/gl-avatar.png',
+    email: 'gl@example.com',
+  },
+});
+
+let connectionResponse: unknown = mockDisconnectedStatus;
+let detectedRepoResponse: unknown = mockDetectedRepo;
+
+function setupMockInvoke(): void {
+  tokenStore.clear();
+  tokenStore.set('gitlab_token_gl-acc-1', encodeToken('glpat-testtoken123456'));
+
+  mockInvoke = async (command: string, args?: unknown) => {
+    const params = args as Record<string, unknown> | undefined;
+
+    // Stronghold / credential service
+    if (command === 'plugin:path|resolve_directory') return '/mock/app/data';
+    if (command === 'plugin:stronghold|initialize') return null;
+    if (command === 'plugin:stronghold|load_client') return null;
+    if (command === 'plugin:stronghold|create_client') return null;
+    if (command === 'plugin:stronghold|save') return null;
+    if (command === 'migrate_vault_if_needed') return null;
+
+    if (command === 'plugin:stronghold|get_store_record') {
+      const recordPath = (params?.recordPath ?? params?.record_path) as string | undefined;
+      if (recordPath && tokenStore.has(recordPath)) {
+        return tokenStore.get(recordPath);
+      }
+      return null;
+    }
+
+    // Unified profile commands
+    if (command === 'get_unified_profiles_config') {
+      return {
+        version: 3,
+        profiles: [],
+        accounts: [mockAccount],
+        repositoryAssignments: {},
+      };
+    }
+    if (command === 'load_unified_profile_for_repository') return null;
+    if (command === 'save_global_account') return params;
+    if (command === 'update_global_account_cached_user') return null;
+
+    // GitLab-specific commands
+    if (command === 'check_gitlab_connection') return connectionResponse;
+    if (command === 'check_gitlab_connection_with_token') return connectionResponse;
+    if (command === 'detect_gitlab_repo') return detectedRepoResponse;
+    if (command === 'list_gitlab_merge_requests') return mockMergeRequests;
+    if (command === 'list_gitlab_issues') return mockIssues;
+    if (command === 'list_gitlab_pipelines') return mockPipelines;
+    if (command === 'get_gitlab_labels') return mockLabels;
+    if (command === 'create_gitlab_merge_request') return mockMergeRequests[0];
+    if (command === 'create_gitlab_issue') return mockIssues[0];
+
+    // OAuth
+    if (command === 'get_oauth_client_id') return null;
+
+    return null;
+  };
+}
+
+describe('lv-gitlab-dialog', () => {
+  beforeEach(() => {
+    invokeHistory.length = 0;
+    connectionResponse = mockDisconnectedStatus;
+    detectedRepoResponse = mockDetectedRepo;
+    unifiedProfileStore.getState().reset();
+    setupMockInvoke();
+  });
+
+  describe('Rendering & Modal', () => {
+    it('renders lv-modal when open=true', async () => {
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      const modal = el.shadowRoot!.querySelector('lv-modal');
+      expect(modal).to.not.be.null;
+    });
+
+    it('shows 4 tab buttons', async () => {
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      expect(tabs.length).to.equal(4);
+
+      const tabTexts = Array.from(tabs).map((t) => t.textContent?.trim());
+      expect(tabTexts).to.include('Connection');
+      expect(tabTexts).to.include('Merge Requests');
+      expect(tabTexts).to.include('Issues');
+      expect(tabTexts).to.include('Pipelines');
+    });
+
+    it('shows detected repo info (projectPath @ instanceUrl)', async () => {
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      const repoName = el.shadowRoot!.querySelector('.repo-name');
+      if (repoName) {
+        expect(repoName.textContent).to.include('test-group/test-project');
+      }
+    });
+
+    it('shows account selector when accounts exist', async () => {
+      unifiedProfileStore.getState().setAccounts([mockAccount]);
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      const selector = el.shadowRoot!.querySelector('lv-account-selector');
+      expect(selector).to.not.be.null;
+    });
+  });
+
+  describe('Connection Tab', () => {
+    it('shows instance URL input and token input when disconnected', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      const tokenForm = el.shadowRoot!.querySelector('.token-form');
+      expect(tokenForm).to.not.be.null;
+
+      // Should have instance URL and token inputs
+      const inputs = el.shadowRoot!.querySelectorAll('input');
+      expect(inputs.length).to.be.greaterThan(0);
+
+      const passwordInput = el.shadowRoot!.querySelector('input[type="password"]');
+      expect(passwordInput).to.not.be.null;
+    });
+
+    it('shows user info (name, username) when connected', async () => {
+      connectionResponse = mockConnectedStatus;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      const connectionStatus = el.shadowRoot!.querySelector('.connection-status');
+      expect(connectionStatus).to.not.be.null;
+
+      const userName = el.shadowRoot!.querySelector('.user-name');
+      expect(userName).to.not.be.null;
+      expect(userName!.textContent).to.include('GL User');
+
+      const userLogin = el.shadowRoot!.querySelector('.user-login');
+      expect(userLogin).to.not.be.null;
+      expect(userLogin!.textContent).to.include('gluser');
+    });
+
+    it('shows disconnect button when connected', async () => {
+      connectionResponse = mockConnectedStatus;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      const disconnectBtn = el.shadowRoot!.querySelector('.btn-danger');
+      expect(disconnectBtn).to.not.be.null;
+      expect(disconnectBtn!.textContent?.trim()).to.include('Disconnect');
+    });
+  });
+
+  describe('Merge Requests Tab', () => {
+    it('shows empty state when not connected', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Merge Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const mrTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Merge Requests') as HTMLButtonElement;
+      mrTab.click();
+      await waitForLoad(el);
+
+      const emptyState = el.shadowRoot!.querySelector('.empty-state');
+      expect(emptyState).to.not.be.null;
+      expect(emptyState!.textContent).to.include('merge requests');
+    });
+
+    it('renders MR items with !iid, title, state, and branches', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Merge Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const mrTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Merge Requests') as HTMLButtonElement;
+      mrTab.click();
+      await waitForLoad(el);
+
+      const mrItems = el.shadowRoot!.querySelectorAll('.mr-item');
+      expect(mrItems.length).to.equal(2);
+
+      const firstMr = mrItems[0];
+      expect(firstMr.querySelector('.mr-number')?.textContent).to.include('!15');
+      expect(firstMr.querySelector('.mr-title')?.textContent).to.include('Add CI pipeline config');
+      expect(firstMr.querySelector('.mr-branch')?.textContent).to.include('feature/ci-setup');
+      expect(firstMr.querySelector('.mr-branch')?.textContent).to.include('main');
+    });
+
+    it('shows filter dropdown and New MR button', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Merge Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const mrTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Merge Requests') as HTMLButtonElement;
+      mrTab.click();
+      await waitForLoad(el);
+
+      const filterSelect = el.shadowRoot!.querySelector('.filter-select');
+      expect(filterSelect).to.not.be.null;
+
+      const newMrBtn = Array.from(el.shadowRoot!.querySelectorAll('.btn')).find(
+        (b) => b.textContent?.trim().includes('New MR')
+      );
+      expect(newMrBtn).to.not.be.undefined;
+    });
+  });
+
+  describe('Issues Tab', () => {
+    it('renders issue items with #iid, title, and string labels', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Issues tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const issuesTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Issues') as HTMLButtonElement;
+      issuesTab.click();
+      await waitForLoad(el);
+
+      const issueItems = el.shadowRoot!.querySelectorAll('.issue-item');
+      expect(issueItems.length).to.equal(1);
+
+      const firstIssue = issueItems[0];
+      expect(firstIssue.querySelector('.issue-number')?.textContent).to.include('42');
+      expect(firstIssue.querySelector('.issue-title')?.textContent).to.include('Performance regression in API');
+
+      const labels = firstIssue.querySelectorAll('.issue-label');
+      expect(labels.length).to.equal(2);
+      expect(labels[0].textContent?.trim()).to.equal('bug');
+      expect(labels[1].textContent?.trim()).to.equal('performance');
+    });
+  });
+
+  describe('Pipelines Tab', () => {
+    it('renders pipeline items with status dot, ref, and sha', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Switch to Pipelines tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const pipelinesTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pipelines') as HTMLButtonElement;
+      pipelinesTab.click();
+      await waitForLoad(el);
+
+      const pipelineItems = el.shadowRoot!.querySelectorAll('.pipeline-item');
+      expect(pipelineItems.length).to.equal(1);
+
+      const firstPipeline = pipelineItems[0];
+      expect(firstPipeline.querySelector('.pipeline-ref')?.textContent).to.include('main');
+
+      // Status indicator should exist
+      const statusDot = firstPipeline.querySelector('.pipeline-status');
+      expect(statusDot).to.not.be.null;
+
+      // Should show truncated sha
+      const metaText = firstPipeline.querySelector('.pipeline-meta')?.textContent;
+      expect(metaText).to.include('abc12345');
+    });
+  });
+
+  describe('Tab Navigation', () => {
+    it('clicking tab button changes displayed content', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Initially on Connection tab - verify token form visible
+      const tokenForm = el.shadowRoot!.querySelector('.token-form');
+      expect(tokenForm).to.not.be.null;
+
+      // Click Merge Requests tab
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const mrTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Merge Requests') as HTMLButtonElement;
+      mrTab.click();
+      await waitForLoad(el);
+
+      // Token form should be gone
+      const tokenFormAfter = el.shadowRoot!.querySelector('.token-form');
+      expect(tokenFormAfter).to.be.null;
+
+      // Empty state should be visible (not connected)
+      const emptyState = el.shadowRoot!.querySelector('.empty-state');
+      expect(emptyState).to.not.be.null;
+    });
+
+    it('active tab has correct styling', async () => {
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const connectionTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Connection');
+      expect(connectionTab?.classList.contains('active')).to.be.true;
+
+      // Click Merge Requests tab
+      const mrTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Merge Requests') as HTMLButtonElement;
+      mrTab.click();
+      await el.updateComplete;
+
+      expect(mrTab.classList.contains('active')).to.be.true;
+      expect(connectionTab?.classList.contains('active')).to.be.false;
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('displays error message when error state is set', async () => {
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Set error state directly to test error rendering
+      (el as unknown as { error: string | null }).error = 'GitLab instance unreachable';
+      await el.updateComplete;
+
+      const errorMsg = el.shadowRoot!.querySelector('.error');
+      expect(errorMsg).to.not.be.null;
+      expect(errorMsg!.textContent).to.include('GitLab instance unreachable');
+    });
+  });
+});

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -5,7 +5,7 @@ export default {
   files: 'src/**/*.test.ts',
   nodeResolve: true,
   plugins: [
-    esbuildPlugin({ ts: true, target: 'auto' }),
+    esbuildPlugin({ ts: true, target: 'auto', tsconfig: 'tsconfig.json' }),
   ],
   browsers: [
     playwrightLauncher({ product: 'chromium' }),


### PR DESCRIPTION
Add integration tests for GitHub, GitLab, Azure DevOps, and Bitbucket dialog components covering rendering, connection status, tab navigation, data display, and error handling with mocked Tauri backend.

- Replace existing 91-line data-only GitHub dialog test with 17 full integration tests
- Add 15 GitLab dialog tests (MRs, issues, pipelines, instance URL)
- Add 15 Azure DevOps dialog tests (PRs, work items, pipelines, PAT-only auth)
- Add 14 Bitbucket dialog tests (PRs, issues, pipelines, app-password auth)