### PR TITLE
deps(cargo): bump chardetng from 0.1 to 1.0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -608,9 +608,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chardetng"
-version = "0.1.17"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+checksum = "13de944a44b5064ee5d3a5ceccc49a41bfec50f2580e66f82e87703acdb88b53"
 dependencies = [
  "cfg-if",
  "encoding_rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,7 +39,7 @@ urlencoding = "2.1.3"
 uuid = { version = "1.23.0", features = ["v4"] }
 glob = "0.3"
 once_cell = "1"
-chardetng = "0.1"
+chardetng = "1.0"
 encoding_rs = "0.8"
 
 # Archive support

--- a/src-tauri/src/commands/encoding.rs
+++ b/src-tauri/src/commands/encoding.rs
@@ -177,13 +177,14 @@ fn detect_encoding_heuristic(data: &[u8]) -> (String, f64) {
     }
 
     // Not valid UTF-8, try to detect other encodings
-    // Use chardetng for encoding detection
-    let mut detector = chardetng::EncodingDetector::new();
+    // Use chardetng for encoding detection. chardetng 1.0 dropped the
+    // reliability signal that `guess_assess` used to return, so we report a
+    // single mid-confidence value.
+    let mut detector = chardetng::EncodingDetector::new(chardetng::Iso2022JpDetection::Allow);
     detector.feed(content_to_check, true);
-    let (encoding, is_reliable) = detector.guess_assess(None, true);
+    let encoding = detector.guess(None, chardetng::Utf8Detection::Allow);
 
-    let confidence = if is_reliable { 0.9 } else { 0.5 };
-    (encoding.name().to_string().to_uppercase(), confidence)
+    (encoding.name().to_string().to_uppercase(), 0.7)
 }
 
 /// Detect the encoding of a file


### PR DESCRIPTION
Supersedes #162. The 1.0 release changed two APIs that we use in \`commands/encoding.rs::detect_encoding\`:

- \`EncodingDetector::new()\` now requires an \`Iso2022JpDetection\` argument.
  We pass \`Allow\` since this runs on local source-file bytes, not
  untrusted web content.
- \`guess_assess(...) -> (&Encoding, bool)\` was replaced by
  \`guess(...) -> &Encoding\`. The reliability flag is gone, so the
  \`is_reliable ? 0.9 : 0.5\` split collapses to a single 0.7
  mid-confidence value when chardetng is consulted.

Verified locally: \`cargo check\` and \`cargo clippy -- -D warnings\` both clean.

Closes #162