### PR TITLE
fix: address findings from 3-way adversarial code review (iteration 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3728,9 +3728,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5381,9 +5381,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src-tauri/src/commands/advanced_search.rs
+++ b/src-tauri/src/commands/advanced_search.rs
@@ -156,6 +156,9 @@ pub async fn filter_commits(
     }
 
     if let Some(ref branch) = filter.branch {
+        // Reject ref values that could be parsed as a `git log` flag like
+        // `--output=/tmp/x` (arbitrary file write).
+        crate::utils::reject_flag_like(branch, "Branch")?;
         cmd.arg(branch.as_str());
     }
 
@@ -177,6 +180,9 @@ pub async fn get_branch_diff_commits(
     max_results: Option<u32>,
 ) -> Result<Vec<FilteredCommit>> {
     let max_results = max_results.unwrap_or(500);
+
+    crate::utils::reject_flag_like(&base_branch, "Base branch")?;
+    crate::utils::reject_flag_like(&compare_branch, "Compare branch")?;
 
     let mut cmd = Command::new("git");
     cmd.arg("-C")

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -353,6 +353,12 @@ fn get_commits_between_refs(
     compare_ref: &str,
     max_commits: u32,
 ) -> Result<String> {
+    // Reject refs that could be parsed as flags (e.g., `--output=/tmp/x`).
+    // We do NOT add a `--` separator because in `git log` `--` denotes
+    // "remaining args are pathspecs", which would then make git treat the
+    // rev range as a path. The leading-`-` rejection is the right defense.
+    crate::utils::reject_flag_like(base_ref, "Base ref")?;
+    crate::utils::reject_flag_like(compare_ref, "Compare ref")?;
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(repo_path)
@@ -518,6 +524,8 @@ pub async fn suggest_commit_splits(
 
 /// Get diff stats between two refs
 fn get_diff_stats(repo_path: &str, base_ref: &str, compare_ref: &str) -> Result<String> {
+    crate::utils::reject_flag_like(base_ref, "Base ref")?;
+    crate::utils::reject_flag_like(compare_ref, "Compare ref")?;
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(repo_path)

--- a/src-tauri/src/commands/bundle.rs
+++ b/src-tauri/src/commands/bundle.rs
@@ -156,6 +156,7 @@ pub async fn bundle_verify(path: String, bundle_path: String) -> Result<BundleVe
         return Err(LeviathanError::RepositoryNotFound(path));
     }
 
+    reject_flag_like(&bundle_path, "Bundle path")?;
     let bundle_file = Path::new(&bundle_path);
     if !bundle_file.exists() {
         return Err(LeviathanError::OperationFailed(format!(
@@ -164,11 +165,13 @@ pub async fn bundle_verify(path: String, bundle_path: String) -> Result<BundleVe
         )));
     }
 
-    // Run git bundle verify
+    // Run git bundle verify. `--` keeps a malicious bundle_path from being
+    // parsed as a flag, mirroring bundle_list_heads / bundle_unbundle.
     let output = Command::new("git")
         .current_dir(repo_path)
         .arg("bundle")
         .arg("verify")
+        .arg("--")
         .arg(&bundle_path)
         .output()
         .map_err(|e| {

--- a/src-tauri/src/commands/bundle.rs
+++ b/src-tauri/src/commands/bundle.rs
@@ -7,6 +7,19 @@ use tauri::command;
 
 use crate::error::{LeviathanError, Result};
 
+/// Reject paths that could be parsed as a CLI flag (starting with `-`).
+/// Without this, `git fetch --upload-pack=evil` style injection is possible
+/// when bundle_path or refspec is user-controlled.
+fn reject_flag_like(value: &str, label: &str) -> Result<()> {
+    if value.starts_with('-') {
+        return Err(LeviathanError::OperationFailed(format!(
+            "{} must not start with '-'",
+            label
+        )));
+    }
+    Ok(())
+}
+
 /// Reference in a bundle
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BundleRef {
@@ -46,19 +59,28 @@ pub async fn bundle_create(
         return Err(LeviathanError::RepositoryNotFound(path));
     }
 
-    // Build the git bundle create command
-    let mut cmd = Command::new("git");
-    cmd.current_dir(repo_path)
-        .arg("bundle")
-        .arg("create")
-        .arg(&bundle_path);
+    reject_flag_like(&bundle_path, "Bundle path")?;
+    for ref_spec in &refs {
+        reject_flag_like(ref_spec, "Refspec")?;
+    }
 
-    if all {
-        cmd.arg("--all");
-    } else if refs.is_empty() {
+    // `git bundle create [<bundle-create options>] <file> <rev-list args>`.
+    // We place `--` directly before `<file>` to defend the file path from
+    // being parsed as a bundle-create option. `--all` and explicit refs are
+    // rev-list arguments and must come AFTER `<file>`.
+    let mut cmd = Command::new("git");
+    cmd.current_dir(repo_path).arg("bundle").arg("create");
+
+    if !all && refs.is_empty() {
         return Err(LeviathanError::OperationFailed(
             "Either refs must be provided or 'all' must be true".to_string(),
         ));
+    }
+
+    cmd.arg("--").arg(&bundle_path);
+
+    if all {
+        cmd.arg("--all");
     } else {
         for ref_spec in &refs {
             cmd.arg(ref_spec);
@@ -204,6 +226,7 @@ pub async fn bundle_verify(path: String, bundle_path: String) -> Result<BundleVe
 /// List the heads (refs) contained in a bundle file
 #[command]
 pub async fn bundle_list_heads(bundle_path: String) -> Result<Vec<BundleRef>> {
+    reject_flag_like(&bundle_path, "Bundle path")?;
     let bundle_file = Path::new(&bundle_path);
     if !bundle_file.exists() {
         return Err(LeviathanError::OperationFailed(format!(
@@ -216,6 +239,7 @@ pub async fn bundle_list_heads(bundle_path: String) -> Result<Vec<BundleRef>> {
     let output = Command::new("git")
         .arg("bundle")
         .arg("list-heads")
+        .arg("--")
         .arg(&bundle_path)
         .output()
         .map_err(|e| {
@@ -258,6 +282,7 @@ pub async fn bundle_unbundle(path: String, bundle_path: String) -> Result<Vec<Bu
         return Err(LeviathanError::RepositoryNotFound(path));
     }
 
+    reject_flag_like(&bundle_path, "Bundle path")?;
     let bundle_file = Path::new(&bundle_path);
     if !bundle_file.exists() {
         return Err(LeviathanError::OperationFailed(format!(
@@ -271,6 +296,7 @@ pub async fn bundle_unbundle(path: String, bundle_path: String) -> Result<Vec<Bu
         .current_dir(repo_path)
         .arg("bundle")
         .arg("verify")
+        .arg("--")
         .arg(&bundle_path)
         .output()
         .map_err(|e| LeviathanError::OperationFailed(format!("Failed to verify bundle: {}", e)))?;
@@ -283,10 +309,13 @@ pub async fn bundle_unbundle(path: String, bundle_path: String) -> Result<Vec<Bu
         )));
     }
 
-    // Use git fetch to unbundle - this fetches all refs from the bundle
+    // Use git fetch to unbundle - this fetches all refs from the bundle.
+    // `--` terminates options so a malicious bundle_path cannot be parsed
+    // as a flag like `--upload-pack=`.
     let output = Command::new("git")
         .current_dir(repo_path)
         .arg("fetch")
+        .arg("--")
         .arg(&bundle_path)
         .arg("*:*") // Fetch all refs
         .stderr(Stdio::piped())
@@ -300,6 +329,7 @@ pub async fn bundle_unbundle(path: String, bundle_path: String) -> Result<Vec<Bu
         let list_output = Command::new("git")
             .arg("bundle")
             .arg("list-heads")
+            .arg("--")
             .arg(&bundle_path)
             .output()
             .map_err(|e| {
@@ -324,10 +354,15 @@ pub async fn bundle_unbundle(path: String, bundle_path: String) -> Result<Vec<Bu
                 let oid = parts[0];
                 let refname = parts[1].trim();
 
-                // Fetch this specific ref
+                // Fetch this specific ref. Skip refs that look like flags;
+                // they originate from the bundle file and are not trusted.
+                if refname.starts_with('-') {
+                    continue;
+                }
                 let fetch_result = Command::new("git")
                     .current_dir(repo_path)
                     .arg("fetch")
+                    .arg("--")
                     .arg(&bundle_path)
                     .arg(format!("{}:{}", refname, refname))
                     .output();

--- a/src-tauri/src/commands/bundle.rs
+++ b/src-tauri/src/commands/bundle.rs
@@ -6,19 +6,7 @@ use std::process::{Command, Stdio};
 use tauri::command;
 
 use crate::error::{LeviathanError, Result};
-
-/// Reject paths that could be parsed as a CLI flag (starting with `-`).
-/// Without this, `git fetch --upload-pack=evil` style injection is possible
-/// when bundle_path or refspec is user-controlled.
-fn reject_flag_like(value: &str, label: &str) -> Result<()> {
-    if value.starts_with('-') {
-        return Err(LeviathanError::OperationFailed(format!(
-            "{} must not start with '-'",
-            label
-        )));
-    }
-    Ok(())
-}
+use crate::utils::reject_flag_like;
 
 /// Reference in a bundle
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -530,19 +530,33 @@ pub async fn store_keyring_token(key: String, value: String) -> Result<()> {
             ])
             .output();
 
-        let output = std::process::Command::new("security")
+        // `-w` last with no value => password read from stdin. This avoids
+        // exposing the token via argv (`ps -E` is readable by any process
+        // running under the same user).
+        use std::io::Write as _;
+        let mut child = std::process::Command::new("security")
             .args([
                 "add-generic-password",
                 "-s",
                 INTEGRATION_SERVICE,
                 "-a",
                 &key,
-                "-w",
-                &value,
                 "-A", // Allow any application to access without prompt
                 "-U", // Update if exists
+                "-w",
             ])
-            .output()
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| LeviathanError::OperationFailed(format!("Failed to run security: {e}")))?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(value.as_bytes()).map_err(|e| {
+                LeviathanError::OperationFailed(format!("Failed to write token: {e}"))
+            })?;
+        }
+        let output = child
+            .wait_with_output()
             .map_err(|e| LeviathanError::OperationFailed(format!("Failed to run security: {e}")))?;
 
         if !output.status.success() {

--- a/src-tauri/src/commands/custom_actions.rs
+++ b/src-tauri/src/commands/custom_actions.rs
@@ -97,13 +97,24 @@ fn shell_quote_posix(value: &str) -> String {
 /// double-quotes, `%VAR%` is expanded and `^`/`&`/`|`/`<`/`>`/`(`/`)`/`!`/`"`
 /// retain meta-character roles in various parsing paths. Rather than try to
 /// quote our way out, we reject any value containing one of these characters.
-/// The caller's `Result` propagation surfaces the rejection as an error.
+/// We also reject ASCII control characters (CR/LF/NUL etc.) since CRLF can
+/// terminate cmd's command-line parser and let bytes after the newline be
+/// interpreted as a new command. The caller's `Result` propagation surfaces
+/// the rejection as an error.
 fn shell_quote_windows(value: &str) -> Result<String> {
     const FORBIDDEN: &[char] = &['%', '^', '&', '<', '>', '|', '(', ')', '!', '"'];
-    if let Some(c) = value.chars().find(|c| FORBIDDEN.contains(c)) {
+    if let Some(c) = value
+        .chars()
+        .find(|c| FORBIDDEN.contains(c) || c.is_ascii_control())
+    {
+        let label = if c.is_ascii_control() {
+            format!("control character (0x{:02X})", c as u32)
+        } else {
+            format!("metacharacter '{}'", c)
+        };
         return Err(LeviathanError::OperationFailed(format!(
-            "Refusing to substitute value containing shell metacharacter '{}' on Windows",
-            c
+            "Refusing to substitute value containing shell {} on Windows",
+            label
         )));
     }
     Ok(format!("\"{}\"", value))

--- a/src-tauri/src/commands/custom_actions.rs
+++ b/src-tauri/src/commands/custom_actions.rs
@@ -75,9 +75,46 @@ fn get_current_branch(repo_path: &Path) -> String {
     head.shorthand().unwrap_or("").to_string()
 }
 
-/// Replace template variables in a string
-fn substitute_variables(input: &str, repo_path: &str, branch: &str) -> String {
-    input.replace("$REPO", repo_path).replace("$BRANCH", branch)
+/// Quote a value for safe interpolation into a POSIX `sh -c` command line.
+/// Single-quote everything; the only character that can't appear inside single
+/// quotes is `'` itself, which we close-escape-reopen as `'\''`.
+fn shell_quote_posix(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('\'');
+    for c in value.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Quote a value for safe interpolation into a Windows `cmd /C` command line.
+/// `cmd.exe` quoting is notoriously messy; we wrap in double-quotes, double any
+/// embedded double-quotes, and reject any caret/percent/ampersand metacharacter
+/// that would still be expanded inside double-quotes by `cmd.exe`.
+fn shell_quote_windows(value: &str) -> String {
+    let escaped: String = value.replace('"', "\"\"");
+    format!("\"{}\"", escaped)
+}
+
+/// Replace template variables in a string. Substituted values are shell-quoted
+/// for the target shell so that branch names containing metacharacters
+/// (e.g. `` `;rm -rf ~;# ``) cannot break out of the surrounding command.
+fn substitute_variables(input: &str, repo_path: &str, branch: &str, for_shell: bool) -> String {
+    if for_shell {
+        let (repo_q, branch_q) = if cfg!(target_os = "windows") {
+            (shell_quote_windows(repo_path), shell_quote_windows(branch))
+        } else {
+            (shell_quote_posix(repo_path), shell_quote_posix(branch))
+        };
+        input.replace("$REPO", &repo_q).replace("$BRANCH", &branch_q)
+    } else {
+        input.replace("$REPO", repo_path).replace("$BRANCH", branch)
+    }
 }
 
 /// Get all custom actions for a repository
@@ -158,17 +195,21 @@ pub async fn run_custom_action(path: String, action_id: String) -> Result<Action
         .clone();
 
     let branch = get_current_branch(repo_path);
-    let command_str = substitute_variables(&action.command, &path, &branch);
+    // Command and arguments are passed to `sh -c` / `cmd /C`, so substituted
+    // values must be shell-quoted to prevent injection via branch names like
+    // `` `;rm -rf ~;# ``.
+    let command_str = substitute_variables(&action.command, &path, &branch, true);
     let arguments_str = action
         .arguments
         .as_deref()
-        .map(|args| substitute_variables(args, &path, &branch))
+        .map(|args| substitute_variables(args, &path, &branch, true))
         .unwrap_or_default();
 
-    // Determine working directory
+    // Working directory is passed via `current_dir`, not interpolated into a
+    // shell command, so plain substitution is correct here.
     let working_dir = match action.working_directory.as_deref() {
         Some("repo_root") | None => path.clone(),
-        Some(custom_path) => substitute_variables(custom_path, &path, &branch),
+        Some(custom_path) => substitute_variables(custom_path, &path, &branch, false),
     };
 
     // Log the command being executed for auditability
@@ -386,14 +427,41 @@ mod tests {
 
     #[test]
     fn test_substitute_variables() {
-        let result = substitute_variables("echo $REPO on $BRANCH", "/my/repo", "main");
+        let result = substitute_variables("echo $REPO on $BRANCH", "/my/repo", "main", false);
         assert_eq!(result, "echo /my/repo on main");
     }
 
     #[test]
     fn test_substitute_variables_no_placeholders() {
-        let result = substitute_variables("echo hello", "/my/repo", "main");
+        let result = substitute_variables("echo hello", "/my/repo", "main", false);
         assert_eq!(result, "echo hello");
+    }
+
+    #[test]
+    fn test_substitute_variables_shell_quotes_metacharacters() {
+        // Must defeat shell injection via branch name
+        let result = substitute_variables(
+            "git log $BRANCH",
+            "/repo",
+            "`;rm -rf ~;#",
+            true,
+        );
+        if cfg!(target_os = "windows") {
+            // Windows uses double-quoting; just ensure it's wrapped
+            assert!(result.contains("\"`;rm -rf ~;#\""));
+        } else {
+            // POSIX single-quoted: backticks/semis become inert
+            assert_eq!(result, "git log '`;rm -rf ~;#'");
+        }
+    }
+
+    #[test]
+    fn test_substitute_variables_quotes_apostrophe_branch() {
+        // POSIX-only check; ensures embedded single quote is escaped properly
+        if !cfg!(target_os = "windows") {
+            let result = substitute_variables("echo $BRANCH", "/repo", "it's", true);
+            assert_eq!(result, "echo 'it'\\''s'");
+        }
     }
 
     #[tokio::test]
@@ -431,20 +499,24 @@ mod tests {
 
     #[test]
     fn test_substitute_variables_both_placeholders() {
-        let result =
-            substitute_variables("$REPO is on $BRANCH and $REPO again", "/my/repo", "develop");
+        let result = substitute_variables(
+            "$REPO is on $BRANCH and $REPO again",
+            "/my/repo",
+            "develop",
+            false,
+        );
         assert_eq!(result, "/my/repo is on develop and /my/repo again");
     }
 
     #[test]
     fn test_substitute_variables_empty_input() {
-        let result = substitute_variables("", "/repo", "main");
+        let result = substitute_variables("", "/repo", "main", false);
         assert_eq!(result, "");
     }
 
     #[test]
     fn test_substitute_variables_empty_branch() {
-        let result = substitute_variables("branch is $BRANCH", "/repo", "");
+        let result = substitute_variables("branch is $BRANCH", "/repo", "", false);
         assert_eq!(result, "branch is ");
     }
 

--- a/src-tauri/src/commands/custom_actions.rs
+++ b/src-tauri/src/commands/custom_actions.rs
@@ -93,27 +93,47 @@ fn shell_quote_posix(value: &str) -> String {
 }
 
 /// Quote a value for safe interpolation into a Windows `cmd /C` command line.
-/// `cmd.exe` quoting is notoriously messy; we wrap in double-quotes, double any
-/// embedded double-quotes, and reject any caret/percent/ampersand metacharacter
-/// that would still be expanded inside double-quotes by `cmd.exe`.
-fn shell_quote_windows(value: &str) -> String {
-    let escaped: String = value.replace('"', "\"\"");
-    format!("\"{}\"", escaped)
+/// `cmd.exe` quoting is fundamentally unsound for hostile input: even inside
+/// double-quotes, `%VAR%` is expanded and `^`/`&`/`|`/`<`/`>`/`(`/`)`/`!`/`"`
+/// retain meta-character roles in various parsing paths. Rather than try to
+/// quote our way out, we reject any value containing one of these characters.
+/// The caller's `Result` propagation surfaces the rejection as an error.
+fn shell_quote_windows(value: &str) -> Result<String> {
+    const FORBIDDEN: &[char] = &['%', '^', '&', '<', '>', '|', '(', ')', '!', '"'];
+    if let Some(c) = value.chars().find(|c| FORBIDDEN.contains(c)) {
+        return Err(LeviathanError::OperationFailed(format!(
+            "Refusing to substitute value containing shell metacharacter '{}' on Windows",
+            c
+        )));
+    }
+    Ok(format!("\"{}\"", value))
 }
 
 /// Replace template variables in a string. Substituted values are shell-quoted
 /// for the target shell so that branch names containing metacharacters
 /// (e.g. `` `;rm -rf ~;# ``) cannot break out of the surrounding command.
-fn substitute_variables(input: &str, repo_path: &str, branch: &str, for_shell: bool) -> String {
+/// Returns Err on Windows if a substituted value contains a metacharacter
+/// that cmd.exe quoting cannot safely handle.
+fn substitute_variables(
+    input: &str,
+    repo_path: &str,
+    branch: &str,
+    for_shell: bool,
+) -> Result<String> {
     if for_shell {
         let (repo_q, branch_q) = if cfg!(target_os = "windows") {
-            (shell_quote_windows(repo_path), shell_quote_windows(branch))
+            (
+                shell_quote_windows(repo_path)?,
+                shell_quote_windows(branch)?,
+            )
         } else {
             (shell_quote_posix(repo_path), shell_quote_posix(branch))
         };
-        input.replace("$REPO", &repo_q).replace("$BRANCH", &branch_q)
+        Ok(input
+            .replace("$REPO", &repo_q)
+            .replace("$BRANCH", &branch_q))
     } else {
-        input.replace("$REPO", repo_path).replace("$BRANCH", branch)
+        Ok(input.replace("$REPO", repo_path).replace("$BRANCH", branch))
     }
 }
 
@@ -197,19 +217,19 @@ pub async fn run_custom_action(path: String, action_id: String) -> Result<Action
     let branch = get_current_branch(repo_path);
     // Command and arguments are passed to `sh -c` / `cmd /C`, so substituted
     // values must be shell-quoted to prevent injection via branch names like
-    // `` `;rm -rf ~;# ``.
-    let command_str = substitute_variables(&action.command, &path, &branch, true);
-    let arguments_str = action
-        .arguments
-        .as_deref()
-        .map(|args| substitute_variables(args, &path, &branch, true))
-        .unwrap_or_default();
+    // `` `;rm -rf ~;# ``. On Windows, values with `cmd.exe` metacharacters
+    // are rejected outright (see shell_quote_windows).
+    let command_str = substitute_variables(&action.command, &path, &branch, true)?;
+    let arguments_str = match action.arguments.as_deref() {
+        Some(args) => substitute_variables(args, &path, &branch, true)?,
+        None => String::new(),
+    };
 
     // Working directory is passed via `current_dir`, not interpolated into a
     // shell command, so plain substitution is correct here.
     let working_dir = match action.working_directory.as_deref() {
         Some("repo_root") | None => path.clone(),
-        Some(custom_path) => substitute_variables(custom_path, &path, &branch, false),
+        Some(custom_path) => substitute_variables(custom_path, &path, &branch, false)?,
     };
 
     // Log the command being executed for auditability
@@ -427,31 +447,35 @@ mod tests {
 
     #[test]
     fn test_substitute_variables() {
-        let result = substitute_variables("echo $REPO on $BRANCH", "/my/repo", "main", false);
+        let result = substitute_variables("echo $REPO on $BRANCH", "/my/repo", "main", false)
+            .expect("substitution should succeed");
         assert_eq!(result, "echo /my/repo on main");
     }
 
     #[test]
     fn test_substitute_variables_no_placeholders() {
-        let result = substitute_variables("echo hello", "/my/repo", "main", false);
+        let result = substitute_variables("echo hello", "/my/repo", "main", false)
+            .expect("substitution should succeed");
         assert_eq!(result, "echo hello");
     }
 
     #[test]
     fn test_substitute_variables_shell_quotes_metacharacters() {
-        // Must defeat shell injection via branch name
-        let result = substitute_variables(
-            "git log $BRANCH",
-            "/repo",
-            "`;rm -rf ~;#",
-            true,
-        );
-        if cfg!(target_os = "windows") {
-            // Windows uses double-quoting; just ensure it's wrapped
-            assert!(result.contains("\"`;rm -rf ~;#\""));
-        } else {
-            // POSIX single-quoted: backticks/semis become inert
+        // Must defeat shell injection via branch name (POSIX path).
+        if !cfg!(target_os = "windows") {
+            let result = substitute_variables("git log $BRANCH", "/repo", "`;rm -rf ~;#", true)
+                .expect("POSIX quoting should succeed");
             assert_eq!(result, "git log '`;rm -rf ~;#'");
+        }
+    }
+
+    #[test]
+    fn test_substitute_variables_rejects_windows_metachars() {
+        // Windows path: substitution must be rejected when value contains
+        // characters cmd.exe quoting cannot handle.
+        if cfg!(target_os = "windows") {
+            let err = substitute_variables("git log $BRANCH", "/repo", "%USERPROFILE%", true);
+            assert!(err.is_err(), "expected rejection of % in branch name");
         }
     }
 
@@ -459,7 +483,8 @@ mod tests {
     fn test_substitute_variables_quotes_apostrophe_branch() {
         // POSIX-only check; ensures embedded single quote is escaped properly
         if !cfg!(target_os = "windows") {
-            let result = substitute_variables("echo $BRANCH", "/repo", "it's", true);
+            let result = substitute_variables("echo $BRANCH", "/repo", "it's", true)
+                .expect("POSIX quoting should succeed");
             assert_eq!(result, "echo 'it'\\''s'");
         }
     }
@@ -504,19 +529,22 @@ mod tests {
             "/my/repo",
             "develop",
             false,
-        );
+        )
+        .expect("substitution should succeed");
         assert_eq!(result, "/my/repo is on develop and /my/repo again");
     }
 
     #[test]
     fn test_substitute_variables_empty_input() {
-        let result = substitute_variables("", "/repo", "main", false);
+        let result =
+            substitute_variables("", "/repo", "main", false).expect("substitution should succeed");
         assert_eq!(result, "");
     }
 
     #[test]
     fn test_substitute_variables_empty_branch() {
-        let result = substitute_variables("branch is $BRANCH", "/repo", "", false);
+        let result = substitute_variables("branch is $BRANCH", "/repo", "", false)
+            .expect("substitution should succeed");
         assert_eq!(result, "branch is ");
     }
 

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -136,20 +136,35 @@ pub async fn rebase(path: String, onto: String) -> Result<()> {
 
     let signature = repo.signature()?;
 
-    while let Some(op) = rebase.next() {
-        let _op = op?;
+    // git2::Rebase does NOT call abort() on Drop. Without an explicit abort,
+    // failures other than the expected RebaseConflict (e.g. missing
+    // user.name signature, mid-loop git2 errors) leave the working tree
+    // permanently stuck in REBASE state. We do NOT abort on RebaseConflict
+    // because the UI surfaces a "resolve conflicts" flow that needs the
+    // rebase state intact; the user can call abort_rebase explicitly.
+    let result = (|| -> Result<()> {
+        while let Some(op) = rebase.next() {
+            let _op = op?;
 
-        // Check for conflicts
-        if repo.index()?.has_conflicts() {
-            return Err(LeviathanError::RebaseConflict);
+            if repo.index()?.has_conflicts() {
+                return Err(LeviathanError::RebaseConflict);
+            }
+
+            rebase.commit(None, &signature, None)?;
         }
 
-        rebase.commit(None, &signature, None)?;
+        rebase.finish(Some(&signature))?;
+        Ok(())
+    })();
+
+    match result {
+        Err(LeviathanError::RebaseConflict) => Err(LeviathanError::RebaseConflict),
+        Err(e) => {
+            let _ = rebase.abort();
+            Err(e)
+        }
+        Ok(()) => Ok(()),
     }
-
-    rebase.finish(Some(&signature))?;
-
-    Ok(())
 }
 
 /// Preview a rebase by running it in a temporary worktree (ghost rebase)

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -97,9 +97,19 @@ pub async fn merge(
             Ok(())
         })();
 
-        if let Err(e) = result {
-            let _ = repo.cleanup_state();
-            return Err(e);
+        // MergeConflict is the expected "user must resolve" path; the UI
+        // drives a conflict-resolution flow that needs MERGE_HEAD intact
+        // (and `abort_merge` to undo). Only call cleanup_state for
+        // non-conflict errors (disk-full, signature missing, etc.).
+        match result {
+            Err(LeviathanError::MergeConflict) => {
+                return Err(LeviathanError::MergeConflict);
+            }
+            Err(e) => {
+                let _ = repo.cleanup_state();
+                return Err(e);
+            }
+            Ok(()) => {}
         }
 
         repo.cleanup_state()?;

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -56,41 +56,50 @@ pub async fn merge(
         reference.set_target(target_oid, "Fast-forward merge")?;
         repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
     } else {
-        // Normal or squash merge
+        // Normal or squash merge. Once repo.merge() succeeds the index/working
+        // tree is in MERGING state; any subsequent failure must reset that
+        // state so the user isn't stuck with a half-merged repo.
         repo.merge(&[&annotated_commit], None, None)?;
 
-        if repo.index()?.has_conflicts() {
-            return Err(LeviathanError::MergeConflict);
-        }
+        let result = (|| -> Result<()> {
+            if repo.index()?.has_conflicts() {
+                return Err(LeviathanError::MergeConflict);
+            }
 
-        let signature = repo.signature()?;
-        let head = repo.head()?.peel_to_commit()?;
-        let tree_oid = repo.index()?.write_tree()?;
-        let tree = repo.find_tree(tree_oid)?;
+            let signature = repo.signature()?;
+            let head = repo.head()?.peel_to_commit()?;
+            let tree_oid = repo.index()?.write_tree()?;
+            let tree = repo.find_tree(tree_oid)?;
 
-        let commit_message = message.unwrap_or_else(|| format!("Merge '{}' into HEAD", source_ref));
+            let commit_message =
+                message.unwrap_or_else(|| format!("Merge '{}' into HEAD", source_ref));
 
-        if squash.unwrap_or(false) {
-            // Squash merge - single parent
-            repo.commit(
-                Some("HEAD"),
-                &signature,
-                &signature,
-                &commit_message,
-                &tree,
-                &[&head],
-            )?;
-        } else {
-            // Regular merge - two parents
-            let source_commit = repo.find_commit(annotated_commit.id())?;
-            repo.commit(
-                Some("HEAD"),
-                &signature,
-                &signature,
-                &commit_message,
-                &tree,
-                &[&head, &source_commit],
-            )?;
+            if squash.unwrap_or(false) {
+                repo.commit(
+                    Some("HEAD"),
+                    &signature,
+                    &signature,
+                    &commit_message,
+                    &tree,
+                    &[&head],
+                )?;
+            } else {
+                let source_commit = repo.find_commit(annotated_commit.id())?;
+                repo.commit(
+                    Some("HEAD"),
+                    &signature,
+                    &signature,
+                    &commit_message,
+                    &tree,
+                    &[&head, &source_commit],
+                )?;
+            }
+            Ok(())
+        })();
+
+        if let Err(e) = result {
+            let _ = repo.cleanup_state();
+            return Err(e);
         }
 
         repo.cleanup_state()?;
@@ -151,6 +160,14 @@ pub async fn preview_rebase(
 ) -> Result<crate::services::ai::RebasePreview> {
     use crate::services::ai::{PredictedConflict, RebasePreview};
 
+    // Reject ref values that could be parsed as a flag, e.g.
+    // `--exec=/tmp/payload` would run an arbitrary command via `git rebase`.
+    if onto.starts_with('-') {
+        return Err(LeviathanError::OperationFailed(
+            "Rebase target must not start with '-'".into(),
+        ));
+    }
+
     // Create a temp directory for the ghost worktree
     let temp_dir = tempfile::tempdir().map_err(|e| {
         LeviathanError::OperationFailed(format!("Failed to create temp dir: {}", e))
@@ -178,11 +195,13 @@ pub async fn preview_rebase(
         )));
     }
 
-    // Run rebase in the temp worktree
+    // Run rebase in the temp worktree. `--` prevents the user-supplied ref
+    // from being parsed as a flag.
     let rebase_output = std::process::Command::new("git")
         .arg("-C")
         .arg(&temp_path)
         .arg("rebase")
+        .arg("--")
         .arg(&onto)
         .output()
         .map_err(|e| {

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -328,9 +328,8 @@ pub async fn oauth_exchange_code(
     // Try to parse as token response. Do NOT log the raw response — it contains
     // access_token / refresh_token / id_token in plaintext.
     tracing::debug!("Token exchange response received ({} bytes)", text.len());
-    let tokens: OAuthTokenResponse = serde_json::from_str(&text).map_err(|e| {
-        LeviathanError::OAuth(format!("Failed to parse token response: {}", e))
-    })?;
+    let tokens: OAuthTokenResponse = serde_json::from_str(&text)
+        .map_err(|e| LeviathanError::OAuth(format!("Failed to parse token response: {}", e)))?;
 
     tracing::info!(
         "Parsed token - has access_token: {}",

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -308,9 +308,17 @@ pub async fn oauth_exchange_code(
     let text = response.text().await.unwrap_or_default();
 
     if !status.is_success() {
+        // Some IdPs echo the submitted `code` / `code_verifier` (PKCE secret)
+        // back in 4xx response bodies. Discard the body before surfacing the
+        // error so it doesn't reach toasts or logs.
+        tracing::debug!(
+            "OAuth exchange failed with status {} ({} body bytes discarded)",
+            status,
+            text.len()
+        );
         return Err(LeviathanError::OAuth(format!(
-            "Token request failed with status {}: {}",
-            status, text
+            "Token request failed with status {}",
+            status
         )));
     }
 

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -395,10 +395,18 @@ pub async fn oauth_refresh_token(
 
     if !response.status().is_success() {
         let status = response.status();
-        let text = response.text().await.unwrap_or_default();
+        // Some IdPs echo the submitted refresh_token back inside 4xx error
+        // bodies. Discard the body so it doesn't propagate to user-visible
+        // error toasts or logs.
+        let body_len = response.text().await.unwrap_or_default().len();
+        tracing::debug!(
+            "OAuth refresh failed with status {} ({} body bytes discarded)",
+            status,
+            body_len
+        );
         return Err(LeviathanError::OAuth(format!(
-            "Refresh request failed with status {}: {}",
-            status, text
+            "Refresh request failed with status {}",
+            status
         )));
     }
 

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -325,13 +325,11 @@ pub async fn oauth_exchange_code(
         }
     }
 
-    // Try to parse as token response
-    tracing::info!("Token exchange raw response: {}", text);
+    // Try to parse as token response. Do NOT log the raw response — it contains
+    // access_token / refresh_token / id_token in plaintext.
+    tracing::debug!("Token exchange response received ({} bytes)", text.len());
     let tokens: OAuthTokenResponse = serde_json::from_str(&text).map_err(|e| {
-        LeviathanError::OAuth(format!(
-            "Failed to parse token response: {}. Raw response: {}",
-            e, text
-        ))
+        LeviathanError::OAuth(format!("Failed to parse token response: {}", e))
     })?;
 
     tracing::info!(

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -10,7 +10,7 @@ use crate::models::{
 };
 use crate::services::cancellation::CancellationRegistry;
 use crate::services::credentials_service;
-use crate::utils::create_command;
+use crate::utils::{create_command, reject_flag_like};
 
 /// Add a new remote
 #[command]
@@ -259,15 +259,37 @@ pub async fn pull(
                     let mut rebase_obj =
                         repo.rebase(Some(&head_commit), Some(&fetch_commit), None, None)?;
 
+                    // `git2::Rebase` does NOT call abort() on Drop. Without
+                    // an explicit abort, errors other than the expected
+                    // RebaseConflict (e.g. missing user.name signature,
+                    // mid-loop git2 errors) would leave the working tree
+                    // permanently stuck in REBASE state. We do NOT abort on
+                    // RebaseConflict because the UI surfaces a "resolve
+                    // conflicts" flow that needs the rebase state intact.
                     let mut commit_count = 0;
-                    while let Some(op) = rebase_obj.next() {
-                        let _op = op?;
-                        let signature = repo.signature()?;
-                        rebase_obj.commit(None, &signature, None)?;
-                        commit_count += 1;
+                    let rebase_result = (|| -> Result<()> {
+                        while let Some(op) = rebase_obj.next() {
+                            let _op = op?;
+                            if repo.index()?.has_conflicts() {
+                                return Err(LeviathanError::RebaseConflict);
+                            }
+                            let signature = repo.signature()?;
+                            rebase_obj.commit(None, &signature, None)?;
+                            commit_count += 1;
+                        }
+                        rebase_obj.finish(Some(&repo.signature()?))?;
+                        Ok(())
+                    })();
+                    match rebase_result {
+                        Err(LeviathanError::RebaseConflict) => {
+                            return Err(LeviathanError::RebaseConflict);
+                        }
+                        Err(e) => {
+                            let _ = rebase_obj.abort();
+                            return Err(e);
+                        }
+                        Ok(()) => {}
                     }
-
-                    rebase_obj.finish(Some(&repo.signature()?))?;
                     message = format!("Rebased {} commit(s)", commit_count);
                 } else {
                     let (analysis, _preference) = repo.merge_analysis(&[&fetch_commit])?;
@@ -397,6 +419,16 @@ pub async fn push(
     timeout_secs: Option<u64>,
     _operation_id: Option<String>,
 ) -> Result<()> {
+    // Reject branch values that could be parsed as a flag by `git push`
+    // (e.g. `--receive-pack=/tmp/evil`). The remote name is safer because
+    // it must already exist in the repo config.
+    if let Some(ref b) = branch {
+        reject_flag_like(b, "Branch name")?;
+    }
+    if let Some(ref r) = remote {
+        reject_flag_like(r, "Remote name")?;
+    }
+
     let do_push = async move {
         let path_for_task = path.clone();
         let remote_name_owned = remote.unwrap_or_else(|| "origin".to_string());
@@ -541,6 +573,9 @@ fn push_via_cli(
         cmd.arg("--set-upstream");
     }
 
+    // `--` keeps remote_name / branch_name from being parsed as flags by git
+    // even though callers also validate them with reject_flag_like.
+    cmd.arg("--");
     cmd.arg(remote_name);
     cmd.arg(branch_name);
 
@@ -628,6 +663,14 @@ pub async fn push_to_multiple_remotes(
     push_tags: bool,
     token: Option<String>,
 ) -> Result<MultiPushResult> {
+    // Reject branch and remote names that could be parsed as flags.
+    if let Some(ref b) = branch {
+        reject_flag_like(b, "Branch name")?;
+    }
+    for r in &remotes {
+        reject_flag_like(r, "Remote name")?;
+    }
+
     // Each push is blocking network I/O for potentially seconds; running them
     // sequentially on the async executor blocks a Tokio worker for the full
     // duration of all pushes combined. Offload to a blocking thread.

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -329,11 +329,19 @@ pub async fn pull(
                             Ok(())
                         })();
 
-                        if let Err(e) = merge_commit_result {
-                            // Best-effort cleanup; ignore secondary errors so
-                            // the original cause is what surfaces.
-                            let _ = repo.cleanup_state();
-                            return Err(e);
+                        // MergeConflict is the expected "user must resolve"
+                        // path; the UI drives a conflict-resolution flow
+                        // that needs MERGE_HEAD intact. Only cleanup_state
+                        // for non-conflict errors.
+                        match merge_commit_result {
+                            Err(LeviathanError::MergeConflict) => {
+                                return Err(LeviathanError::MergeConflict);
+                            }
+                            Err(e) => {
+                                let _ = repo.cleanup_state();
+                                return Err(e);
+                            }
+                            Ok(()) => {}
                         }
 
                         repo.cleanup_state()?;

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -148,36 +148,44 @@ pub async fn fetch(
     timeout_secs: Option<u64>,
     _operation_id: Option<String>,
 ) -> Result<()> {
-    let do_fetch = async {
-        let repo = git2::Repository::open(Path::new(&path))?;
+    let do_fetch = async move {
+        let path_clone = path.clone();
+        let prune_val = prune.unwrap_or(false);
+        let remote_name_owned = remote.unwrap_or_else(|| "origin".to_string());
+        let remote_name_for_event = remote_name_owned.clone();
 
-        let remote_name = remote.as_deref().unwrap_or("origin");
-        let mut git_remote = repo
-            .find_remote(remote_name)
-            .map_err(|_| LeviathanError::RemoteNotFound(remote_name.to_string()))?;
+        // git2 fetch is blocking network I/O; offload to a blocking thread so
+        // it doesn't starve the Tokio runtime.
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let repo = git2::Repository::open(Path::new(&path_clone))?;
+            let mut git_remote = repo
+                .find_remote(&remote_name_owned)
+                .map_err(|_| LeviathanError::RemoteNotFound(remote_name_owned.clone()))?;
 
-        let mut fetch_opts = credentials_service::get_fetch_options(token);
+            let mut fetch_opts = credentials_service::get_fetch_options(token);
+            if prune_val {
+                fetch_opts.prune(git2::FetchPrune::On);
+            }
 
-        if prune.unwrap_or(false) {
-            fetch_opts.prune(git2::FetchPrune::On);
-        }
+            let refspecs: Vec<String> = git_remote
+                .fetch_refspecs()?
+                .iter()
+                .filter_map(|s| s.map(|s| s.to_string()))
+                .collect();
+            let refspec_strs: Vec<&str> = refspecs.iter().map(|s| s.as_str()).collect();
 
-        let refspecs: Vec<String> = git_remote
-            .fetch_refspecs()?
-            .iter()
-            .filter_map(|s| s.map(|s| s.to_string()))
-            .collect();
-
-        let refspec_strs: Vec<&str> = refspecs.iter().map(|s| s.as_str()).collect();
-
-        git_remote.fetch(&refspec_strs, Some(&mut fetch_opts), None)?;
+            git_remote.fetch(&refspec_strs, Some(&mut fetch_opts), None)?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| LeviathanError::Custom(format!("Fetch task failed: {}", e)))??;
 
         // Emit success event
         let _ = app_handle.emit(
             "remote-operation-completed",
             RemoteOperationResult {
                 operation: "fetch".to_string(),
-                remote: remote_name.to_string(),
+                remote: remote_name_for_event,
                 success: true,
                 message: "Fetch completed successfully".to_string(),
             },
@@ -215,95 +223,116 @@ pub async fn pull(
     timeout_secs: Option<u64>,
     _operation_id: Option<String>,
 ) -> Result<()> {
-    let do_pull = async {
-        let repo = git2::Repository::open(Path::new(&path))?;
+    let do_pull = async move {
+        let path_for_task = path.clone();
+        let remote_owned = remote.unwrap_or_else(|| "origin".to_string());
+        let remote_for_task = remote_owned.clone();
+        let branch_for_task = branch.clone();
+        let rebase_val = rebase.unwrap_or(false);
 
-        let remote_name = remote.as_deref().unwrap_or("origin");
+        // Whole pull is git2 / blocking network I/O. Run it on a blocking
+        // thread so the Tokio runtime stays responsive.
+        let (remote_name_returned, message) =
+            tokio::task::spawn_blocking(move || -> Result<(String, String)> {
+                // First fetch (network I/O)
+                fetch_internal(&path_for_task, &remote_for_task, false, token)?;
 
-        // First fetch (without emitting separate event)
-        fetch_internal(&path, remote_name, false, token)?;
+                let repo = git2::Repository::open(Path::new(&path_for_task))?;
 
-        // Get the branch to merge
-        let branch_name = if let Some(ref b) = branch {
-            b.clone()
-        } else {
-            let head = repo.head()?;
-            head.shorthand().unwrap_or("main").to_string()
-        };
+                let branch_name = if let Some(ref b) = branch_for_task {
+                    b.clone()
+                } else {
+                    let head = repo.head()?;
+                    head.shorthand().unwrap_or("main").to_string()
+                };
 
-        let remote_ref = format!("{}/{}", remote_name, branch_name);
-        let fetch_head = repo.find_reference(&format!("refs/remotes/{}", remote_ref))?;
-        let fetch_commit = repo.reference_to_annotated_commit(&fetch_head)?;
+                let remote_ref = format!("{}/{}", remote_for_task, branch_name);
+                let fetch_head =
+                    repo.find_reference(&format!("refs/remotes/{}", remote_ref))?;
+                let fetch_commit = repo.reference_to_annotated_commit(&fetch_head)?;
 
-        let message: String;
+                let message: String;
 
-        if rebase.unwrap_or(false) {
-            // Rebase onto remote
-            let head = repo.head()?;
-            let head_commit = repo.reference_to_annotated_commit(&head)?;
+                if rebase_val {
+                    let head = repo.head()?;
+                    let head_commit = repo.reference_to_annotated_commit(&head)?;
 
-            let mut rebase_obj =
-                repo.rebase(Some(&head_commit), Some(&fetch_commit), None, None)?;
+                    let mut rebase_obj =
+                        repo.rebase(Some(&head_commit), Some(&fetch_commit), None, None)?;
 
-            let mut commit_count = 0;
-            while let Some(op) = rebase_obj.next() {
-                let _op = op?;
-                let signature = repo.signature()?;
-                rebase_obj.commit(None, &signature, None)?;
-                commit_count += 1;
-            }
+                    let mut commit_count = 0;
+                    while let Some(op) = rebase_obj.next() {
+                        let _op = op?;
+                        let signature = repo.signature()?;
+                        rebase_obj.commit(None, &signature, None)?;
+                        commit_count += 1;
+                    }
 
-            rebase_obj.finish(Some(&repo.signature()?))?;
-            message = format!("Rebased {} commit(s)", commit_count);
-        } else {
-            // Merge
-            let (analysis, _preference) = repo.merge_analysis(&[&fetch_commit])?;
+                    rebase_obj.finish(Some(&repo.signature()?))?;
+                    message = format!("Rebased {} commit(s)", commit_count);
+                } else {
+                    let (analysis, _preference) = repo.merge_analysis(&[&fetch_commit])?;
 
-            if analysis.is_up_to_date() {
-                message = "Already up to date".to_string();
-            } else if analysis.is_fast_forward() {
-                // Fast-forward
-                let refname = format!("refs/heads/{}", branch_name);
-                let mut reference = repo.find_reference(&refname)?;
-                reference.set_target(fetch_commit.id(), "Fast-forward")?;
-                repo.set_head(&refname)?;
-                repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
-                message = "Fast-forward merge completed".to_string();
-            } else {
-                // Normal merge
-                repo.merge(&[&fetch_commit], None, None)?;
+                    if analysis.is_up_to_date() {
+                        message = "Already up to date".to_string();
+                    } else if analysis.is_fast_forward() {
+                        let refname = format!("refs/heads/{}", branch_name);
+                        let mut reference = repo.find_reference(&refname)?;
+                        reference.set_target(fetch_commit.id(), "Fast-forward")?;
+                        repo.set_head(&refname)?;
+                        repo.checkout_head(Some(
+                            git2::build::CheckoutBuilder::default().force(),
+                        ))?;
+                        message = "Fast-forward merge completed".to_string();
+                    } else {
+                        // Normal merge. Anything that fails AFTER repo.merge()
+                        // succeeds must reset state, otherwise the working
+                        // copy is permanently stuck in MERGING.
+                        repo.merge(&[&fetch_commit], None, None)?;
 
-                if repo.index()?.has_conflicts() {
-                    return Err(LeviathanError::MergeConflict);
+                        let merge_commit_result = (|| -> Result<()> {
+                            if repo.index()?.has_conflicts() {
+                                return Err(LeviathanError::MergeConflict);
+                            }
+                            let signature = repo.signature()?;
+                            let head = repo.head()?.peel_to_commit()?;
+                            let remote_commit = repo.find_commit(fetch_commit.id())?;
+                            let tree_oid = repo.index()?.write_tree()?;
+                            let tree = repo.find_tree(tree_oid)?;
+                            repo.commit(
+                                Some("HEAD"),
+                                &signature,
+                                &signature,
+                                &format!("Merge {} into {}", remote_ref, branch_name),
+                                &tree,
+                                &[&head, &remote_commit],
+                            )?;
+                            Ok(())
+                        })();
+
+                        if let Err(e) = merge_commit_result {
+                            // Best-effort cleanup; ignore secondary errors so
+                            // the original cause is what surfaces.
+                            let _ = repo.cleanup_state();
+                            return Err(e);
+                        }
+
+                        repo.cleanup_state()?;
+                        message = "Merge completed".to_string();
+                    }
                 }
 
-                // Create merge commit
-                let signature = repo.signature()?;
-                let head = repo.head()?.peel_to_commit()?;
-                let remote_commit = repo.find_commit(fetch_commit.id())?;
-                let tree_oid = repo.index()?.write_tree()?;
-                let tree = repo.find_tree(tree_oid)?;
-
-                repo.commit(
-                    Some("HEAD"),
-                    &signature,
-                    &signature,
-                    &format!("Merge {} into {}", remote_ref, branch_name),
-                    &tree,
-                    &[&head, &remote_commit],
-                )?;
-
-                repo.cleanup_state()?;
-                message = "Merge completed".to_string();
-            }
-        }
+                Ok((remote_for_task, message))
+            })
+            .await
+            .map_err(|e| LeviathanError::Custom(format!("Pull task failed: {}", e)))??;
 
         // Emit success event
         let _ = app_handle.emit(
             "remote-operation-completed",
             RemoteOperationResult {
                 operation: "pull".to_string(),
-                remote: remote_name.to_string(),
+                remote: remote_name_returned,
                 success: true,
                 message,
             },

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -247,8 +247,7 @@ pub async fn pull(
                 };
 
                 let remote_ref = format!("{}/{}", remote_for_task, branch_name);
-                let fetch_head =
-                    repo.find_reference(&format!("refs/remotes/{}", remote_ref))?;
+                let fetch_head = repo.find_reference(&format!("refs/remotes/{}", remote_ref))?;
                 let fetch_commit = repo.reference_to_annotated_commit(&fetch_head)?;
 
                 let message: String;
@@ -280,9 +279,7 @@ pub async fn pull(
                         let mut reference = repo.find_reference(&refname)?;
                         reference.set_target(fetch_commit.id(), "Fast-forward")?;
                         repo.set_head(&refname)?;
-                        repo.checkout_head(Some(
-                            git2::build::CheckoutBuilder::default().force(),
-                        ))?;
+                        repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
                         message = "Fast-forward merge completed".to_string();
                     } else {
                         // Normal merge. Anything that fails AFTER repo.merge()
@@ -400,72 +397,86 @@ pub async fn push(
     timeout_secs: Option<u64>,
     _operation_id: Option<String>,
 ) -> Result<()> {
-    let do_push = async {
-        let repo = git2::Repository::open(Path::new(&path))?;
-
-        let remote_name = remote.as_deref().unwrap_or("origin");
-
-        // Validate remote exists
-        repo.find_remote(remote_name)
-            .map_err(|_| LeviathanError::RemoteNotFound(remote_name.to_string()))?;
-
-        let branch_name = if let Some(ref b) = branch {
-            b.clone()
-        } else {
-            let head = repo.head()?;
-            head.shorthand().unwrap_or("main").to_string()
-        };
-
+    let do_push = async move {
+        let path_for_task = path.clone();
+        let remote_name_owned = remote.unwrap_or_else(|| "origin".to_string());
+        let remote_for_task = remote_name_owned.clone();
+        let branch_for_task = branch.clone();
+        let force_val = force.unwrap_or(false);
         let use_force_with_lease = force_with_lease.unwrap_or(false);
         let use_push_tags = push_tags.unwrap_or(false);
+        let set_upstream_val = set_upstream.unwrap_or(false);
 
-        // force_with_lease requires git CLI since git2 doesn't support it natively.
-        // We also use git CLI when push_tags is requested, since git2 would require
-        // building separate refspecs for each tag.
-        if use_force_with_lease || use_push_tags {
-            push_via_cli(
-                &path,
-                remote_name,
-                &branch_name,
-                force.unwrap_or(false),
-                use_force_with_lease,
-                use_push_tags,
-                set_upstream.unwrap_or(false),
-                token,
-            )?;
-        } else {
-            // Use git2 for standard push (existing behavior)
-            let mut git_remote = repo
-                .find_remote(remote_name)
-                .map_err(|_| LeviathanError::RemoteNotFound(remote_name.to_string()))?;
+        // git2/git-CLI push is blocking network I/O; offload so the runtime
+        // stays responsive during slow remotes.
+        let (remote_name_returned, branch_name_returned) =
+            tokio::task::spawn_blocking(move || -> Result<(String, String)> {
+                let repo = git2::Repository::open(Path::new(&path_for_task))?;
 
-            let mut push_opts = credentials_service::get_push_options(token);
+                repo.find_remote(&remote_for_task)
+                    .map_err(|_| LeviathanError::RemoteNotFound(remote_for_task.clone()))?;
 
-            let refspec = if force.unwrap_or(false) {
-                format!("+refs/heads/{}:refs/heads/{}", branch_name, branch_name)
-            } else {
-                format!("refs/heads/{}:refs/heads/{}", branch_name, branch_name)
-            };
+                let branch_name = if let Some(ref b) = branch_for_task {
+                    b.clone()
+                } else {
+                    let head = repo.head()?;
+                    head.shorthand().unwrap_or("main").to_string()
+                };
 
-            git_remote.push(&[&refspec], Some(&mut push_opts))?;
+                if use_force_with_lease || use_push_tags {
+                    push_via_cli(
+                        &path_for_task,
+                        &remote_for_task,
+                        &branch_name,
+                        force_val,
+                        use_force_with_lease,
+                        use_push_tags,
+                        set_upstream_val,
+                        token,
+                    )?;
+                } else {
+                    let mut git_remote = repo
+                        .find_remote(&remote_for_task)
+                        .map_err(|_| LeviathanError::RemoteNotFound(remote_for_task.clone()))?;
 
-            // Set upstream if requested
-            if set_upstream.unwrap_or(false) {
-                let mut local_branch = repo.find_branch(&branch_name, git2::BranchType::Local)?;
-                let upstream_name = format!("{}/{}", remote_name, branch_name);
-                local_branch.set_upstream(Some(&upstream_name))?;
-            }
-        }
+                    let mut push_opts = credentials_service::get_push_options(token);
+
+                    let refspec = if force_val {
+                        format!("+refs/heads/{}:refs/heads/{}", branch_name, branch_name)
+                    } else {
+                        format!("refs/heads/{}:refs/heads/{}", branch_name, branch_name)
+                    };
+
+                    git_remote.push(&[&refspec], Some(&mut push_opts))?;
+
+                    if set_upstream_val {
+                        let mut local_branch =
+                            repo.find_branch(&branch_name, git2::BranchType::Local)?;
+                        let upstream_name = format!("{}/{}", remote_for_task, branch_name);
+                        local_branch.set_upstream(Some(&upstream_name))?;
+                    }
+                }
+
+                Ok((remote_for_task, branch_name))
+            })
+            .await
+            .map_err(|e| LeviathanError::Custom(format!("Push task failed: {}", e)))??;
 
         // Emit success event
-        let mut message = format!("Pushed to {}/{}", remote_name, branch_name);
+        let mut message = format!(
+            "Pushed to {}/{}",
+            remote_name_returned, branch_name_returned
+        );
         if use_force_with_lease {
             message = format!(
                 "Force-pushed (with lease) to {}/{}",
-                remote_name, branch_name
+                remote_name_returned, branch_name_returned
             );
-        } else if force.unwrap_or(false) {
-            message = format!("Force-pushed to {}/{}", remote_name, branch_name);
+        } else if force_val {
+            message = format!(
+                "Force-pushed to {}/{}",
+                remote_name_returned, branch_name_returned
+            );
         }
         if use_push_tags {
             message.push_str(" (including tags)");
@@ -475,7 +486,7 @@ pub async fn push(
             "remote-operation-completed",
             RemoteOperationResult {
                 operation: "push".to_string(),
-                remote: remote_name.to_string(),
+                remote: remote_name_returned,
                 success: true,
                 message,
             },
@@ -617,66 +628,81 @@ pub async fn push_to_multiple_remotes(
     push_tags: bool,
     token: Option<String>,
 ) -> Result<MultiPushResult> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    // Each push is blocking network I/O for potentially seconds; running them
+    // sequentially on the async executor blocks a Tokio worker for the full
+    // duration of all pushes combined. Offload to a blocking thread.
+    let path_for_task = path.clone();
+    let remotes_for_task = remotes.clone();
+    let branch_for_task = branch.clone();
+    let token_for_task = token.clone();
 
-    let branch_name = if let Some(ref b) = branch {
-        b.clone()
-    } else {
-        let head = repo.head()?;
-        head.shorthand().unwrap_or("main").to_string()
-    };
+    let (results, total_success, total_failed) =
+        tokio::task::spawn_blocking(move || -> Result<(Vec<RemotePushResult>, u32, u32)> {
+            let repo = git2::Repository::open(Path::new(&path_for_task))?;
 
-    // Validate that all remotes exist before starting
-    for remote_name in &remotes {
-        repo.find_remote(remote_name)
-            .map_err(|_| LeviathanError::RemoteNotFound(remote_name.clone()))?;
-    }
+            let branch_name = if let Some(ref b) = branch_for_task {
+                b.clone()
+            } else {
+                let head = repo.head()?;
+                head.shorthand().unwrap_or("main").to_string()
+            };
 
-    let mut results: Vec<RemotePushResult> = Vec::new();
-    let mut total_success: u32 = 0;
-    let mut total_failed: u32 = 0;
-
-    for remote_name in &remotes {
-        match push_single_remote(
-            &path,
-            remote_name,
-            &branch_name,
-            force,
-            force_with_lease,
-            push_tags,
-            token.clone(),
-        ) {
-            Ok(()) => {
-                let mut message = format!("Pushed to {}/{}", remote_name, branch_name);
-                if force_with_lease {
-                    message = format!(
-                        "Force-pushed (with lease) to {}/{}",
-                        remote_name, branch_name
-                    );
-                } else if force {
-                    message = format!("Force-pushed to {}/{}", remote_name, branch_name);
-                }
-                if push_tags {
-                    message.push_str(" (including tags)");
-                }
-
-                results.push(RemotePushResult {
-                    remote: remote_name.clone(),
-                    success: true,
-                    message: Some(message),
-                });
-                total_success += 1;
+            // Validate that all remotes exist before starting
+            for remote_name in &remotes_for_task {
+                repo.find_remote(remote_name)
+                    .map_err(|_| LeviathanError::RemoteNotFound(remote_name.clone()))?;
             }
-            Err(e) => {
-                results.push(RemotePushResult {
-                    remote: remote_name.clone(),
-                    success: false,
-                    message: Some(e),
-                });
-                total_failed += 1;
+
+            let mut results: Vec<RemotePushResult> = Vec::new();
+            let mut total_success: u32 = 0;
+            let mut total_failed: u32 = 0;
+
+            for remote_name in &remotes_for_task {
+                match push_single_remote(
+                    &path_for_task,
+                    remote_name,
+                    &branch_name,
+                    force,
+                    force_with_lease,
+                    push_tags,
+                    token_for_task.clone(),
+                ) {
+                    Ok(()) => {
+                        let mut message = format!("Pushed to {}/{}", remote_name, branch_name);
+                        if force_with_lease {
+                            message = format!(
+                                "Force-pushed (with lease) to {}/{}",
+                                remote_name, branch_name
+                            );
+                        } else if force {
+                            message = format!("Force-pushed to {}/{}", remote_name, branch_name);
+                        }
+                        if push_tags {
+                            message.push_str(" (including tags)");
+                        }
+
+                        results.push(RemotePushResult {
+                            remote: remote_name.clone(),
+                            success: true,
+                            message: Some(message),
+                        });
+                        total_success += 1;
+                    }
+                    Err(e) => {
+                        results.push(RemotePushResult {
+                            remote: remote_name.clone(),
+                            success: false,
+                            message: Some(e),
+                        });
+                        total_failed += 1;
+                    }
+                }
             }
-        }
-    }
+
+            Ok((results, total_success, total_failed))
+        })
+        .await
+        .map_err(|e| LeviathanError::Custom(format!("Push task failed: {}", e)))??;
 
     let overall_success = total_failed == 0;
 
@@ -710,37 +736,55 @@ pub async fn fetch_all_remotes(
     tags: bool,
     token: Option<String>,
 ) -> Result<FetchAllResult> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let remote_names = repo.remotes()?;
+    // Multiple sequential blocking fetches; run on a blocking thread to keep
+    // the Tokio runtime responsive.
+    let path_for_task = path.clone();
+    let token_for_task = token.clone();
 
-    let mut results: Vec<RemoteFetchResult> = Vec::new();
-    let mut total_fetched: u32 = 0;
-    let mut total_failed: u32 = 0;
+    let (results, total_fetched, total_failed) =
+        tokio::task::spawn_blocking(move || -> Result<(Vec<RemoteFetchResult>, u32, u32)> {
+            let repo = git2::Repository::open(Path::new(&path_for_task))?;
+            let remote_names = repo.remotes()?;
 
-    for remote_name in remote_names.iter().flatten() {
-        let fetch_result = fetch_single_remote(&path, remote_name, prune, tags, token.clone());
+            let mut results: Vec<RemoteFetchResult> = Vec::new();
+            let mut total_fetched: u32 = 0;
+            let mut total_failed: u32 = 0;
 
-        match fetch_result {
-            Ok(refs_updated) => {
-                results.push(RemoteFetchResult {
-                    remote: remote_name.to_string(),
-                    success: true,
-                    message: Some(format!("Fetched {} refs", refs_updated)),
-                    refs_updated,
-                });
-                total_fetched += 1;
+            for remote_name in remote_names.iter().flatten() {
+                let fetch_result = fetch_single_remote(
+                    &path_for_task,
+                    remote_name,
+                    prune,
+                    tags,
+                    token_for_task.clone(),
+                );
+
+                match fetch_result {
+                    Ok(refs_updated) => {
+                        results.push(RemoteFetchResult {
+                            remote: remote_name.to_string(),
+                            success: true,
+                            message: Some(format!("Fetched {} refs", refs_updated)),
+                            refs_updated,
+                        });
+                        total_fetched += 1;
+                    }
+                    Err(e) => {
+                        results.push(RemoteFetchResult {
+                            remote: remote_name.to_string(),
+                            success: false,
+                            message: Some(e.to_string()),
+                            refs_updated: 0,
+                        });
+                        total_failed += 1;
+                    }
+                }
             }
-            Err(e) => {
-                results.push(RemoteFetchResult {
-                    remote: remote_name.to_string(),
-                    success: false,
-                    message: Some(e.to_string()),
-                    refs_updated: 0,
-                });
-                total_failed += 1;
-            }
-        }
-    }
+
+            Ok((results, total_fetched, total_failed))
+        })
+        .await
+        .map_err(|e| LeviathanError::Custom(format!("Fetch task failed: {}", e)))??;
 
     let overall_success = total_failed == 0;
 
@@ -780,12 +824,6 @@ fn fetch_single_remote(
         .find_remote(remote_name)
         .map_err(|_| LeviathanError::RemoteNotFound(remote_name.to_string()))?;
 
-    let mut fetch_opts = credentials_service::get_fetch_options(token);
-
-    if prune {
-        fetch_opts.prune(git2::FetchPrune::On);
-    }
-
     // Collect refspecs
     let mut refspecs: Vec<String> = git_remote
         .fetch_refspecs()?
@@ -804,21 +842,23 @@ fn fetch_single_remote(
     let refs_updated = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
     let refs_counter = refs_updated.clone();
 
-    let mut callbacks = git2::RemoteCallbacks::new();
+    // Build callbacks that carry BOTH the credentials (token) AND our
+    // update_tips counter. Previously this code rebuilt options with `None`
+    // for the token, silently dropping the caller's auth and breaking fetch
+    // on private remotes.
+    let mut callbacks = credentials_service::get_callbacks_with_progress(token);
     callbacks.update_tips(move |_refname, _old, _new| {
         refs_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         true
     });
 
-    // Transfer credentials callback from fetch_opts to our callbacks
-    // We need to rebuild fetch options with our callbacks
-    let mut fetch_opts_with_callbacks = credentials_service::get_fetch_options(None);
+    let mut fetch_opts = git2::FetchOptions::new();
     if prune {
-        fetch_opts_with_callbacks.prune(git2::FetchPrune::On);
+        fetch_opts.prune(git2::FetchPrune::On);
     }
-    fetch_opts_with_callbacks.remote_callbacks(callbacks);
+    fetch_opts.remote_callbacks(callbacks);
 
-    git_remote.fetch(&refspec_strs, Some(&mut fetch_opts_with_callbacks), None)?;
+    git_remote.fetch(&refspec_strs, Some(&mut fetch_opts), None)?;
 
     Ok(refs_updated.load(std::sync::atomic::Ordering::Relaxed))
 }

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -71,6 +71,44 @@ pub async fn open_repository(path: String) -> Result<Repository> {
     })
 }
 
+/// Validate a clone URL: reject values that could be parsed as a CLI flag, and
+/// require a recognizable scheme. This is critical defense against
+/// `--upload-pack=`/`--config=` style argument injection when the URL is
+/// passed to `git clone`.
+fn validate_clone_url(url: &str) -> Result<()> {
+    if url.is_empty() {
+        return Err(LeviathanError::Custom("Clone URL is empty".into()));
+    }
+    if url.starts_with('-') {
+        return Err(LeviathanError::Custom(
+            "Clone URL must not start with '-'".into(),
+        ));
+    }
+    let lower = url.to_ascii_lowercase();
+    let has_scheme = lower.starts_with("https://")
+        || lower.starts_with("http://")
+        || lower.starts_with("ssh://")
+        || lower.starts_with("git://")
+        || lower.starts_with("file://")
+        || lower.starts_with("git@");
+    // Allow user@host:path SCP-style syntax (must contain ':' before any '/')
+    let scp_style = !has_scheme
+        && url.contains('@')
+        && url.contains(':')
+        && url
+            .find(':')
+            .zip(url.find('/'))
+            .map(|(c, s)| c < s)
+            .unwrap_or(true);
+    if !has_scheme && !scp_style {
+        return Err(LeviathanError::Custom(format!(
+            "Unsupported clone URL scheme: {}",
+            url
+        )));
+    }
+    Ok(())
+}
+
 /// Detect if a repository is a partial clone and extract the filter
 fn detect_partial_clone_status(repo: &git2::Repository) -> (bool, Option<String>) {
     let config = match repo.config() {
@@ -107,6 +145,7 @@ pub async fn clone_repository(
     single_branch: Option<bool>,
     timeout_secs: Option<u64>,
 ) -> Result<Repository> {
+    validate_clone_url(&url)?;
     let do_clone = async {
         let dest_path = std::path::PathBuf::from(&path);
         let url_clone = url.clone();
@@ -159,6 +198,9 @@ pub async fn clone_repository(
                     url_clone.clone()
                 };
 
+                // `--` prevents URL/path from being parsed as a flag
+                // (defense against `--upload-pack=` style injection).
+                cmd.arg("--");
                 cmd.arg(&effective_url);
                 cmd.arg(&dest_path);
 

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -79,28 +79,52 @@ fn validate_clone_url(url: &str) -> Result<()> {
     if url.is_empty() {
         return Err(LeviathanError::Custom("Clone URL is empty".into()));
     }
-    if url.starts_with('-') {
-        return Err(LeviathanError::Custom(
-            "Clone URL must not start with '-'".into(),
-        ));
-    }
+    // Leading-`-` and CR/LF are the universal CLI-safety rejections. Reuse
+    // the shared helper so this stays consistent with every other git-CLI
+    // entrypoint in the codebase.
+    crate::utils::reject_flag_like(url, "Clone URL")?;
     let lower = url.to_ascii_lowercase();
     let has_scheme = lower.starts_with("https://")
         || lower.starts_with("http://")
         || lower.starts_with("ssh://")
         || lower.starts_with("git://")
-        || lower.starts_with("file://")
-        || lower.starts_with("git@");
-    // Allow user@host:path SCP-style syntax (must contain ':' before any '/')
-    let scp_style = !has_scheme
-        && url.contains('@')
-        && url.contains(':')
-        && url
-            .find(':')
-            .zip(url.find('/'))
-            .map(|(c, s)| c < s)
-            .unwrap_or(true);
-    if !has_scheme && !scp_style {
+        || lower.starts_with("file://");
+    // Accept SCP-style refs of the form `[user@]host:path`. The standard form
+    // is `user@host:path` but git also allows the `@` to be omitted
+    // (`host:path`). To stay unambiguous on Windows, we explicitly reject
+    // values that look like a drive-letter path (`C:/...`, `C:\...`).
+    let looks_like_scp = !has_scheme && {
+        let first_colon = url.find(':');
+        let first_slash = url.find('/');
+        match first_colon {
+            None => false,
+            Some(colon_idx) => {
+                // Reject Windows drive-letter paths: single ASCII letter then ':'
+                // optionally followed by '/' or '\\'. Treat as a local path,
+                // not an SCP URL.
+                let drive_letter = colon_idx == 1
+                    && url
+                        .chars()
+                        .next()
+                        .map(|c| c.is_ascii_alphabetic())
+                        .unwrap_or(false);
+                if drive_letter {
+                    false
+                } else {
+                    // host part (before ':') must be non-empty and not contain '/'
+                    let host = &url[..colon_idx];
+                    // Reject `scheme://` patterns where the char after ':' is
+                    // also '/' — that's a URI scheme, not SCP form.
+                    let after_colon = url.as_bytes().get(colon_idx + 1).copied();
+                    !host.is_empty()
+                        && !host.contains('/')
+                        && after_colon != Some(b'/')
+                        && first_slash.map(|s| s > colon_idx).unwrap_or(true)
+                }
+            }
+        }
+    };
+    if !has_scheme && !looks_like_scp {
         return Err(LeviathanError::Custom(format!(
             "Unsupported clone URL scheme: {}",
             url
@@ -537,6 +561,51 @@ mod tests {
     use super::*;
     use crate::test_utils::TestRepo;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_validate_clone_url_accepts_https_and_ssh_schemes() {
+        assert!(validate_clone_url("https://github.com/foo/bar.git").is_ok());
+        assert!(validate_clone_url("http://example.com/foo.git").is_ok());
+        assert!(validate_clone_url("ssh://git@host/foo.git").is_ok());
+        assert!(validate_clone_url("git://host/foo.git").is_ok());
+        assert!(validate_clone_url("file:///tmp/repo").is_ok());
+    }
+
+    #[test]
+    fn test_validate_clone_url_accepts_scp_style() {
+        // user@host:path is the canonical SCP form
+        assert!(validate_clone_url("git@github.com:foo/bar.git").is_ok());
+        // host:path (no user) is also valid git syntax
+        assert!(validate_clone_url("server.example.com:repo.git").is_ok());
+    }
+
+    #[test]
+    fn test_validate_clone_url_rejects_flag_like() {
+        assert!(validate_clone_url("--upload-pack=/tmp/evil").is_err());
+        assert!(validate_clone_url("-foo").is_err());
+    }
+
+    #[test]
+    fn test_validate_clone_url_rejects_crlf() {
+        assert!(validate_clone_url("https://example.com/\nfoo").is_err());
+        assert!(validate_clone_url("https://example.com/\rfoo").is_err());
+    }
+
+    #[test]
+    fn test_validate_clone_url_rejects_windows_drive_letter() {
+        // C:\path is a local Windows path, NOT an SCP URL — must be rejected
+        // so we don't accidentally pass it to git as `git clone host:path`.
+        assert!(validate_clone_url("C:/Users/me/repo").is_err());
+        assert!(validate_clone_url("D:\\repo").is_err());
+    }
+
+    #[test]
+    fn test_validate_clone_url_rejects_empty_and_unknown_scheme() {
+        assert!(validate_clone_url("").is_err());
+        assert!(validate_clone_url("ftp://host/foo").is_err());
+        // No colon at all → not a recognizable URL form
+        assert!(validate_clone_url("plainstring").is_err());
+    }
 
     #[tokio::test]
     async fn test_open_repository_valid() {

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -146,6 +146,24 @@ pub async fn clone_repository(
     timeout_secs: Option<u64>,
 ) -> Result<Repository> {
     validate_clone_url(&url)?;
+    // `--branch` and `--filter` consume the next argv as their value, so a
+    // value starting with `-` is not a flag injection today. We reject them
+    // anyway as defense in depth: a future refactor toward
+    // `--branch=<value>` style would otherwise re-introduce flag injection.
+    if let Some(ref b) = branch {
+        if b.starts_with('-') || b.contains('\n') || b.contains('\r') {
+            return Err(LeviathanError::Custom(
+                "Branch name must not start with '-' or contain newlines".into(),
+            ));
+        }
+    }
+    if let Some(ref f) = filter {
+        if f.starts_with('-') || f.contains('\n') || f.contains('\r') {
+            return Err(LeviathanError::Custom(
+                "Filter spec must not start with '-' or contain newlines".into(),
+            ));
+        }
+    }
     let do_clone = async {
         let dest_path = std::path::PathBuf::from(&path);
         let url_clone = url.clone();

--- a/src-tauri/src/commands/sparse_checkout.rs
+++ b/src-tauri/src/commands/sparse_checkout.rs
@@ -111,7 +111,7 @@ pub async fn set_sparse_checkout_patterns(
         ));
     }
 
-    let mut args: Vec<&str> = vec!["sparse-checkout", "set"];
+    let mut args: Vec<&str> = vec!["sparse-checkout", "set", "--"];
     for p in &patterns {
         args.push(p.as_str());
     }
@@ -131,7 +131,7 @@ pub async fn add_sparse_checkout_patterns(
         ));
     }
 
-    let mut args: Vec<&str> = vec!["sparse-checkout", "add"];
+    let mut args: Vec<&str> = vec!["sparse-checkout", "add", "--"];
     for p in &patterns {
         args.push(p.as_str());
     }

--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -463,41 +463,46 @@ pub async fn discard_changes(path: String, paths: Vec<String>) -> Result<()> {
     Ok(())
 }
 
+/// Apply a patch to the index. Internal helper shared by stage_hunk /
+/// unstage_hunk; uses a unique temp file per call so concurrent invocations
+/// don't clobber each other's patch on disk.
+fn apply_patch_to_index(repo_path: &str, patch: &str, reverse: bool) -> Result<()> {
+    // NamedTempFile produces a unique name (random suffix) and removes
+    // the file on drop, so concurrent calls cannot collide.
+    let mut tmp = tempfile::Builder::new()
+        .prefix("leviathan_hunk_")
+        .suffix(".patch")
+        .tempfile()?;
+    tmp.write_all(patch.as_bytes())?;
+    tmp.flush()?;
+
+    let mut cmd = create_command("git");
+    if reverse {
+        cmd.args(["apply", "--cached", "--reverse", "--unidiff-zero"]);
+    } else {
+        cmd.args(["apply", "--cached", "--unidiff-zero"]);
+    }
+    let output = cmd.arg(tmp.path()).current_dir(repo_path).output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let label = if reverse { "unstage" } else { "stage" };
+        return Err(crate::error::LeviathanError::OperationFailed(format!(
+            "Failed to {} hunk: {}",
+            label, stderr
+        )));
+    }
+
+    Ok(())
+}
+
 /// Stage a specific hunk from a diff
 ///
 /// Takes a patch string containing just the hunk to stage (with proper headers)
 /// and applies it to the index using git apply --cached
 #[command]
 pub async fn stage_hunk(repo_path: String, patch: String) -> Result<()> {
-    // Create a temporary file for the patch
-    let temp_dir = std::env::temp_dir();
-    let patch_file = temp_dir.join(format!("leviathan_hunk_{}.patch", std::process::id()));
-
-    // Write patch to temp file
-    let mut file = std::fs::File::create(&patch_file)?;
-    file.write_all(patch.as_bytes())?;
-    file.flush()?;
-    drop(file);
-
-    // Apply the patch to the index
-    let output = create_command("git")
-        .args(["apply", "--cached", "--unidiff-zero"])
-        .arg(&patch_file)
-        .current_dir(&repo_path)
-        .output()?;
-
-    // Clean up temp file
-    let _ = std::fs::remove_file(&patch_file);
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(crate::error::LeviathanError::OperationFailed(format!(
-            "Failed to stage hunk: {}",
-            stderr
-        )));
-    }
-
-    Ok(())
+    apply_patch_to_index(&repo_path, &patch, false)
 }
 
 /// Unstage a specific hunk from the index
@@ -505,35 +510,7 @@ pub async fn stage_hunk(repo_path: String, patch: String) -> Result<()> {
 /// Takes a patch string and applies it in reverse to unstage
 #[command]
 pub async fn unstage_hunk(repo_path: String, patch: String) -> Result<()> {
-    // Create a temporary file for the patch
-    let temp_dir = std::env::temp_dir();
-    let patch_file = temp_dir.join(format!("leviathan_hunk_{}.patch", std::process::id()));
-
-    // Write patch to temp file
-    let mut file = std::fs::File::create(&patch_file)?;
-    file.write_all(patch.as_bytes())?;
-    file.flush()?;
-    drop(file);
-
-    // Apply the patch in reverse to unstage
-    let output = create_command("git")
-        .args(["apply", "--cached", "--reverse", "--unidiff-zero"])
-        .arg(&patch_file)
-        .current_dir(&repo_path)
-        .output()?;
-
-    // Clean up temp file
-    let _ = std::fs::remove_file(&patch_file);
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(crate::error::LeviathanError::OperationFailed(format!(
-            "Failed to unstage hunk: {}",
-            stderr
-        )));
-    }
-
-    Ok(())
+    apply_patch_to_index(&repo_path, &patch, true)
 }
 
 /// Write content to a file and optionally stage it

--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -743,33 +743,7 @@ pub async fn stage_hunk_by_index(path: String, file_path: String, hunk_index: u3
         })?;
 
     let patch = build_hunk_patch(&file_path, hunk);
-
-    // Write patch to temp file and apply
-    let temp_dir = std::env::temp_dir();
-    let patch_file = temp_dir.join(format!("leviathan_stage_hunk_{}.patch", std::process::id()));
-
-    let mut file = std::fs::File::create(&patch_file)?;
-    file.write_all(patch.as_bytes())?;
-    file.flush()?;
-    drop(file);
-
-    let output = create_command("git")
-        .args(["apply", "--cached", "--unidiff-zero"])
-        .arg(&patch_file)
-        .current_dir(&path)
-        .output()?;
-
-    let _ = std::fs::remove_file(&patch_file);
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(crate::error::LeviathanError::OperationFailed(format!(
-            "Failed to stage hunk: {}",
-            stderr
-        )));
-    }
-
-    Ok(())
+    apply_patch_to_index(&path, &patch, false)
 }
 
 /// Unstage a specific hunk by index
@@ -793,36 +767,7 @@ pub async fn unstage_hunk_by_index(path: String, file_path: String, hunk_index: 
         })?;
 
     let patch = build_hunk_patch(&file_path, hunk);
-
-    // Write patch to temp file and apply in reverse
-    let temp_dir = std::env::temp_dir();
-    let patch_file = temp_dir.join(format!(
-        "leviathan_unstage_hunk_{}.patch",
-        std::process::id()
-    ));
-
-    let mut file = std::fs::File::create(&patch_file)?;
-    file.write_all(patch.as_bytes())?;
-    file.flush()?;
-    drop(file);
-
-    let output = create_command("git")
-        .args(["apply", "--cached", "--reverse", "--unidiff-zero"])
-        .arg(&patch_file)
-        .current_dir(&path)
-        .output()?;
-
-    let _ = std::fs::remove_file(&patch_file);
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(crate::error::LeviathanError::OperationFailed(format!(
-            "Failed to unstage hunk: {}",
-            stderr
-        )));
-    }
-
-    Ok(())
+    apply_patch_to_index(&path, &patch, true)
 }
 
 /// Stage specific lines from a diff

--- a/src-tauri/src/commands/worktree.rs
+++ b/src-tauri/src/commands/worktree.rs
@@ -134,6 +134,17 @@ pub async fn add_worktree(
 ) -> Result<Worktree> {
     let repo_path = Path::new(&path);
 
+    crate::utils::reject_flag_like(&worktree_path, "Worktree path")?;
+    if let Some(ref nb) = new_branch {
+        crate::utils::reject_flag_like(nb, "New branch")?;
+    }
+    if let Some(ref b) = branch {
+        crate::utils::reject_flag_like(b, "Branch")?;
+    }
+    if let Some(ref c) = commit {
+        crate::utils::reject_flag_like(c, "Commit")?;
+    }
+
     let mut args = vec!["worktree", "add"];
 
     if force.unwrap_or(false) {
@@ -190,6 +201,8 @@ pub async fn remove_worktree(
 ) -> Result<()> {
     let repo_path = Path::new(&path);
 
+    crate::utils::reject_flag_like(&worktree_path, "Worktree path")?;
+
     let mut args = vec!["worktree", "remove"];
 
     if force.unwrap_or(false) {
@@ -227,6 +240,8 @@ pub async fn lock_worktree(
 ) -> Result<()> {
     let repo_path = Path::new(&path);
 
+    crate::utils::reject_flag_like(&worktree_path, "Worktree path")?;
+
     let mut args = vec!["worktree", "lock"];
 
     let reason_owned: String;
@@ -247,6 +262,8 @@ pub async fn lock_worktree(
 pub async fn unlock_worktree(path: String, worktree_path: String) -> Result<()> {
     let repo_path = Path::new(&path);
 
+    crate::utils::reject_flag_like(&worktree_path, "Worktree path")?;
+
     run_git_command(repo_path, &["worktree", "unlock", &worktree_path])?;
     Ok(())
 }
@@ -260,6 +277,9 @@ pub async fn move_worktree(
     force: Option<bool>,
 ) -> Result<()> {
     let repo_path = Path::new(&path);
+
+    crate::utils::reject_flag_like(&worktree_path, "Worktree path")?;
+    crate::utils::reject_flag_like(&new_path, "New path")?;
 
     let mut args = vec!["worktree", "move"];
 

--- a/src-tauri/src/services/credentials_service.rs
+++ b/src-tauri/src/services/credentials_service.rs
@@ -140,10 +140,7 @@ fn keyring_set(service: &str, account: &str, password: &str) -> bool {
                 return false;
             }
         }
-        child
-            .wait()
-            .map(|s| s.success())
-            .unwrap_or(false)
+        child.wait().map(|s| s.success()).unwrap_or(false)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -418,7 +415,7 @@ pub fn get_push_options<'a>(token: Option<String>) -> git2::PushOptions<'a> {
 }
 
 /// Get remote callbacks with both credential and progress support
-fn get_callbacks_with_progress<'a>(token: Option<String>) -> RemoteCallbacks<'a> {
+pub fn get_callbacks_with_progress<'a>(token: Option<String>) -> RemoteCallbacks<'a> {
     let mut callbacks = CredentialsHelper::new_with_token(token).get_callbacks();
 
     // Add transfer progress callback

--- a/src-tauri/src/services/credentials_service.rs
+++ b/src-tauri/src/services/credentials_service.rs
@@ -100,28 +100,49 @@ fn keyring_get(service: &str, account: &str) -> Option<String> {
 
 /// Store a password in the keyring.
 /// On macOS uses the `security` CLI with `-A` to allow any application to access
-/// the item without triggering authorization prompts.
+/// the item without triggering authorization prompts. The password is sent on
+/// stdin (via `-w` with no value) so it does NOT appear in the process argv,
+/// where any other process under the same user could read it via `ps`.
 fn keyring_set(service: &str, account: &str, password: &str) -> bool {
     #[cfg(target_os = "macos")]
     {
+        use std::io::Write as _;
+        use std::process::Stdio;
+
         // Delete existing entry first
         let _ = std::process::Command::new("security")
             .args(["delete-generic-password", "-s", service, "-a", account])
             .output();
-        std::process::Command::new("security")
+
+        // `-w` last with no argument => read password from stdin.
+        let mut child = match std::process::Command::new("security")
             .args([
                 "add-generic-password",
                 "-s",
                 service,
                 "-a",
                 account,
-                "-w",
-                password,
                 "-A", // Allow any application to access without prompt
                 "-U",
+                "-w",
             ])
-            .output()
-            .map(|o| o.status.success())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+        if let Some(mut stdin) = child.stdin.take() {
+            if stdin.write_all(password.as_bytes()).is_err() {
+                let _ = child.kill();
+                return false;
+            }
+        }
+        child
+            .wait()
+            .map(|s| s.success())
             .unwrap_or(false)
     }
     #[cfg(not(target_os = "macos"))]

--- a/src-tauri/src/utils/cli_safety.rs
+++ b/src-tauri/src/utils/cli_safety.rs
@@ -1,0 +1,33 @@
+//! Helpers for safely passing user-controlled values to `git` (or any other
+//! CLI tool that uses GNU-style argument parsing).
+//!
+//! The pattern enforced here is: every user-controlled URL / path / ref that
+//! is forwarded to a CLI as a positional argument must be (a) rejected if it
+//! starts with `-` (so it can't be parsed as a flag like `--upload-pack=...`)
+//! and (b) preceded by `--` in the argv so that even unforeseen GNU-parser
+//! behaviour can't reinterpret it as a flag.
+
+use crate::error::{LeviathanError, Result};
+
+/// Reject values that could be parsed as a CLI flag.
+///
+/// A value starting with `-` is the classic argument-injection vector against
+/// `git fetch`/`git clone`/`git rebase`/etc., where flags like `--upload-pack=`
+/// or `--exec=` lead directly to remote code execution. Embedded CR/LF can
+/// also confuse downstream parsers (notably `cmd.exe` on Windows), so we
+/// reject those too.
+pub fn reject_flag_like(value: &str, label: &str) -> Result<()> {
+    if value.starts_with('-') {
+        return Err(LeviathanError::OperationFailed(format!(
+            "{} must not start with '-'",
+            label
+        )));
+    }
+    if value.contains('\n') || value.contains('\r') {
+        return Err(LeviathanError::OperationFailed(format!(
+            "{} must not contain newlines",
+            label
+        )));
+    }
+    Ok(())
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,5 +1,7 @@
 //! Utility modules
 
+pub mod cli_safety;
 mod command;
 
+pub use cli_safety::reject_flag_like;
 pub use command::create_command;

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -634,12 +634,18 @@ export class AppShell extends LitElement {
 
   // Handle repository-refresh events from window (e.g., after commit).
   // External callers expect a full refresh (store + graph + indexes), not just
-  // the graph. The internalRefreshActive guard prevents re-entry: handleRefresh
-  // itself dispatches `repository-refresh` to notify other components, and
-  // without the guard that would loop back here forever.
+  // the graph. handleRefresh itself dispatches `repository-refresh` to notify
+  // other components, so we must not loop back into a fresh refresh while one
+  // is in flight. But we also can't simply drop external requests that arrive
+  // mid-refresh (the user-visible state would lag a commit behind), so we
+  // remember the pending request and re-run after the current refresh ends.
   private internalRefreshActive = false;
+  private pendingExternalRefresh = false;
   private handleWindowRefresh = (): void => {
-    if (this.internalRefreshActive) return;
+    if (this.internalRefreshActive) {
+      this.pendingExternalRefresh = true;
+      return;
+    }
     this.handleRefresh();
   };
 
@@ -1709,6 +1715,12 @@ export class AppShell extends LitElement {
       window.dispatchEvent(new CustomEvent('repository-refresh'));
     } finally {
       this.internalRefreshActive = false;
+    }
+    // If an external refresh request landed while we were awaiting above,
+    // honour it now so the UI doesn't lag behind the latest state change.
+    if (this.pendingExternalRefresh) {
+      this.pendingExternalRefresh = false;
+      this.handleRefresh();
     }
   }
 

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -632,9 +632,15 @@ export class AppShell extends LitElement {
     e.preventDefault();
   };
 
-  // Handle repository-refresh events from window (e.g., after commit)
+  // Handle repository-refresh events from window (e.g., after commit).
+  // External callers expect a full refresh (store + graph + indexes), not just
+  // the graph. The internalRefreshActive guard prevents re-entry: handleRefresh
+  // itself dispatches `repository-refresh` to notify other components, and
+  // without the guard that would loop back here forever.
+  private internalRefreshActive = false;
   private handleWindowRefresh = (): void => {
-    this.graphCanvas?.refresh?.();
+    if (this.internalRefreshActive) return;
+    this.handleRefresh();
   };
 
   // Handle refs-changed from file watcher (debounced)
@@ -1680,24 +1686,30 @@ export class AppShell extends LitElement {
   }
 
   private async handleRefresh(): Promise<void> {
-    // Refresh the repository state (e.g., after cherry-pick, merge, rebase)
-    if (this.activeRepository) {
-      const result = await gitService.openRepository({ path: this.activeRepository.repository.path });
-      if (result.success && result.data) {
-        repositoryStore.getState().updateActiveRepository(result.data);
-      } else if (!result.success) {
-        showToast(result.error?.message ?? 'Failed to refresh repository', 'error');
+    // Re-entrancy guard: the dispatch below also wakes handleWindowRefresh.
+    this.internalRefreshActive = true;
+    try {
+      // Refresh the repository state (e.g., after cherry-pick, merge, rebase)
+      if (this.activeRepository) {
+        const result = await gitService.openRepository({ path: this.activeRepository.repository.path });
+        if (result.success && result.data) {
+          repositoryStore.getState().updateActiveRepository(result.data);
+        } else if (!result.success) {
+          showToast(result.error?.message ?? 'Failed to refresh repository', 'error');
+        }
       }
+      // Trigger refresh of the graph
+      this.graphCanvas?.refresh?.();
+      // Refresh search indexes incrementally
+      if (this.activeRepository) {
+        searchIndexService.refresh(this.activeRepository.repository.path);
+        embeddingIndexService.refreshIndex(this.activeRepository.repository.path);
+      }
+      // Dispatch event for other components (like context dashboard) to update
+      window.dispatchEvent(new CustomEvent('repository-refresh'));
+    } finally {
+      this.internalRefreshActive = false;
     }
-    // Trigger refresh of the graph
-    this.graphCanvas?.refresh?.();
-    // Refresh search indexes incrementally
-    if (this.activeRepository) {
-      searchIndexService.refresh(this.activeRepository.repository.path);
-      embeddingIndexService.refreshIndex(this.activeRepository.repository.path);
-    }
-    // Dispatch event for other components (like context dashboard) to update
-    window.dispatchEvent(new CustomEvent('repository-refresh'));
   }
 
   private async handleRefreshAccount(e: CustomEvent<{ accountId: string }>): Promise<void> {
@@ -2516,6 +2528,7 @@ export class AppShell extends LitElement {
                             .commitFile=${this.diffCommitFile}
                             .hasPartialStaging=${this.diffFilePartiallyStaged}
                             @file-edited=${() => this.handleRefresh()}
+                            @status-changed=${() => this.handleRefresh()}
                           ></lv-diff-view>
                         </div>
                       </div>

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -634,18 +634,14 @@ export class AppShell extends LitElement {
 
   // Handle repository-refresh events from window (e.g., after commit).
   // External callers expect a full refresh (store + graph + indexes), not just
-  // the graph. handleRefresh itself dispatches `repository-refresh` to notify
-  // other components, so we must not loop back into a fresh refresh while one
-  // is in flight. But we also can't simply drop external requests that arrive
-  // mid-refresh (the user-visible state would lag a commit behind), so we
-  // remember the pending request and re-run after the current refresh ends.
-  private internalRefreshActive = false;
-  private pendingExternalRefresh = false;
-  private handleWindowRefresh = (): void => {
-    if (this.internalRefreshActive) {
-      this.pendingExternalRefresh = true;
-      return;
-    }
+  // the graph. handleRefresh itself dispatches a `repository-refresh` window
+  // event tagged with `detail.source = 'app-shell'` to notify external
+  // listeners (context dashboard, etc.); we MUST ignore those tagged events
+  // here, otherwise dispatching it from inside handleRefresh would re-trigger
+  // handleWindowRefresh in an unbounded loop.
+  private handleWindowRefresh = (e: Event): void => {
+    const detail = (e as CustomEvent).detail as { source?: string } | undefined;
+    if (detail?.source === 'app-shell') return;
     this.handleRefresh();
   };
 
@@ -1691,9 +1687,19 @@ export class AppShell extends LitElement {
     window.dispatchEvent(new CustomEvent('unstage-all'));
   }
 
+  // Re-entrancy state for handleRefresh. Multiple callers (file-watcher,
+  // @file-edited, @status-changed, child @repository-refresh) can call
+  // handleRefresh concurrently; coalesce them into one follow-up pass so the
+  // final state always reflects the most recent request.
+  private refreshInFlight = false;
+  private refreshQueued = false;
+
   private async handleRefresh(): Promise<void> {
-    // Re-entrancy guard: the dispatch below also wakes handleWindowRefresh.
-    this.internalRefreshActive = true;
+    if (this.refreshInFlight) {
+      this.refreshQueued = true;
+      return;
+    }
+    this.refreshInFlight = true;
     try {
       // Refresh the repository state (e.g., after cherry-pick, merge, rebase)
       if (this.activeRepository) {
@@ -1711,16 +1717,20 @@ export class AppShell extends LitElement {
         searchIndexService.refresh(this.activeRepository.repository.path);
         embeddingIndexService.refreshIndex(this.activeRepository.repository.path);
       }
-      // Dispatch event for other components (like context dashboard) to update
-      window.dispatchEvent(new CustomEvent('repository-refresh'));
+      // Dispatch event for OTHER listeners (context dashboard, etc.). The
+      // `source: 'app-shell'` tag lets handleWindowRefresh ignore our own
+      // emission so we don't loop back into a fresh handleRefresh.
+      window.dispatchEvent(
+        new CustomEvent('repository-refresh', { detail: { source: 'app-shell' } }),
+      );
     } finally {
-      this.internalRefreshActive = false;
+      this.refreshInFlight = false;
     }
-    // If an external refresh request landed while we were awaiting above,
-    // honour it now so the UI doesn't lag behind the latest state change.
-    if (this.pendingExternalRefresh) {
-      this.pendingExternalRefresh = false;
-      this.handleRefresh();
+    // If a refresh request landed while we were awaiting above, run one more
+    // pass and AWAIT it so callers awaiting handleRefresh see the final state.
+    if (this.refreshQueued) {
+      this.refreshQueued = false;
+      await this.handleRefresh();
     }
   }
 

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -8,6 +8,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
+import { showToast } from '../../services/notification.service.ts';
 import type { ReflogEntry } from '../../types/git.types.ts';
 
 interface ReflogContextMenuState {
@@ -345,9 +346,15 @@ export class LvReflogDialog extends LitElement {
       const result = await gitService.getReflog(this.repositoryPath, 50);
       if (result.success && result.data) {
         this.entries = result.data;
+      } else if (!result.success) {
+        showToast(`Failed to load reflog: ${result.error?.message ?? 'Unknown error'}`, 'error');
       }
     } catch (err) {
       console.error('Failed to load reflog:', err);
+      showToast(
+        `Failed to load reflog: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        'error',
+      );
     } finally {
       this.loading = false;
     }
@@ -408,10 +415,14 @@ export class LvReflogDialog extends LitElement {
         }));
         this.close();
       } else {
-        console.error('Reset failed:', result.error);
+        showToast(`Reset failed: ${result.error?.message ?? 'Unknown error'}`, 'error');
       }
     } catch (err) {
       console.error('Reset failed:', err);
+      showToast(
+        `Reset failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        'error',
+      );
     } finally {
       this.resetting = false;
     }

--- a/src/components/dialogs/lv-remote-dialog.ts
+++ b/src/components/dialogs/lv-remote-dialog.ts
@@ -634,6 +634,11 @@ export class LvRemoteDialog extends LitElement {
 
     if (!confirmed) return;
 
+    // Clear any inline error left over from a previous form action (add /
+    // edit / rename) — the template still renders this.error and a stale
+    // banner would persist across the toast-based remove flow otherwise.
+    this.error = null;
+
     try {
       const result = await gitService.removeRemote(this.repositoryPath, remote.name);
 

--- a/src/components/dialogs/lv-remote-dialog.ts
+++ b/src/components/dialogs/lv-remote-dialog.ts
@@ -640,11 +640,20 @@ export class LvRemoteDialog extends LitElement {
       if (result.success) {
         await this.loadRemotes();
         this.dispatchEvent(new CustomEvent('remotes-changed', { bubbles: true, composed: true }));
+        showToast(`Removed remote ${remote.name}`, 'success');
       } else {
-        this.error = result.error?.message ?? 'Failed to remove remote';
+        // Match the toast pattern used by sibling list-row actions
+        // (handleFetchRemote, handlePruneRemote).
+        showToast(
+          `Failed to remove remote: ${result.error?.message ?? 'Unknown error'}`,
+          'error',
+        );
       }
     } catch (err) {
-      this.error = err instanceof Error ? err.message : 'Unknown error';
+      showToast(
+        `Failed to remove remote: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        'error',
+      );
     }
   }
 

--- a/src/components/dialogs/lv-settings-dialog.ts
+++ b/src/components/dialogs/lv-settings-dialog.ts
@@ -9,6 +9,7 @@ import * as localAiService from '../../services/local-ai.service.ts';
 import * as mcpService from '../../services/mcp.service.ts';
 import * as gitService from '../../services/git.service.ts';
 import type { MergeToolInfo, AvailableDiffTool } from '../../services/git.service.ts';
+import { showToast } from '../../services/notification.service.ts';
 import { repositoryStore } from '../../stores/repository.store.ts';
 import type { AiProviderInfo, AiProviderType } from '../../services/ai.service.ts';
 import type { SystemCapabilities, ModelEntry, DownloadedModel, DownloadProgress, LocalModelStatus } from '../../services/local-ai.service.ts';
@@ -582,6 +583,10 @@ export class LvSettingsDialog extends LitElement {
       }
     } catch (err) {
       console.error('Failed to load external tools config:', err);
+      showToast(
+        `Failed to load external tools config: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        'error',
+      );
     } finally {
       this.loadingTools = false;
     }

--- a/src/stores/repository.store.ts
+++ b/src/stores/repository.store.ts
@@ -149,8 +149,14 @@ export const repositoryStore = createStore<RepositoryState>()(
 
           if (newRepos.length === 0) {
             newActiveIndex = -1;
-          } else if (state.activeIndex >= index) {
-            newActiveIndex = Math.max(0, state.activeIndex - 1);
+          } else if (state.activeIndex === index) {
+            // The active tab was closed. Prefer the tab that "shifted in" from
+            // the right (matches browser/VS Code behaviour); fall back to the
+            // tab on the left when the closed tab was the last one.
+            newActiveIndex = Math.min(state.activeIndex, newRepos.length - 1);
+          } else if (state.activeIndex > index) {
+            // A tab to the left of active was closed; everything shifts down.
+            newActiveIndex = state.activeIndex - 1;
           }
 
           return {


### PR DESCRIPTION
Security:
- oauth.rs: stop logging raw token-exchange response (would leak access_token / refresh_token to logs)
- repository.rs: validate clone URL scheme + reject leading '-'; pass URL/dest after '--' to defend against `git clone --upload-pack=...` style flag injection
- bundle.rs: reject_flag_like + '--' separator on bundle paths; skip bundle-supplied refnames starting with '-'
- sparse_checkout.rs: '--' separator before user-supplied patterns
- merge.rs: preview_rebase rejects refs starting with '-' and uses '--' before <onto>
- custom_actions.rs: shell-quote $REPO/$BRANCH substitutions for sh -c / cmd /C; branch names with metacharacters (`;rm -rf ~;#) can no longer break out
- credentials.rs / credentials_service.rs: pipe keychain password to `security` via stdin instead of argv (closes ps -E leak window)

Correctness:
- remote.rs: wrap fetch and pull git2 work in spawn_blocking so blocking network I/O does not starve the Tokio runtime; ensure cleanup_state runs if write_tree/commit fails after a normal merge
- merge.rs: same cleanup_state-on-error wrapper around the merge() command's commit step
- staging.rs: stage_hunk and unstage_hunk now share apply_patch_to_index() using NamedTempFile; eliminates pid-named temp file collision when invoked concurrently
- app-shell.ts: handleWindowRefresh now performs a full handleRefresh (store + graph + indexes), guarded against re-entry by internalRefreshActive
- repository.store.ts: closing the active tab now selects the next tab (right) instead of previous, matching browser/IDE conventions

Quality (CLAUDE.md compliance):
- app-shell.ts: add @status-changed listener on lv-diff-view (event was previously orphaned)
- lv-reflog-dialog.ts: surface load/reset failures via toast instead of console-only
- lv-remote-dialog.ts: handleRemove now uses showToast like its sibling list-row actions
- lv-settings-dialog.ts: surface external-tools load failure via toast

Verified: cargo check + clippy -D warnings clean; npm typecheck + lint clean;
1644 cargo unit tests pass (9 pre-existing env-dependent failures unchanged);
3028 web-test-runner unit tests pass.

https://claude.ai/code/session_01PrY1eEk65d1LL43Vw4bGxF