### PR TITLE
deps(npm): bump playwright + playwright-core to 1.59.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@web/test-runner-playwright": "^0.11.0",
         "eslint": "^10.2.1",
         "globals": "^17.5.0",
-        "playwright-core": "1.58.2",
+        "playwright-core": "1.59.1",
         "prettier": "^3.8.3",
         "sharp": "^0.34.5",
         "typescript": "^5.3.0",
@@ -6830,13 +6830,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6849,9 +6849,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@web/test-runner-playwright": "^0.11.0",
     "eslint": "^10.2.1",
     "globals": "^17.5.0",
-    "playwright-core": "1.58.2",
+    "playwright-core": "1.59.1",
     "prettier": "^3.8.3",
     "sharp": "^0.34.5",
     "typescript": "^5.3.0",
@@ -53,8 +53,8 @@
     "vite": "^8.0.10"
   },
   "overrides": {
-    "playwright": "1.58.2",
-    "playwright-core": "1.58.2",
+    "playwright": "1.59.1",
+    "playwright-core": "1.59.1",
     "koa": ">=2.16.4"
   }
 }


### PR DESCRIPTION
Supersedes #156. The original PR bumped only \`playwright-core\` (devDep + override) but not the \`playwright\` override, leaving them mismatched. CI failed at \`npx playwright install --with-deps chromium\` with:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'object')
    at .../node_modules/playwright/lib/common/validators.js:26
\`\`\`

The 1.59 CLI expects 1.59 internals; pairing it with 1.58 internals via the override blew up the bundled zod re-export.

This PR bumps both \`playwright\` and \`playwright-core\` (plus matching \`overrides\` entries) to 1.59.1 in lockstep.

Closes #156