### PR TITLE
deps(npm): bump typescript from 5.x to 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "playwright-core": "1.59.1",
         "prettier": "^3.8.3",
         "sharp": "^0.34.5",
-        "typescript": "^5.3.0",
+        "typescript": "^6.0.0",
         "typescript-eslint": "^8.59.0",
         "vite": "^8.0.10"
       }
@@ -8038,9 +8038,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "playwright-core": "1.59.1",
     "prettier": "^3.8.3",
     "sharp": "^0.34.5",
-    "typescript": "^5.3.0",
+    "typescript": "^6.0.0",
     "typescript-eslint": "^8.59.0",
     "vite": "^8.0.10"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,17 +17,7 @@
     "experimentalDecorators": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"],
-      "@components/*": ["src/components/*"],
-      "@stores/*": ["src/stores/*"],
-      "@services/*": ["src/services/*"],
-      "@types/*": ["src/types/*"],
-      "@utils/*": ["src/utils/*"],
-      "@styles/*": ["src/styles/*"]
-    }
+    "sourceMap": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "src-tauri"]


### PR DESCRIPTION
Supersedes #171. The dependabot bump itself was just a version pin; what blocked it was a single TS6 deprecation:

\`\`\`
tsconfig.json(21,5): error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
\`\`\`

Every other failing check in #171 cascaded from this — the \`Build frontend\` step exits 2, so \`Lint Backend\`, \`Test Backend\`, and the three platform builds all failed because \`dist/\` was missing.

## Fix

Removed \`baseUrl\` and the \`paths\` block from \`tsconfig.json\`. Grepping the codebase for \`from '@/\` or \`from '@components/\` etc. returns zero hits — the seven path aliases are unused, so the entire block is dead config. Dropping it resolves the deprecation without needing \`ignoreDeprecations\`.

Verified: \`tsc --noEmit\`, \`npm run lint\`, and \`npm run build\` all clean under typescript 6.0.3.

Closes #171