### PR TITLE
fix(profiles): make attaching/detaching integration accounts work

### DIFF
--- a/e2e/pages/dialogs.page.ts
+++ b/e2e/pages/dialogs.page.ts
@@ -199,6 +199,10 @@ export class ProfileManagerDialogPage extends BaseDialog {
   readonly setDefaultButton: Locator;
   readonly accountsSection: Locator;
   readonly addAccountButton: Locator;
+  readonly integrationAccountsSection: Locator;
+  readonly attachAccountButton: Locator;
+  readonly attachedAccountItems: Locator;
+  readonly pickerAccountRows: Locator;
 
   constructor(page: Page) {
     super(page, 'lv-profile-manager-dialog');
@@ -226,6 +230,18 @@ export class ProfileManagerDialogPage extends BaseDialog {
     this.setDefaultButton = page.getByRole('button', { name: /set as default|make default/i });
     this.accountsSection = page.locator('.accounts-section, [data-section="accounts"]');
     this.addAccountButton = page.getByRole('button', { name: /add account/i });
+    // The "Integration Accounts" section of the profile edit form (distinct from
+    // the "Assigned Repositories" section, which shares the .accounts-section class).
+    this.integrationAccountsSection = page
+      .locator('lv-profile-manager-dialog .accounts-section')
+      .filter({ hasText: 'Integration Accounts' });
+    this.attachAccountButton = this.integrationAccountsSection.getByRole('button', {
+      name: 'Add',
+      exact: true,
+    });
+    this.attachedAccountItems = this.integrationAccountsSection.locator('.account-item');
+    // Selectable rows shown in the account picker (select-account view).
+    this.pickerAccountRows = page.locator('lv-profile-manager-dialog .account-item.selectable');
   }
 
   async getProfileCount(): Promise<number> {

--- a/e2e/tests/profiles-integrations.spec.ts
+++ b/e2e/tests/profiles-integrations.spec.ts
@@ -237,6 +237,300 @@ test.describe('Profile Manager Dialog - With Existing Profiles', () => {
 });
 
 // ============================================================================
+// Integration Accounts on Profiles (attach / detach)
+// ============================================================================
+
+test.describe('Profile Manager Dialog - Integration Accounts', () => {
+  let dialogs: DialogsPage;
+
+  test.beforeEach(async ({ page }) => {
+    dialogs = new DialogsPage(page);
+
+    await setupProfilesAndAccounts(page, {
+      profiles: [testProfiles.work, testProfiles.personal],
+      accounts: [testAccounts.githubWork, testAccounts.githubPersonal, testAccounts.gitlab],
+    });
+
+    await injectCommandMock(page, {
+      get_unified_profiles_config: {
+        version: 3,
+        profiles: [testProfiles.work, testProfiles.personal],
+        accounts: [testAccounts.githubWork, testAccounts.githubPersonal, testAccounts.gitlab],
+        repositoryAssignments: {},
+      },
+      get_migration_backup_info: { hasBackup: false },
+    });
+  });
+
+  async function openProfileManager(page: Page): Promise<void> {
+    await dialogs.commandPalette.open();
+    await dialogs.commandPalette.search('Git Profiles');
+    await dialogs.commandPalette.executeFirst();
+    await expect(page.getByRole('button', { name: 'New Profile' })).toBeVisible();
+  }
+
+  test('edit profile lists only the accounts attached to it', async ({ page }) => {
+    await openProfileManager(page);
+
+    // Work profile has github: account-github-work attached
+    await page.locator('.profile-item').first().click();
+    await expect(page.getByRole('button', { name: 'Save Profile' })).toBeVisible();
+
+    await expect(dialogs.profileManager.attachedAccountItems).toHaveCount(1);
+    await expect(dialogs.profileManager.attachedAccountItems.first()).toContainText('Work GitHub');
+  });
+
+  test('attach an existing account to a profile and persist on save', async ({ page }) => {
+    await openProfileManager(page);
+
+    // Personal profile has no attached accounts
+    await page.locator('.profile-item').nth(1).click();
+    await expect(dialogs.profileManager.attachedAccountItems).toHaveCount(0);
+
+    await dialogs.profileManager.attachAccountButton.click();
+    await expect(page.locator('lv-profile-manager-dialog .dialog-title')).toContainText(
+      'Attach Account'
+    );
+
+    // Pick the Personal GitHub account from the picker
+    await dialogs.profileManager.pickerAccountRows.filter({ hasText: 'Personal GitHub' }).click();
+
+    // Back on the edit form, the account is now attached
+    await expect(dialogs.profileManager.attachedAccountItems).toHaveCount(1);
+    await expect(dialogs.profileManager.attachedAccountItems.first()).toContainText(
+      'Personal GitHub'
+    );
+
+    await startCommandCaptureWithMocks(page, {
+      save_unified_profile: {
+        ...testProfiles.personal,
+        defaultAccounts: { github: 'account-github-personal' },
+      },
+    });
+
+    await page.getByRole('button', { name: 'Save Profile' }).click();
+    await waitForCommand(page, 'save_unified_profile');
+
+    const cmds = await findCommand(page, 'save_unified_profile');
+    const profile = (cmds[0].args as { profile: { defaultAccounts: Record<string, string> } })
+      .profile;
+    expect(profile.defaultAccounts.github).toBe('account-github-personal');
+  });
+
+  test('detach an account removes it from the profile without deleting it globally', async ({
+    page,
+  }) => {
+    await openProfileManager(page);
+
+    // Work profile has one attached account
+    await page.locator('.profile-item').first().click();
+    await expect(dialogs.profileManager.attachedAccountItems).toHaveCount(1);
+
+    await startCommandCaptureWithMocks(page, {
+      save_unified_profile: { ...testProfiles.work, defaultAccounts: {} },
+    });
+
+    // Click the detach (X) button on the attached account
+    await dialogs.profileManager.attachedAccountItems
+      .first()
+      .locator('.account-actions .action-btn.delete')
+      .click();
+    await expect(dialogs.profileManager.attachedAccountItems).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Save Profile' }).click();
+    await waitForCommand(page, 'save_unified_profile');
+
+    const cmds = await findCommand(page, 'save_unified_profile');
+    const profile = (cmds[0].args as { profile: { defaultAccounts: Record<string, string> } })
+      .profile;
+    expect(profile.defaultAccounts.github).toBeUndefined();
+
+    // The key fix: detaching must NOT delete the global account
+    const deletes = await findCommand(page, 'delete_global_account');
+    expect(deletes.length).toBe(0);
+  });
+
+  test('attaching another account of the same provider replaces it', async ({ page }) => {
+    await openProfileManager(page);
+
+    // Work profile has github: account-github-work attached
+    await page.locator('.profile-item').first().click();
+    await expect(dialogs.profileManager.attachedAccountItems.first()).toContainText('Work GitHub');
+
+    await dialogs.profileManager.attachAccountButton.click();
+    await dialogs.profileManager.pickerAccountRows.filter({ hasText: 'Personal GitHub' }).click();
+
+    // Still one github slot, now showing Personal GitHub
+    await expect(dialogs.profileManager.attachedAccountItems).toHaveCount(1);
+    await expect(dialogs.profileManager.attachedAccountItems.first()).toContainText(
+      'Personal GitHub'
+    );
+  });
+
+  test('delete account globally from the account edit screen', async ({ page }) => {
+    await openProfileManager(page);
+
+    await page.locator('.profile-item').first().click();
+    await expect(dialogs.profileManager.attachedAccountItems).toHaveCount(1);
+
+    // Open the attached account's edit screen via the pencil (non-delete) button
+    await dialogs.profileManager.attachedAccountItems
+      .first()
+      .locator('.account-actions .action-btn:not(.delete)')
+      .click();
+    await expect(page.locator('lv-profile-manager-dialog .dialog-title')).toContainText(
+      'Edit Account'
+    );
+
+    await startCommandCaptureWithMocks(page, {
+      delete_global_account: null,
+      'plugin:dialog|message': 'Ok',
+    });
+
+    await page.getByRole('button', { name: 'Delete Account' }).click();
+    await waitForCommand(page, 'delete_global_account');
+
+    const cmds = await findCommand(page, 'delete_global_account');
+    expect(cmds.length).toBeGreaterThan(0);
+
+    // After deletion the dialog returns to the profile editor and the now-deleted
+    // account no longer appears in the attached list.
+    await expect(page.locator('lv-profile-manager-dialog .dialog-title')).toContainText(
+      'Edit Profile'
+    );
+    await expect(dialogs.profileManager.attachedAccountItems).toHaveCount(0);
+  });
+});
+
+test.describe('Profile Manager Dialog - Attach with no accounts', () => {
+  let dialogs: DialogsPage;
+
+  test.beforeEach(async ({ page }) => {
+    dialogs = new DialogsPage(page);
+
+    await setupProfilesAndAccounts(page, {
+      profiles: [testProfiles.personal],
+      accounts: [],
+    });
+
+    await injectCommandMock(page, {
+      get_unified_profiles_config: {
+        version: 3,
+        profiles: [testProfiles.personal],
+        accounts: [],
+        repositoryAssignments: {},
+      },
+      get_migration_backup_info: { hasBackup: false },
+    });
+  });
+
+  test('picker offers connect-new buttons and opens the GitHub dialog', async ({ page }) => {
+    await dialogs.commandPalette.open();
+    await dialogs.commandPalette.search('Git Profiles');
+    await dialogs.commandPalette.executeFirst();
+    await expect(page.getByRole('button', { name: 'New Profile' })).toBeVisible();
+
+    await page.locator('.profile-item').first().click();
+    await dialogs.profileManager.attachAccountButton.click();
+    await expect(page.locator('lv-profile-manager-dialog .dialog-title')).toContainText(
+      'Attach Account'
+    );
+
+    // No existing accounts to pick, but connect-new buttons are present
+    await expect(dialogs.profileManager.pickerAccountRows).toHaveCount(0);
+    const githubBtn = page
+      .locator('lv-profile-manager-dialog')
+      .getByRole('button', { name: 'GitHub', exact: true });
+    await expect(githubBtn).toBeVisible();
+
+    await githubBtn.click();
+
+    // The GitHub dialog opens on top; the profile manager stays mounted underneath
+    // (demoted) so it can be revealed again when the GitHub dialog closes.
+    await expect(dialogs.github.dialog).toBeVisible();
+    await expect(page.locator('lv-profile-manager-dialog[open][demoted]')).toHaveCount(1);
+  });
+
+  test('connecting a new account auto-attaches it to the profile', async ({ page }) => {
+    await dialogs.commandPalette.open();
+    await dialogs.commandPalette.search('Git Profiles');
+    await dialogs.commandPalette.executeFirst();
+    await expect(page.getByRole('button', { name: 'New Profile' })).toBeVisible();
+
+    await page.locator('.profile-item').first().click();
+    await dialogs.profileManager.attachAccountButton.click();
+    await expect(page.locator('lv-profile-manager-dialog .dialog-title')).toContainText(
+      'Attach Account'
+    );
+
+    // Connect a new GitHub account → GitHub dialog opens on top, profile manager
+    // stays mounted underneath (demoted).
+    await page
+      .locator('lv-profile-manager-dialog')
+      .getByRole('button', { name: 'GitHub', exact: true })
+      .click();
+    await expect(dialogs.github.dialog).toBeVisible();
+    await expect(page.locator('lv-profile-manager-dialog[open][demoted]')).toHaveCount(1);
+
+    // Opened from the profile manager → the dialog shows a Back arrow, not a close ×
+    await expect(
+      page.locator('lv-github-dialog').getByRole('button', { name: 'Back' })
+    ).toBeVisible();
+    await expect(
+      page.locator('lv-github-dialog').getByRole('button', { name: 'Close' })
+    ).toHaveCount(0);
+
+    // Simulate the account being connected while in the GitHub dialog: the next
+    // profile reload (on reveal) will include it.
+    const newAccount = {
+      id: 'account-new-gh',
+      name: 'Freshly Connected GitHub',
+      integrationType: 'github' as const,
+      config: { type: 'github' },
+      color: null,
+      cachedUser: null,
+      urlPatterns: [],
+      isDefault: false,
+    };
+    await injectCommandMock(page, {
+      get_unified_profiles_config: {
+        version: 3,
+        profiles: [testProfiles.personal],
+        accounts: [newAccount],
+        repositoryAssignments: {},
+      },
+      get_migration_backup_info: { hasBackup: false },
+    });
+
+    // Going back from the GitHub dialog reveals the profile manager and auto-attaches
+    // the account that was just connected — landing back on the edit form.
+    await page.locator('lv-github-dialog').getByRole('button', { name: 'Back' }).click();
+
+    await expect(page.locator('lv-profile-manager-dialog[open][demoted]')).toHaveCount(0);
+    await expect(page.locator('lv-profile-manager-dialog .dialog-title')).toContainText(
+      'Edit Profile'
+    );
+    await expect(dialogs.profileManager.attachedAccountItems.first()).toContainText(
+      'Freshly Connected GitHub'
+    );
+
+    // And saving persists it to the profile
+    await startCommandCaptureWithMocks(page, {
+      save_unified_profile: {
+        ...testProfiles.personal,
+        defaultAccounts: { github: 'account-new-gh' },
+      },
+    });
+    await page.getByRole('button', { name: 'Save Profile' }).click();
+    await waitForCommand(page, 'save_unified_profile');
+    const cmds = await findCommand(page, 'save_unified_profile');
+    const profile = (cmds[0].args as { profile: { defaultAccounts: Record<string, string> } })
+      .profile;
+    expect(profile.defaultAccounts.github).toBe('account-new-gh');
+  });
+});
+
+// ============================================================================
 // Global Accounts Management Tests
 // ============================================================================
 

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1352,6 +1352,13 @@ export class AppShell extends LitElement {
     this.showSettings = true;
   };
 
+  // True while any integration dialog is open. Used to demote the profile manager
+  // behind it (it stays open underneath), so closing the integration dialog reveals
+  // the account picker again exactly where the user left off.
+  private get integrationDialogOpen(): boolean {
+    return this.showGitHub || this.showGitLab || this.showBitbucket || this.showAzureDevOps;
+  }
+
   private handleTriggerAbort = (): void => {
     this.handleAbortOperation();
   };
@@ -2977,6 +2984,7 @@ export class AppShell extends LitElement {
       ${this.activeRepository ? html`
         <lv-github-dialog
           ?open=${this.showGitHub}
+          ?backButton=${this.showProfileManager}
           .repositoryPath=${this.activeRepository.repository.path}
           @close=${() => { this.showGitHub = false; }}
           @manage-accounts=${() => { this.showProfileManager = true; }}
@@ -2986,6 +2994,7 @@ export class AppShell extends LitElement {
       ${this.activeRepository ? html`
         <lv-gitlab-dialog
           ?open=${this.showGitLab}
+          ?backButton=${this.showProfileManager}
           .repositoryPath=${this.activeRepository.repository.path}
           @close=${() => { this.showGitLab = false; }}
           @manage-accounts=${() => { this.showProfileManager = true; }}
@@ -2995,6 +3004,7 @@ export class AppShell extends LitElement {
       ${this.activeRepository ? html`
         <lv-bitbucket-dialog
           ?open=${this.showBitbucket}
+          ?backButton=${this.showProfileManager}
           .repositoryPath=${this.activeRepository.repository.path}
           @close=${() => { this.showBitbucket = false; }}
           @manage-accounts=${() => { this.showProfileManager = true; }}
@@ -3004,6 +3014,7 @@ export class AppShell extends LitElement {
       ${this.activeRepository ? html`
         <lv-azure-devops-dialog
           ?open=${this.showAzureDevOps}
+          ?backButton=${this.showProfileManager}
           .repositoryPath=${this.activeRepository.repository.path}
           @close=${() => { this.showAzureDevOps = false; }}
           @manage-accounts=${() => { this.showProfileManager = true; }}
@@ -3012,12 +3023,13 @@ export class AppShell extends LitElement {
 
       <lv-profile-manager-dialog
         ?open=${this.showProfileManager}
+        ?demoted=${this.integrationDialogOpen}
         .repoPath=${this.activeRepository?.repository.path ?? ''}
         @close=${() => { this.showProfileManager = false; }}
-        @open-github=${() => { this.showProfileManager = false; this.showGitHub = true; }}
-        @open-gitlab=${() => { this.showProfileManager = false; this.showGitLab = true; }}
-        @open-bitbucket=${() => { this.showProfileManager = false; this.showBitbucket = true; }}
-        @open-azure-devops=${() => { this.showProfileManager = false; this.showAzureDevOps = true; }}
+        @open-github=${() => { this.showGitHub = true; }}
+        @open-gitlab=${() => { this.showGitLab = true; }}
+        @open-bitbucket=${() => { this.showBitbucket = true; }}
+        @open-azure-devops=${() => { this.showAzureDevOps = true; }}
       ></lv-profile-manager-dialog>
 
       <lv-migration-dialog

--- a/src/components/dialogs/__tests__/lv-github-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-github-dialog.test.ts
@@ -327,6 +327,38 @@ describe('lv-github-dialog', () => {
       expect(tokenForm !== null || authToggle !== null || oauthSection !== null).to.be.true;
     });
 
+    // Cross-component contract: verifying a connection here must update the SHARED
+    // store status that other views (e.g. the profile manager dots) read.
+    it('writes verified connected status to the shared store', async () => {
+      connectionResponse = mockConnectedStatus;
+      unifiedProfileStore.getState().setAccounts([mockAccount]);
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+      await new Promise((r) => setTimeout(r, 30));
+
+      expect(unifiedProfileStore.getState().accountConnectionStatus['gh-acc-1']?.status).to.equal(
+        'connected'
+      );
+    });
+
+    it('writes disconnected status to the shared store when verification fails', async () => {
+      connectionResponse = mockDisconnectedStatus;
+      unifiedProfileStore.getState().setAccounts([mockAccount]);
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+      await new Promise((r) => setTimeout(r, 30));
+
+      expect(unifiedProfileStore.getState().accountConnectionStatus['gh-acc-1']?.status).to.equal(
+        'disconnected'
+      );
+    });
+
     it('shows user info when connected', async () => {
       connectionResponse = mockConnectedStatus;
 

--- a/src/components/dialogs/__tests__/lv-modal.test.ts
+++ b/src/components/dialogs/__tests__/lv-modal.test.ts
@@ -1,0 +1,40 @@
+/**
+ * lv-modal tests — focuses on the header controls (close × vs. back ←).
+ */
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-modal.ts';
+import type { LvModal } from '../lv-modal.ts';
+
+describe('lv-modal', () => {
+  it('shows a close button by default', async () => {
+    const el = await fixture<LvModal>(html`<lv-modal .open=${true} modalTitle="Test"></lv-modal>`);
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector('button[aria-label="Close"]')).to.not.be.null;
+    expect(el.shadowRoot!.querySelector('button[aria-label="Back"]')).to.be.null;
+  });
+
+  it('shows a back button (and no close) when backButton is set', async () => {
+    const el = await fixture<LvModal>(
+      html`<lv-modal .open=${true} ?backButton=${true} modalTitle="Test"></lv-modal>`
+    );
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector('button[aria-label="Back"]')).to.not.be.null;
+    expect(el.shadowRoot!.querySelector('button[aria-label="Close"]')).to.be.null;
+  });
+
+  it('dispatches close when the back button is clicked', async () => {
+    const el = await fixture<LvModal>(
+      html`<lv-modal .open=${true} ?backButton=${true} modalTitle="Test"></lv-modal>`
+    );
+    await el.updateComplete;
+
+    let closed = false;
+    el.addEventListener('close', () => {
+      closed = true;
+    });
+    (el.shadowRoot!.querySelector('button[aria-label="Back"]') as HTMLButtonElement).click();
+    expect(closed).to.be.true;
+  });
+});

--- a/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
@@ -783,7 +783,7 @@ describe('lv-profile-manager-dialog', () => {
     it('lists only the accounts attached to the profile', async () => {
       const el = await renderDialog();
       const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
-      // Personal profile has defaultAccounts { github: 'account-2' } → one attached account
+      // Personal profile has defaultAccounts { gitlab: 'account-2' } → one attached account
       (profileItems[1] as HTMLElement).click();
       await el.updateComplete;
 

--- a/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
@@ -71,7 +71,7 @@ const personalProfile = makeProfile({
   isDefault: true,
   color: PROFILE_COLORS[1],
   urlPatterns: ['github.com/personal/*'],
-  defaultAccounts: { github: 'account-2' },
+  defaultAccounts: { gitlab: 'account-2' },
 });
 
 const githubAccount = makeAccount();
@@ -142,6 +142,29 @@ function setupStoreState(): void {
   const repoStore = repositoryStore.getState();
   repoStore.addRecentRepository('/repo/work', 'work');
   repoStore.addRecentRepository('/repo/personal', 'personal');
+}
+
+// Override both the Tauri mock and the store so a custom config survives the
+// component's initial loadProfiles() call (which reloads via get_unified_profiles_config).
+function useConfig(profiles: UnifiedProfile[], accounts: IntegrationAccount[]): void {
+  mockInvoke = async (command: string, args?: unknown) => {
+    switch (command) {
+      case 'get_unified_profiles_config':
+        return { version: 3, profiles, accounts, repositoryAssignments: {} };
+      case 'get_migration_backup_info':
+        return { hasBackup: false, backupDate: null, profilesCount: null, accountsCount: null };
+      case 'save_unified_profile':
+        // Echo back the submitted profile so the store reflects what was saved.
+        return (args as { profile?: UnifiedProfile } | undefined)?.profile ?? profiles[0] ?? null;
+      case 'delete_global_account':
+        return null;
+      case 'plugin:dialog|message':
+        return 'Ok';
+      default:
+        return null;
+    }
+  };
+  unifiedProfileStore.getState().setConfig({ version: 3, profiles, accounts, repositoryAssignments: {} });
 }
 
 async function renderDialog(props: { open?: boolean; repoPath?: string } = {}): Promise<LvProfileManagerDialog> {
@@ -757,70 +780,563 @@ describe('lv-profile-manager-dialog', () => {
       expect(accountsTitle).to.not.be.undefined;
     });
 
-    it('lists global accounts in the accounts section', async () => {
+    it('lists only the accounts attached to the profile', async () => {
       const el = await renderDialog();
       const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
-      (profileItems[0] as HTMLElement).click();
+      // Personal profile has defaultAccounts { github: 'account-2' } → one attached account
+      (profileItems[1] as HTMLElement).click();
       await el.updateComplete;
 
-      const accountItems = el.shadowRoot!.querySelectorAll('.account-item');
-      expect(accountItems.length).to.be.greaterThanOrEqual(2);
+      const accountsSection = el.shadowRoot!.querySelector('.accounts-section');
+      const accountItems = accountsSection!.querySelectorAll('.account-item');
+      expect(accountItems.length).to.equal(1);
+      expect(accountItems[0].textContent).to.include('Personal GitLab');
     });
 
-    it('shows account name and type badge for each account', async () => {
+    it('shows the attached account name and type badge', async () => {
       const el = await renderDialog();
       const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
-      (profileItems[0] as HTMLElement).click();
+      (profileItems[1] as HTMLElement).click();
       await el.updateComplete;
 
-      const accountNames = el.shadowRoot!.querySelectorAll('.account-name');
+      const accountsSection = el.shadowRoot!.querySelector('.accounts-section');
+      const accountNames = accountsSection!.querySelectorAll('.account-name');
       const nameTexts = Array.from(accountNames).map((n) => n.textContent?.trim());
-      expect(nameTexts.some((t) => t?.includes('Work GitHub'))).to.be.true;
       expect(nameTexts.some((t) => t?.includes('Personal GitLab'))).to.be.true;
+      // Work GitHub is NOT attached to the Personal profile
+      expect(nameTexts.some((t) => t?.includes('Work GitHub'))).to.be.false;
 
-      const typeBadges = el.shadowRoot!.querySelectorAll('.type-badge');
-      expect(typeBadges.length).to.be.greaterThanOrEqual(2);
+      const typeBadges = accountsSection!.querySelectorAll('.type-badge');
+      expect(typeBadges.length).to.equal(1);
     });
 
-    it('shows empty accounts warning when no accounts exist', async () => {
-      // Override mock to return config with no accounts
+    it('shows empty state when no accounts are attached to the profile', async () => {
+      const el = await renderDialog();
+      const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
+      // Work profile has empty defaultAccounts
+      (profileItems[0] as HTMLElement).click();
+      await el.updateComplete;
+
+      const accountsSection = el.shadowRoot!.querySelector('.accounts-section');
+      const empty = accountsSection!.querySelector('.empty-accounts');
+      expect(empty).to.not.be.null;
+      expect(empty!.textContent).to.include('No accounts attached to this profile');
+      expect(accountsSection!.querySelectorAll('.account-item').length).to.equal(0);
+    });
+
+    it('ignores dangling account ids whose global account no longer exists', async () => {
+      const danglingProfile = makeProfile({
+        id: 'profile-dangling',
+        name: 'Dangling',
+        defaultAccounts: { github: 'does-not-exist' },
+      });
+      useConfig([danglingProfile], testAccounts);
+
+      const el = await renderDialog();
+      const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
+      (profileItems[0] as HTMLElement).click();
+      await el.updateComplete;
+
+      const accountsSection = el.shadowRoot!.querySelector('.accounts-section');
+      expect(accountsSection!.querySelectorAll('.account-item').length).to.equal(0);
+      expect(accountsSection!.querySelector('.empty-accounts')).to.not.be.null;
+    });
+  });
+
+  // ── Attaching/detaching accounts ───────────────────────────────────────
+  describe('attaching and detaching accounts', () => {
+    function getAddButton(el: LvProfileManagerDialog): HTMLButtonElement {
+      const section = el.shadowRoot!.querySelector('.accounts-section')!;
+      return Array.from(section.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Add'
+      ) as HTMLButtonElement;
+    }
+
+    it('opens the account picker when Add is clicked', async () => {
+      const el = await renderDialog();
+      const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
+      (profileItems[0] as HTMLElement).click();
+      await el.updateComplete;
+
+      getAddButton(el).click();
+      await el.updateComplete;
+
+      const title = el.shadowRoot!.querySelector('.dialog-title');
+      expect(title!.textContent).to.include('Attach Account');
+      // Picker lists the existing global accounts as selectable rows
+      const selectable = el.shadowRoot!.querySelectorAll('.account-item.selectable');
+      expect(selectable.length).to.equal(2);
+    });
+
+    it('attaches a selected account and returns to the form without a Tauri call', async () => {
+      const el = await renderDialog();
+      const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
+      (profileItems[0] as HTMLElement).click(); // Work profile, no attached accounts
+      await el.updateComplete;
+
+      getAddButton(el).click();
+      await el.updateComplete;
+
+      clearHistory();
+      // Click the Work GitHub row
+      const rows = el.shadowRoot!.querySelectorAll('.account-item.selectable');
+      const githubRow = Array.from(rows).find((r) => r.textContent?.includes('Work GitHub'));
+      (githubRow as HTMLElement).click();
+      await el.updateComplete;
+
+      // Back on the edit form with the account now attached
+      const title = el.shadowRoot!.querySelector('.dialog-title');
+      expect(title!.textContent).to.include('Edit Profile');
+      const accountsSection = el.shadowRoot!.querySelector('.accounts-section');
+      const accountItems = accountsSection!.querySelectorAll('.account-item');
+      expect(accountItems.length).to.equal(1);
+      expect(accountItems[0].textContent).to.include('Work GitHub');
+
+      // Attach is local-only until Save - no association command should fire
+      expect(findCommands('set_profile_default_account').length).to.equal(0);
+    });
+
+    it('replaces the existing account of the same provider when attaching another', async () => {
+      const ghA = makeAccount({ id: 'gh-a', name: 'GitHub A', integrationType: 'github' });
+      const ghB = makeAccount({ id: 'gh-b', name: 'GitHub B', integrationType: 'github' });
+      const profile = makeProfile({ id: 'p', name: 'P', defaultAccounts: { github: 'gh-a' } });
+      useConfig([profile], [ghA, ghB]);
+
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+
+      getAddButton(el).click();
+      await el.updateComplete;
+
+      const rows = el.shadowRoot!.querySelectorAll('.account-item.selectable');
+      const rowB = Array.from(rows).find((r) => r.textContent?.includes('GitHub B'));
+      (rowB as HTMLElement).click();
+      await el.updateComplete;
+
+      const accountsSection = el.shadowRoot!.querySelector('.accounts-section');
+      const accountItems = accountsSection!.querySelectorAll('.account-item');
+      // Still one github slot, now showing GitHub B
+      expect(accountItems.length).to.equal(1);
+      expect(accountItems[0].textContent).to.include('GitHub B');
+      expect(accountItems[0].textContent).to.not.include('GitHub A');
+    });
+
+    it('detaches an account without deleting it globally', async () => {
+      const el = await renderDialog();
+      const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
+      (profileItems[1] as HTMLElement).click(); // Personal, one attached account
+      await el.updateComplete;
+
+      clearHistory();
+      const detachBtn = el.shadowRoot!.querySelector(
+        '.accounts-section .account-actions .action-btn.delete'
+      ) as HTMLButtonElement;
+      detachBtn.click();
+      await el.updateComplete;
+
+      const accountsSection = el.shadowRoot!.querySelector('.accounts-section');
+      expect(accountsSection!.querySelectorAll('.account-item').length).to.equal(0);
+      expect(accountsSection!.querySelector('.empty-accounts')).to.not.be.null;
+
+      // Detach is local-only - no global delete and no association command
+      expect(findCommands('delete_global_account').length).to.equal(0);
+      expect(findCommands('remove_profile_default_account').length).to.equal(0);
+    });
+
+    it('persists an attached account on Save Profile', async () => {
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click(); // Work
+      await el.updateComplete;
+
+      getAddButton(el).click();
+      await el.updateComplete;
+      const rows = el.shadowRoot!.querySelectorAll('.account-item.selectable');
+      const githubRow = Array.from(rows).find((r) => r.textContent?.includes('Work GitHub'));
+      (githubRow as HTMLElement).click();
+      await el.updateComplete;
+
+      clearHistory();
+      const saveBtn = Array.from(
+        el.shadowRoot!.querySelectorAll('.dialog-footer .btn-primary')
+      ).find((b) => b.textContent?.trim().includes('Save Profile')) as HTMLButtonElement;
+      saveBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      const saveCalls = findCommands('save_unified_profile');
+      expect(saveCalls.length).to.equal(1);
+      const saved = (saveCalls[0].args as { profile: UnifiedProfile }).profile;
+      expect(saved.defaultAccounts.github).to.equal('account-1');
+    });
+
+    it('persists an attached account when creating a new profile', async () => {
+      const el = await renderDialog();
+      const newProfileBtn = Array.from(
+        el.shadowRoot!.querySelectorAll('.dialog-footer .btn-primary')
+      ).find((b) => b.textContent?.trim().includes('New Profile')) as HTMLButtonElement;
+      newProfileBtn.click();
+      await el.updateComplete;
+
+      const inputs = el.shadowRoot!.querySelectorAll(
+        '.form-group input'
+      ) as NodeListOf<HTMLInputElement>;
+      inputs[0].value = 'Created';
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }));
+      inputs[1].value = 'Created User';
+      inputs[1].dispatchEvent(new Event('input', { bubbles: true }));
+      inputs[2].value = 'created@test.com';
+      inputs[2].dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+
+      getAddButton(el).click();
+      await el.updateComplete;
+      const rows = el.shadowRoot!.querySelectorAll('.account-item.selectable');
+      const githubRow = Array.from(rows).find((r) => r.textContent?.includes('Work GitHub'));
+      (githubRow as HTMLElement).click();
+      await el.updateComplete;
+
+      clearHistory();
+      const saveBtn = Array.from(
+        el.shadowRoot!.querySelectorAll('.dialog-footer .btn-primary')
+      ).find((b) => b.textContent?.trim().includes('Save Profile')) as HTMLButtonElement;
+      saveBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      const saveCalls = findCommands('save_unified_profile');
+      expect(saveCalls.length).to.equal(1);
+      const saved = (saveCalls[0].args as { profile: UnifiedProfile }).profile;
+      expect(saved.id).to.be.a('string').and.not.be.empty;
+      expect(saved.defaultAccounts.github).to.equal('account-1');
+    });
+
+    it('shows connect-new buttons in the picker and dispatches open-github', async () => {
+      useConfig(testProfiles, []);
+
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+
+      getAddButton(el).click();
+      await el.updateComplete;
+
+      // No global accounts → no selectable rows, but connect-new buttons present
+      expect(el.shadowRoot!.querySelectorAll('.account-item.selectable').length).to.equal(0);
+      const githubBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'GitHub'
+      ) as HTMLButtonElement;
+      expect(githubBtn).to.not.be.undefined;
+
+      let dispatched = false;
+      el.addEventListener('open-github', () => {
+        dispatched = true;
+      });
+      githubBtn.click();
+      await el.updateComplete;
+      expect(dispatched).to.be.true;
+
+      // The picker view is preserved (the host hides/reopens the dialog), so the
+      // user returns here to select the newly connected account.
+      const title = el.shadowRoot!.querySelector('.dialog-title');
+      expect(title!.textContent).to.include('Attach Account');
+    });
+
+    it('preserves the picker and refreshes when demoted then revealed', async () => {
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+      getAddButton(el).click();
+      await el.updateComplete;
+
+      // Demote behind a stacked dialog (e.g. an integration dialog)
+      el.demoted = true;
+      await el.updateComplete;
+      expect(el.hasAttribute('demoted')).to.be.true;
+      // Still mounted and on the picker (state preserved)
+      expect(el.shadowRoot!.querySelector('.dialog-overlay')).to.not.be.null;
+      expect(el.shadowRoot!.querySelector('.dialog-title')!.textContent).to.include('Attach Account');
+
+      // Revealing again refreshes the account list so a newly connected account shows
+      clearHistory();
+      el.demoted = false;
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 20));
+      expect(el.hasAttribute('demoted')).to.be.false;
+      expect(findCommands('get_unified_profiles_config').length).to.be.greaterThan(0);
+      expect(el.shadowRoot!.querySelector('.dialog-title')!.textContent).to.include('Attach Account');
+    });
+
+    it('auto-attaches a newly connected account on return from the integration dialog', async () => {
+      const profile = makeProfile({ id: 'p1', name: 'P1', defaultAccounts: {} });
+      useConfig([profile], []); // no global accounts yet
+
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+      getAddButton(el).click();
+      await el.updateComplete;
+
+      // Click the "Connect a new account → GitHub" button
+      const githubBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'GitHub'
+      ) as HTMLButtonElement;
+      githubBtn.click();
+      await el.updateComplete;
+
+      // Integration dialog opens (demoted); user connects an account
+      el.demoted = true;
+      await el.updateComplete;
+      const newGh = makeAccount({ id: 'gh-new', name: 'New GH', integrationType: 'github' });
+      useConfig([profile], [newGh]);
+
+      // Closing the integration dialog reveals the picker and auto-attaches
+      el.demoted = false;
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+
+      // Back on the edit form with the connected account attached
+      expect(el.shadowRoot!.querySelector('.dialog-title')!.textContent).to.include('Edit Profile');
+      const accountsSection = el.shadowRoot!.querySelector('.accounts-section');
+      expect(accountsSection!.querySelectorAll('.account-item').length).to.equal(1);
+      expect(accountsSection!.textContent).to.include('New GH');
+    });
+
+    it('auto-attaches the existing default account when re-connecting a provider', async () => {
+      const gh = makeAccount({
+        id: 'gh1',
+        name: 'Existing GH',
+        integrationType: 'github',
+        isDefault: true,
+      });
+      const profile = makeProfile({ id: 'p1', name: 'P1', defaultAccounts: {} });
+      useConfig([profile], [gh]);
+
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+      getAddButton(el).click();
+      await el.updateComplete;
+
+      // Re-authenticate the existing (disconnected) account via the connect button
+      const githubBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'GitHub'
+      ) as HTMLButtonElement;
+      githubBtn.click();
+      await el.updateComplete;
+
+      el.demoted = true;
+      await el.updateComplete;
+      // No new account (same id re-authed)
+      el.demoted = false;
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+
+      // The existing default account is attached
+      expect(el.shadowRoot!.querySelector('.dialog-title')!.textContent).to.include('Edit Profile');
+      const accountsSection = el.shadowRoot!.querySelector('.accounts-section');
+      expect(accountsSection!.textContent).to.include('Existing GH');
+    });
+
+    it('deletes a global account from the account edit screen', async () => {
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[1] as HTMLElement).click(); // Personal
+      await el.updateComplete;
+
+      // Open the attached account's edit screen
+      const editBtn = el.shadowRoot!.querySelector(
+        '.accounts-section .account-actions .action-btn:not(.delete)'
+      ) as HTMLButtonElement;
+      editBtn.click();
+      await el.updateComplete;
+
+      const title = el.shadowRoot!.querySelector('.dialog-title');
+      expect(title!.textContent).to.include('Edit Account');
+
+      clearHistory();
+      const deleteBtn = Array.from(
+        el.shadowRoot!.querySelectorAll('.dialog-footer .btn-danger')
+      ).find((b) => b.textContent?.trim().includes('Delete Account')) as HTMLButtonElement;
+      expect(deleteBtn).to.not.be.undefined;
+      deleteBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      expect(findCommands('delete_global_account').length).to.equal(1);
+    });
+
+    it('discards an attach when the picker is dismissed with Back', async () => {
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click(); // Work, no accounts
+      await el.updateComplete;
+
+      getAddButton(el).click();
+      await el.updateComplete;
+
+      // Leave the picker without selecting anything
+      const backBtn = Array.from(
+        el.shadowRoot!.querySelectorAll('.dialog-footer .btn-secondary')
+      ).find((b) => b.textContent?.trim() === 'Back') as HTMLButtonElement;
+      backBtn.click();
+      await el.updateComplete;
+
+      const accountsSection = el.shadowRoot!.querySelector('.accounts-section');
+      expect(accountsSection!.querySelectorAll('.account-item').length).to.equal(0);
+    });
+
+    it('discards a detach when the form is cancelled without saving', async () => {
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[1] as HTMLElement).click(); // Personal
+      await el.updateComplete;
+
+      // Detach the attached account locally
+      (
+        el.shadowRoot!.querySelector(
+          '.accounts-section .account-actions .action-btn.delete'
+        ) as HTMLButtonElement
+      ).click();
+      await el.updateComplete;
+      expect(
+        el.shadowRoot!.querySelector('.accounts-section')!.querySelectorAll('.account-item').length
+      ).to.equal(0);
+
+      clearHistory();
+      // Cancel the form (returns to list) - nothing should persist
+      const cancelBtn = Array.from(
+        el.shadowRoot!.querySelectorAll('.dialog-footer .btn-secondary')
+      ).find((b) => b.textContent?.trim() === 'Cancel') as HTMLButtonElement;
+      cancelBtn.click();
+      await el.updateComplete;
+      expect(findCommands('save_unified_profile').length).to.equal(0);
+
+      // Re-open the profile - the account is still attached (the store was untouched)
+      (el.shadowRoot!.querySelectorAll('.profile-item')[1] as HTMLElement).click();
+      await el.updateComplete;
+      expect(
+        el.shadowRoot!.querySelector('.accounts-section')!.querySelectorAll('.account-item').length
+      ).to.equal(1);
+    });
+  });
+
+  // ── Connection status indicator ────────────────────────────────────────
+  describe('connection status', () => {
+    it('refreshes the status dot to connected when opened', async () => {
+      const gh = makeAccount({ id: 'gh1', name: 'GH', integrationType: 'github' });
+      const profile = makeProfile({ id: 'p1', name: 'P1', defaultAccounts: { github: 'gh1' } });
+
       mockInvoke = async (command: string) => {
         switch (command) {
           case 'get_unified_profiles_config':
-            return { version: 3, profiles: testProfiles, accounts: [], repositoryAssignments: {} };
+            return { version: 3, profiles: [profile], accounts: [gh], repositoryAssignments: {} };
           case 'get_migration_backup_info':
             return { hasBackup: false, backupDate: null, profilesCount: null, accountsCount: null };
+          case 'get_keyring_token':
+            return 'tok-123';
+          case 'check_github_connection':
+            return { connected: true, user: { login: 'me', name: 'Me', avatarUrl: null, email: null } };
+          case 'update_global_account_cached_user':
+            return null;
           default:
             return null;
         }
       };
       unifiedProfileStore.getState().setConfig({
         version: 3,
-        profiles: testProfiles,
-        accounts: [],
+        profiles: [profile],
+        accounts: [gh],
         repositoryAssignments: {},
       });
 
       const el = await renderDialog();
-      const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
-      (profileItems[0] as HTMLElement).click();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
       await el.updateComplete;
 
-      const warning = el.shadowRoot!.querySelector('.empty-accounts.warning');
-      expect(warning).to.not.be.null;
-      expect(warning!.textContent).to.include('No integration accounts configured');
+      // The status check runs in the background; wait for it to resolve
+      await new Promise((r) => setTimeout(r, 150));
+      await el.updateComplete;
+
+      const indicator = el.shadowRoot!.querySelector('.accounts-section .status-indicator');
+      expect(indicator).to.not.be.null;
+      expect(indicator!.classList.contains('connected')).to.be.true;
+    });
+
+    it('marks the account disconnected when it has no token', async () => {
+      const gh = makeAccount({ id: 'gh1', name: 'GH', integrationType: 'github' });
+      const profile = makeProfile({ id: 'p1', name: 'P1', defaultAccounts: { github: 'gh1' } });
+
+      mockInvoke = async (command: string) => {
+        switch (command) {
+          case 'get_unified_profiles_config':
+            return { version: 3, profiles: [profile], accounts: [gh], repositoryAssignments: {} };
+          case 'get_migration_backup_info':
+            return { hasBackup: false, backupDate: null, profilesCount: null, accountsCount: null };
+          case 'get_keyring_token':
+            return null; // no token → disconnected
+          default:
+            return null;
+        }
+      };
+      unifiedProfileStore.getState().setConfig({
+        version: 3,
+        profiles: [profile],
+        accounts: [gh],
+        repositoryAssignments: {},
+      });
+
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const indicator = el.shadowRoot!.querySelector('.accounts-section .status-indicator');
+      expect(indicator!.classList.contains('disconnected')).to.be.true;
+    });
+
+    it('does not override the status set by the integration dialog on reveal', async () => {
+      const gh = makeAccount({ id: 'gh1', name: 'GH', integrationType: 'github' });
+      const profile = makeProfile({ id: 'p1', name: 'P1', defaultAccounts: { github: 'gh1' } });
+      useConfig([profile], [gh]); // no token in this mock → fresh-open check = disconnected
+
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+      // Let the fresh-open status check settle (it resolves to disconnected here)
+      await new Promise((r) => setTimeout(r, 60));
+      await el.updateComplete;
+
+      // Simulate the integration dialog reporting a verified connection
+      unifiedProfileStore.getState().setAccountConnectionStatus('gh1', 'connected');
+      await el.updateComplete;
+
+      // Demote (integration dialog opens on top) then reveal (it closes)
+      el.demoted = true;
+      await el.updateComplete;
+      el.demoted = false;
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 60));
+      await el.updateComplete;
+
+      // Reveal must NOT re-check and clobber the dialog's status
+      expect(unifiedProfileStore.getState().accountConnectionStatus['gh1']?.status).to.equal(
+        'connected'
+      );
+      const indicator = el.shadowRoot!.querySelector('.accounts-section .status-indicator');
+      expect(indicator!.classList.contains('connected')).to.be.true;
     });
   });
 
   // ── Default account per integration type ───────────────────────────────
   describe('default account per integration type', () => {
-    it('shows "Default" badge on the default account', async () => {
+    it('shows "Default" badge on the attached default account', async () => {
       const el = await renderDialog();
       const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
-      (profileItems[0] as HTMLElement).click();
+      // Personal profile has the gitlab account (isDefault: true) attached
+      (profileItems[1] as HTMLElement).click();
       await el.updateComplete;
 
-      // gitlabAccount has isDefault: true
       const defaultBadges = el.shadowRoot!.querySelectorAll('.account-item .default-badge');
       expect(defaultBadges.length).to.be.greaterThanOrEqual(1);
     });
@@ -900,7 +1416,7 @@ describe('lv-profile-manager-dialog', () => {
       expect(dialog).to.not.be.null;
     });
 
-    it('handles account removal failure gracefully', async () => {
+    it('handles global account delete failure gracefully', async () => {
       mockInvoke = async (command: string) => {
         switch (command) {
           case 'get_unified_profiles_config':
@@ -917,20 +1433,26 @@ describe('lv-profile-manager-dialog', () => {
       };
 
       const el = await renderDialog();
-      // Go to edit view
+      // Edit the Personal profile (has an attached account) and open its edit screen
       const profileItems = el.shadowRoot!.querySelectorAll('.profile-item');
-      (profileItems[0] as HTMLElement).click();
+      (profileItems[1] as HTMLElement).click();
       await el.updateComplete;
 
-      // Click remove on the first account
-      const removeButtons = el.shadowRoot!.querySelectorAll('.account-actions .action-btn.delete');
-      if (removeButtons.length > 0) {
-        (removeButtons[0] as HTMLButtonElement).click();
-        await new Promise((r) => setTimeout(r, 100));
-        await el.updateComplete;
-      }
+      const editBtn = el.shadowRoot!.querySelector(
+        '.accounts-section .account-actions .action-btn:not(.delete)'
+      ) as HTMLButtonElement;
+      editBtn.click();
+      await el.updateComplete;
 
-      // Component should still be rendered
+      // Click the destructive global delete and confirm
+      const deleteBtn = Array.from(
+        el.shadowRoot!.querySelectorAll('.dialog-footer .btn-danger')
+      ).find((b) => b.textContent?.trim().includes('Delete Account')) as HTMLButtonElement;
+      deleteBtn.click();
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      // Component should still be rendered despite the failure
       const dialog = el.shadowRoot!.querySelector('.dialog');
       expect(dialog).to.not.be.null;
     });

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -564,6 +564,8 @@ export class LvAzureDevOpsDialog extends LitElement {
 
   @property({ type: Boolean }) open = false;
   @property({ type: String }) repositoryPath = '';
+  /** Show a back arrow instead of a close ×, e.g. when opened from the profile manager. */
+  @property({ type: Boolean }) backButton = false;
 
   @state() private activeTab: TabType = 'connection';
   @state() private connectionStatus: AdoConnectionStatus | null = null;
@@ -730,6 +732,18 @@ export class LvAzureDevOpsDialog extends LitElement {
     }
   }
 
+  /**
+   * Mirror a verified connection result into the shared unified-profile store so
+   * other views (e.g. the profile manager's status dots) reflect it immediately.
+   */
+  private syncSharedConnectionStatus(connected: boolean): void {
+    if (this.selectedAccountId) {
+      unifiedProfileStore
+        .getState()
+        .setAccountConnectionStatus(this.selectedAccountId, connected ? 'connected' : 'disconnected');
+    }
+  }
+
   private async checkConnection(): Promise<void> {
     const org = this.detectedRepo?.organization || this.organizationInput;
     if (!org) return;
@@ -739,6 +753,7 @@ export class LvAzureDevOpsDialog extends LitElement {
     const result = await gitService.checkAdoConnectionWithToken(org, token);
     if (result.success && result.data) {
       this.connectionStatus = result.data;
+      this.syncSharedConnectionStatus(result.data.connected);
       // Update cached user in global account if connected
       if (this.selectedAccountId && result.data.connected && result.data.user) {
         await unifiedProfileService.updateGlobalAccountCachedUser(this.selectedAccountId, {
@@ -961,6 +976,8 @@ export class LvAzureDevOpsDialog extends LitElement {
 
           if (result.success && result.data?.connected) {
             this.connectionStatus = result.data;
+            this.selectedAccountId = accountId;
+            this.syncSharedConnectionStatus(true);
             showToast('Connected to Azure DevOps via Microsoft Entra ID', 'success');
           } else {
             this.error = 'Connection verification failed';
@@ -1008,6 +1025,7 @@ export class LvAzureDevOpsDialog extends LitElement {
       }
 
       this.connectionStatus = verifyResult.data;
+      this.syncSharedConnectionStatus(true);
 
       // Update cached user if we got user info
       if (this.selectedAccountId && verifyResult.data.user) {
@@ -1101,6 +1119,7 @@ export class LvAzureDevOpsDialog extends LitElement {
       // Token saved, update state
       this.tokenInput = '';
       this.connectionStatus = verifyResult.data;
+      this.syncSharedConnectionStatus(true);
 
       // Store git credentials in keyring for push/pull operations
       // Username must be non-empty for macOS Keychain - use 'pat' as a placeholder
@@ -1140,6 +1159,7 @@ export class LvAzureDevOpsDialog extends LitElement {
       }
       log.debug('Deleted git credentials from keyring');
 
+      this.syncSharedConnectionStatus(false);
       this.connectionStatus = null;
       this.pullRequests = [];
       this.workItems = [];
@@ -1714,6 +1734,7 @@ export class LvAzureDevOpsDialog extends LitElement {
     return html`
       <lv-modal
         .open=${this.open}
+        ?backButton=${this.backButton}
         title="Azure DevOps"
         @close=${this.handleClose}
       >

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -1735,7 +1735,7 @@ export class LvAzureDevOpsDialog extends LitElement {
       <lv-modal
         .open=${this.open}
         ?backButton=${this.backButton}
-        title="Azure DevOps"
+        modalTitle="Azure DevOps"
         @close=${this.handleClose}
       >
         <div class="content">

--- a/src/components/dialogs/lv-bitbucket-dialog.ts
+++ b/src/components/dialogs/lv-bitbucket-dialog.ts
@@ -572,6 +572,8 @@ export class LvBitbucketDialog extends LitElement {
 
   @property({ type: Boolean }) open = false;
   @property({ type: String }) repositoryPath = '';
+  /** Show a back arrow instead of a close ×, e.g. when opened from the profile manager. */
+  @property({ type: Boolean }) backButton = false;
 
   @state() private activeTab: TabType = 'connection';
   @state() private connectionStatus: BitbucketConnectionStatus | null = null;
@@ -723,6 +725,18 @@ export class LvBitbucketDialog extends LitElement {
     }
   }
 
+  /**
+   * Mirror a verified connection result into the shared unified-profile store so
+   * other views (e.g. the profile manager's status dots) reflect it immediately.
+   */
+  private syncSharedConnectionStatus(connected: boolean): void {
+    if (this.selectedAccountId) {
+      unifiedProfileStore
+        .getState()
+        .setAccountConnectionStatus(this.selectedAccountId, connected ? 'connected' : 'disconnected');
+    }
+  }
+
   private async checkConnection(): Promise<void> {
     // Get token for selected account (or use stored OAuth token)
     const token = this.oauthToken || await this.getSelectedAccountToken();
@@ -732,6 +746,7 @@ export class LvBitbucketDialog extends LitElement {
       const result = await gitService.checkBitbucketConnectionWithToken(token);
       if (result.success && result.data) {
         this.connectionStatus = result.data;
+        this.syncSharedConnectionStatus(result.data.connected);
         this.oauthToken = token;
 
         // Update cached user in global account if connected
@@ -930,6 +945,7 @@ export class LvBitbucketDialog extends LitElement {
           this.accounts = getAccountsByType('bitbucket');
         }
 
+        this.syncSharedConnectionStatus(true);
         this.usernameInput = '';
         this.appPasswordInput = '';
         if (this.detectedRepo) {
@@ -955,6 +971,7 @@ export class LvBitbucketDialog extends LitElement {
       }
       // Also delete legacy credentials
       await gitService.deleteBitbucketCredentials();
+      this.syncSharedConnectionStatus(false);
       this.connectionStatus = null;
       this.oauthToken = null;
       this.pullRequests = [];
@@ -1577,6 +1594,7 @@ export class LvBitbucketDialog extends LitElement {
     return html`
       <lv-modal
         .open=${this.open}
+        ?backButton=${this.backButton}
         title="Bitbucket"
         @close=${this.handleClose}
       >

--- a/src/components/dialogs/lv-bitbucket-dialog.ts
+++ b/src/components/dialogs/lv-bitbucket-dialog.ts
@@ -1595,7 +1595,7 @@ export class LvBitbucketDialog extends LitElement {
       <lv-modal
         .open=${this.open}
         ?backButton=${this.backButton}
-        title="Bitbucket"
+        modalTitle="Bitbucket"
         @close=${this.handleClose}
       >
         <div class="content">

--- a/src/components/dialogs/lv-github-dialog.ts
+++ b/src/components/dialogs/lv-github-dialog.ts
@@ -744,6 +744,8 @@ export class LvGitHubDialog extends LitElement {
 
   @property({ type: Boolean, reflect: true }) open = false;
   @property({ type: String }) repositoryPath = '';
+  /** Show a back arrow instead of a close ×, e.g. when opened from the profile manager. */
+  @property({ type: Boolean }) backButton = false;
 
   @state() private activeTab: TabType = 'connection';
   @state() private connectionStatus: GitHubConnectionStatus | null = null;
@@ -905,6 +907,19 @@ export class LvGitHubDialog extends LitElement {
     }
   }
 
+  /**
+   * Mirror a verified connection result into the shared unified-profile store so
+   * other views (e.g. the profile manager's status dots) reflect it immediately,
+   * rather than waiting for their own re-check.
+   */
+  private syncSharedConnectionStatus(connected: boolean): void {
+    if (this.selectedAccountId) {
+      unifiedProfileStore
+        .getState()
+        .setAccountConnectionStatus(this.selectedAccountId, connected ? 'connected' : 'disconnected');
+    }
+  }
+
   private async checkConnection(): Promise<void> {
     try {
       // Get token for selected account (or legacy token if no account)
@@ -912,6 +927,7 @@ export class LvGitHubDialog extends LitElement {
       const result = await gitService.checkGitHubConnectionWithToken(token);
       if (result.success && result.data) {
         this.connectionStatus = result.data;
+        this.syncSharedConnectionStatus(result.data.connected);
         // Update cached user in global account if connected
         if (this.selectedAccountId && result.data.connected && result.data.user) {
           await unifiedProfileService.updateGlobalAccountCachedUser(this.selectedAccountId, {
@@ -1192,6 +1208,7 @@ export class LvGitHubDialog extends LitElement {
       }
 
       this.connectionStatus = verifyResult.data;
+      this.syncSharedConnectionStatus(true);
       this.oauthState = { status: 'idle' };
 
       // Load data if connected and repo detected
@@ -1259,6 +1276,7 @@ export class LvGitHubDialog extends LitElement {
       // Token saved, update state
       this.tokenInput = '';
       this.connectionStatus = verifyResult.data;
+      this.syncSharedConnectionStatus(true);
 
       // Load data if connected and repo detected
       // Pass the token directly since storage might not be ready yet
@@ -1291,6 +1309,7 @@ export class LvGitHubDialog extends LitElement {
         await gitService.deleteGitHubToken();
       }
 
+      this.syncSharedConnectionStatus(false);
       this.connectionStatus = { connected: false, user: null, scopes: [] };
       this.pullRequests = [];
       this.workflowRuns = [];
@@ -1386,6 +1405,8 @@ export class LvGitHubDialog extends LitElement {
         user: null,
         scopes: ['app-installation'],
       };
+      this.selectedAccountId = accountId;
+      this.syncSharedConnectionStatus(true);
 
       showToast('Connected via GitHub App', 'success');
 
@@ -2340,6 +2361,7 @@ export class LvGitHubDialog extends LitElement {
     return html`
       <lv-modal
         ?open=${this.open}
+        ?backButton=${this.backButton}
         modalTitle="GitHub"
         @close=${this.handleClose}
       >

--- a/src/components/dialogs/lv-gitlab-dialog.ts
+++ b/src/components/dialogs/lv-gitlab-dialog.ts
@@ -593,6 +593,8 @@ export class LvGitLabDialog extends LitElement {
 
   @property({ type: Boolean }) open = false;
   @property({ type: String }) repositoryPath = '';
+  /** Show a back arrow instead of a close ×, e.g. when opened from the profile manager. */
+  @property({ type: Boolean }) backButton = false;
 
   @state() private activeTab: TabType = 'connection';
   @state() private connectionStatus: GitLabConnectionStatus | null = null;
@@ -750,6 +752,18 @@ export class LvGitLabDialog extends LitElement {
     }
   }
 
+  /**
+   * Mirror a verified connection result into the shared unified-profile store so
+   * other views (e.g. the profile manager's status dots) reflect it immediately.
+   */
+  private syncSharedConnectionStatus(connected: boolean): void {
+    if (this.selectedAccountId) {
+      unifiedProfileStore
+        .getState()
+        .setAccountConnectionStatus(this.selectedAccountId, connected ? 'connected' : 'disconnected');
+    }
+  }
+
   private async checkConnection(): Promise<void> {
     const instanceUrl = this.detectedRepo?.instanceUrl || this.instanceUrlInput;
     if (!instanceUrl) return;
@@ -759,6 +773,7 @@ export class LvGitLabDialog extends LitElement {
     const result = await gitService.checkGitLabConnectionWithToken(instanceUrl, token);
     if (result.success && result.data) {
       this.connectionStatus = result.data;
+      this.syncSharedConnectionStatus(result.data.connected);
       // Update cached user in global account if connected
       if (this.selectedAccountId && result.data.connected && result.data.user) {
         await unifiedProfileService.updateGlobalAccountCachedUser(this.selectedAccountId, {
@@ -978,6 +993,7 @@ export class LvGitLabDialog extends LitElement {
       // Token saved, update state
       this.tokenInput = '';
       this.connectionStatus = verifyResult.data;
+      this.syncSharedConnectionStatus(true);
 
       // Load data if connected and repo detected
       if (this.connectionStatus?.connected && this.detectedRepo) {
@@ -1002,6 +1018,7 @@ export class LvGitLabDialog extends LitElement {
         await gitService.deleteGitLabToken();
       }
 
+      this.syncSharedConnectionStatus(false);
       this.connectionStatus = null;
       this.mergeRequests = [];
       this.issues = [];
@@ -1754,6 +1771,7 @@ export class LvGitLabDialog extends LitElement {
     return html`
       <lv-modal
         .open=${this.open}
+        ?backButton=${this.backButton}
         title="GitLab"
         @close=${this.handleClose}
       >

--- a/src/components/dialogs/lv-gitlab-dialog.ts
+++ b/src/components/dialogs/lv-gitlab-dialog.ts
@@ -1772,7 +1772,7 @@ export class LvGitLabDialog extends LitElement {
       <lv-modal
         .open=${this.open}
         ?backButton=${this.backButton}
-        title="GitLab"
+        modalTitle="GitLab"
         @close=${this.handleClose}
       >
         <div class="content">

--- a/src/components/dialogs/lv-modal.ts
+++ b/src/components/dialogs/lv-modal.ts
@@ -61,6 +61,12 @@ export class LvModal extends LitElement {
         background: var(--color-bg-tertiary);
       }
 
+      .header-left {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-sm);
+      }
+
       .title {
         font-size: var(--font-size-lg);
         font-weight: var(--font-weight-semibold);
@@ -113,6 +119,12 @@ export class LvModal extends LitElement {
   @property({ type: Boolean, reflect: true }) open = false;
   @property({ type: String }) modalTitle = '';
   @property({ type: Boolean }) showClose = true;
+  /**
+   * When true, the header shows a back arrow (←) on the left instead of the close
+   * (×) on the right. Used when the dialog was opened from another screen (e.g. the
+   * profile manager) that it should return to. Still dispatches `close`.
+   */
+  @property({ type: Boolean }) backButton = false;
 
   private previouslyFocused: HTMLElement | null = null;
 
@@ -212,8 +224,19 @@ export class LvModal extends LitElement {
       <div class="overlay" @click=${this.handleOverlayClick}></div>
       <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title">
         <header class="header">
-          <h2 class="title" id="modal-title">${this.modalTitle}</h2>
-          ${this.showClose
+          <div class="header-left">
+            ${this.backButton
+              ? html`
+                  <button class="close-btn" @click=${this.close} aria-label="Back" title="Back">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <polyline points="15 18 9 12 15 6"></polyline>
+                    </svg>
+                  </button>
+                `
+              : ''}
+            <h2 class="title" id="modal-title">${this.modalTitle}</h2>
+          </div>
+          ${this.showClose && !this.backButton
             ? html`
                 <button class="close-btn" @click=${this.close} aria-label="Close">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/src/components/dialogs/lv-profile-manager-dialog.ts
+++ b/src/components/dialogs/lv-profile-manager-dialog.ts
@@ -1703,8 +1703,8 @@ export class LvProfileManagerDialog extends LitElement {
           ${accounts.length === 0
             ? html`
                 <div class="empty-accounts">
-                  No integration accounts yet. Connect one below, then reopen this profile to
-                  attach it.
+                  No integration accounts yet. Connect one below — once you return, it'll be
+                  attached to this profile automatically.
                 </div>
               `
             : html`

--- a/src/components/dialogs/lv-profile-manager-dialog.ts
+++ b/src/components/dialogs/lv-profile-manager-dialog.ts
@@ -3,7 +3,7 @@
  * Full CRUD interface for managing unified profiles (git identity + integration accounts)
  */
 
-import { LitElement, html, css, nothing } from 'lit';
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import { unifiedProfileStore, type AccountConnectionStatus, type ConnectionStatus } from '../../stores/unified-profile.store.ts';
@@ -14,7 +14,7 @@ import { PROFILE_COLORS, ACCOUNT_COLORS, INTEGRATION_TYPE_NAMES } from '../../ty
 import { showConfirm } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 
-type ViewMode = 'list' | 'edit' | 'create' | 'add-account' | 'edit-account' | 'assign-repos';
+type ViewMode = 'list' | 'edit' | 'create' | 'select-account' | 'edit-account' | 'assign-repos';
 
 @customElement('lv-profile-manager-dialog')
 export class LvProfileManagerDialog extends LitElement {
@@ -33,6 +33,13 @@ export class LvProfileManagerDialog extends LitElement {
         align-items: center;
         justify-content: center;
         z-index: var(--z-modal);
+      }
+
+      /* Sit behind a stacked dialog (e.g. an integration dialog opened from the
+         picker); the dialog on top provides the backdrop. */
+      :host([demoted]) .dialog-overlay {
+        z-index: calc(var(--z-modal) - 1);
+        background: transparent;
       }
 
       .dialog {
@@ -71,9 +78,19 @@ export class LvProfileManagerDialog extends LitElement {
       .dialog-footer {
         display: flex;
         justify-content: flex-end;
+        align-items: center;
         gap: var(--spacing-sm);
         padding: var(--spacing-md);
         border-top: 1px solid var(--color-border);
+      }
+
+      .btn-danger {
+        background: var(--color-error);
+        color: var(--color-text-inverse);
+      }
+
+      .btn-danger:hover:not(:disabled) {
+        filter: brightness(0.92);
       }
 
       .close-btn {
@@ -584,6 +601,13 @@ export class LvProfileManagerDialog extends LitElement {
 
   @property({ type: Boolean }) open = false;
   @property({ type: String }) repoPath = '';
+  /**
+   * When true, render behind another modal (e.g. an integration dialog opened
+   * from the account picker). The profile manager stays mounted and open so that
+   * closing the dialog stacked on top reveals it again, right where the user left
+   * off — no fragile "return" state to lose across an auth round trip.
+   */
+  @property({ type: Boolean, reflect: true }) demoted = false;
 
   @state() private viewMode: ViewMode = 'list';
   @state() private profiles: UnifiedProfile[] = [];
@@ -601,6 +625,12 @@ export class LvProfileManagerDialog extends LitElement {
 
   private unsubscribeStore?: () => void;
   private unsubscribeRepoStore?: () => void;
+
+  // When the user picks "Connect a new account" for a provider in the picker, we
+  // remember the provider and the account ids that existed beforehand, so that on
+  // return we can auto-attach the account they just connected to the profile.
+  private pendingConnectType: IntegrationType | null = null;
+  private accountIdsBeforeConnect: Set<string> = new Set();
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -636,7 +666,15 @@ export class LvProfileManagerDialog extends LitElement {
 
   updated(changedProperties: Map<string, unknown>): void {
     if (changedProperties.has('open') && this.open) {
-      this.loadProfiles();
+      // Fresh open: load data, then verify connection status for accurate dots.
+      void this.loadProfiles().then(() => this.refreshConnectionStatuses());
+    }
+    // When a dialog stacked on top of us closes (e.g. an integration dialog opened
+    // from the picker), refresh and auto-attach the account the user just connected.
+    // We do NOT re-check connection status here — the integration dialog already
+    // wrote it to the shared store, and re-checking would overwrite it.
+    if (changedProperties.has('demoted') && !this.demoted && this.open) {
+      void this.handleRevealAfterConnect();
     }
   }
 
@@ -644,6 +682,19 @@ export class LvProfileManagerDialog extends LitElement {
     await unifiedProfileService.loadUnifiedProfiles();
     // Also load backup info
     await this.loadBackupInfo();
+  }
+
+  /**
+   * Kick off a background connection check for every global account so the status
+   * indicator dots are accurate on a fresh open (e.g. after app restart the store
+   * status is 'unknown'). NOT called when revealing after connecting an account —
+   * the integration dialog already wrote the authoritative status, and re-checking
+   * here would clobber it.
+   */
+  private refreshConnectionStatuses(): void {
+    for (const account of this.getGlobalAccounts()) {
+      void unifiedProfileService.refreshAccountCachedUser(account);
+    }
   }
 
   private async loadBackupInfo(): Promise<void> {
@@ -752,7 +803,7 @@ export class LvProfileManagerDialog extends LitElement {
   }
 
   private handleBack(): void {
-    if (this.viewMode === 'add-account' || this.viewMode === 'edit-account') {
+    if (this.viewMode === 'select-account' || this.viewMode === 'edit-account') {
       this.viewMode = this.editingProfile?.id ? 'edit' : 'create';
       this.editingAccount = null;
     } else if (this.viewMode === 'assign-repos') {
@@ -914,18 +965,61 @@ export class LvProfileManagerDialog extends LitElement {
     return unifiedProfileStore.getState().accounts;
   }
 
-  // Account management - now works with global accounts
-  private handleAddAccount(): void {
-    this.editingAccount = {
-      name: '',
-      integrationType: 'github',
-      config: { type: 'github' },
-      color: null,
-      cachedUser: null,
-      urlPatterns: [],
-      isDefault: false,
+  /**
+   * Accounts attached to the profile being edited, resolved from the profile's
+   * defaultAccounts map to concrete global account objects. Dangling ids (whose
+   * global account no longer exists) are filtered out defensively, since
+   * editingProfile is a local snapshot taken in handleEdit.
+   */
+  private getAttachedAccounts(): Array<{ type: IntegrationType; account: IntegrationAccount }> {
+    const map = this.editingProfile?.defaultAccounts ?? {};
+    const globals = this.getGlobalAccounts();
+    return Object.entries(map)
+      .map(([type, id]) => ({
+        type: type as IntegrationType,
+        account: globals.find((a) => a.id === id),
+      }))
+      .filter((entry): entry is { type: IntegrationType; account: IntegrationAccount } =>
+        Boolean(entry.account)
+      );
+  }
+
+  private setEditingProfileAccount(type: IntegrationType, accountId: string): void {
+    if (!this.editingProfile) return;
+    this.editingProfile = {
+      ...this.editingProfile,
+      defaultAccounts: { ...this.editingProfile.defaultAccounts, [type]: accountId },
     };
-    this.viewMode = 'add-account';
+  }
+
+  private removeEditingProfileAccount(type: IntegrationType): void {
+    if (!this.editingProfile) return;
+    const defaultAccounts = { ...this.editingProfile.defaultAccounts };
+    delete defaultAccounts[type];
+    this.editingProfile = { ...this.editingProfile, defaultAccounts };
+  }
+
+  // Account management - attaches existing global accounts to the profile
+  private handleOpenAccountPicker(): void {
+    this.viewMode = 'select-account';
+  }
+
+  /**
+   * Attach an existing global account to the profile being edited. Because a
+   * profile holds at most one account per provider type, this replaces any
+   * account already attached for the same type. Persisted on "Save Profile".
+   */
+  private handleAttachAccount(account: IntegrationAccount): void {
+    this.setEditingProfileAccount(account.integrationType, account.id);
+    this.viewMode = this.editingProfile?.id ? 'edit' : 'create';
+  }
+
+  /**
+   * Detach an account from the profile being edited (local only; the global
+   * account is kept). Persisted on "Save Profile".
+   */
+  private handleDetachAccount(type: IntegrationType): void {
+    this.removeEditingProfileAccount(type);
   }
 
   private handleEditAccount(account: IntegrationAccount): void {
@@ -933,19 +1027,31 @@ export class LvProfileManagerDialog extends LitElement {
     this.viewMode = 'edit-account';
   }
 
-  private async handleRemoveAccount(accountId: string): Promise<void> {
+  /**
+   * Delete a global account entirely (for all profiles). Reachable only from the
+   * account's Edit screen because it is destructive and irreversible.
+   */
+  private async handleDeleteGlobalAccount(accountId: string): Promise<void> {
     const confirmed = await showConfirm(
-      'Remove Account',
-      'Remove this account? This will delete the account for all profiles.',
+      'Delete Account',
+      'Delete this account? This will remove the account for all profiles.',
       'warning'
     );
     if (!confirmed) return;
 
     try {
       await unifiedProfileService.deleteGlobalAccount(accountId);
-      showToast('Account removed', 'success');
+      // The editing profile is a local snapshot - drop the deleted account from it too.
+      const attachedType = Object.entries(this.editingProfile?.defaultAccounts ?? {}).find(
+        ([, id]) => id === accountId
+      )?.[0] as IntegrationType | undefined;
+      if (attachedType) {
+        this.removeEditingProfileAccount(attachedType);
+      }
+      showToast('Account deleted', 'success');
+      this.handleBack();
     } catch (error) {
-      showToast(`Failed to remove account: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error');
+      showToast(`Failed to delete account: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error');
     }
   }
 
@@ -1035,8 +1141,8 @@ export class LvProfileManagerDialog extends LitElement {
         return 'New Profile';
       case 'edit':
         return 'Edit Profile';
-      case 'add-account':
-        return 'Add Account';
+      case 'select-account':
+        return 'Attach Account';
       case 'edit-account':
         return 'Edit Account';
       case 'assign-repos':
@@ -1053,7 +1159,8 @@ export class LvProfileManagerDialog extends LitElement {
       case 'create':
       case 'edit':
         return this.renderProfileForm();
-      case 'add-account':
+      case 'select-account':
+        return this.renderAccountPicker();
       case 'edit-account':
         return this.renderAccountForm();
       case 'assign-repos':
@@ -1083,13 +1190,21 @@ export class LvProfileManagerDialog extends LitElement {
             ${this.isSaving ? 'Saving...' : 'Save Profile'}
           </button>
         `;
-      case 'add-account':
-        // Add account mode just shows instructions, only need back button
+      case 'select-account':
+        // Picker rows are click-to-attach, so only a back button is needed.
         return html`
           <button class="btn btn-secondary" @click=${this.handleBack}>Back</button>
         `;
       case 'edit-account':
         return html`
+          <button
+            class="btn btn-danger"
+            ?disabled=${!this.editingAccount?.id}
+            @click=${() => this.editingAccount?.id && this.handleDeleteGlobalAccount(this.editingAccount.id)}
+          >
+            Delete Account
+          </button>
+          <div style="flex: 1;"></div>
           <button class="btn btn-secondary" @click=${this.handleBack}>Cancel</button>
           <button class="btn btn-primary" @click=${this.handleSaveAccount}>Save Account</button>
         `;
@@ -1364,7 +1479,7 @@ export class LvProfileManagerDialog extends LitElement {
             </svg>
             Integration Accounts
           </div>
-          <button class="btn btn-sm" @click=${this.handleAddAccount}>
+          <button class="btn btn-sm" @click=${this.handleOpenAccountPicker}>
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="12" y1="5" x2="12" y2="19"></line>
               <line x1="5" y1="12" x2="19" y2="12"></line>
@@ -1373,22 +1488,19 @@ export class LvProfileManagerDialog extends LitElement {
           </button>
         </div>
 
-        ${this.getGlobalAccounts().length === 0
+        ${this.getAttachedAccounts().length === 0
           ? html`
-              <div class="empty-accounts warning">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align: middle; margin-right: 4px;">
-                  <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
-                  <line x1="12" y1="9" x2="12" y2="13"></line>
-                  <line x1="12" y1="17" x2="12.01" y2="17"></line>
-                </svg>
-                No integration accounts configured.
+              <div class="empty-accounts">
+                No accounts attached to this profile.
                 <br />
-                Connect accounts from the GitHub, GitLab, Azure DevOps, or Bitbucket dialogs.
+                Click "Add" to attach an integration account.
               </div>
             `
           : html`
               <div class="accounts-list">
-                ${this.getGlobalAccounts().map((account) => this.renderAccountItem(account))}
+                ${this.getAttachedAccounts().map(({ type, account }) =>
+                  this.renderAttachedAccountItem(type, account)
+                )}
               </div>
             `}
       </div>
@@ -1500,7 +1612,17 @@ export class LvProfileManagerDialog extends LitElement {
     `;
   }
 
-  private renderAccountItem(account: IntegrationAccount) {
+  /**
+   * Base renderer for an account row. `actions` is an optional template for the
+   * trailing action buttons (edit/detach); `onClick`, when provided, makes the
+   * whole row a click-to-select control (used by the account picker). The same
+   * markup is reused for attached accounts and picker rows.
+   */
+  private renderAccountItem(
+    account: IntegrationAccount,
+    actions: TemplateResult | typeof nothing = nothing,
+    onClick?: () => void
+  ) {
     const details = this.getAccountDetails(account);
     const connectionStatus = this.getAccountConnectionStatus(account.id);
     const statusTitle = {
@@ -1511,7 +1633,20 @@ export class LvProfileManagerDialog extends LitElement {
     }[connectionStatus];
 
     return html`
-      <div class="account-item">
+      <div
+        class="account-item ${onClick ? 'selectable' : ''}"
+        role=${onClick ? 'button' : nothing}
+        tabindex=${onClick ? '0' : nothing}
+        @click=${onClick ?? nothing}
+        @keydown=${onClick
+          ? (e: KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : nothing}
+      >
         ${this.renderAccountIcon(account.integrationType)}
         <div class="account-info">
           <div class="account-name">
@@ -1522,6 +1657,20 @@ export class LvProfileManagerDialog extends LitElement {
           ${details ? html`<div class="account-detail">${details}</div>` : nothing}
         </div>
         <span class="status-indicator ${connectionStatus}" title="${statusTitle}"></span>
+        ${actions}
+      </div>
+    `;
+  }
+
+  /**
+   * An account row in the profile's "Integration Accounts" list. The X button
+   * detaches the account from this profile only (it does not delete the global
+   * account); editing opens the account's Edit screen.
+   */
+  private renderAttachedAccountItem(type: IntegrationType, account: IntegrationAccount) {
+    return this.renderAccountItem(
+      account,
+      html`
         <div class="account-actions">
           <button class="action-btn" @click=${() => this.handleEditAccount(account)} title="Edit account">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1529,12 +1678,69 @@ export class LvProfileManagerDialog extends LitElement {
               <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
             </svg>
           </button>
-          <button class="action-btn delete" @click=${() => this.handleRemoveAccount(account.id)} title="Remove account">
+          <button class="action-btn delete" @click=${() => this.handleDetachAccount(type)} title="Detach from profile">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="18" y1="6" x2="6" y2="18"></line>
               <line x1="6" y1="6" x2="18" y2="18"></line>
             </svg>
           </button>
+        </div>
+      `
+    );
+  }
+
+  /**
+   * Account picker shown when attaching an account to a profile. Lists existing
+   * global accounts as click-to-attach rows, and always offers a path to connect
+   * a brand-new account via the integration dialogs.
+   */
+  private renderAccountPicker() {
+    const accounts = this.getGlobalAccounts();
+
+    return html`
+      <div class="form-content">
+        <div class="form-section">
+          ${accounts.length === 0
+            ? html`
+                <div class="empty-accounts">
+                  No integration accounts yet. Connect one below, then reopen this profile to
+                  attach it.
+                </div>
+              `
+            : html`
+                <p style="color: var(--color-text-secondary); margin-bottom: var(--spacing-md);">
+                  Select an account to attach to <strong>${this.editingProfile?.name || 'this profile'}</strong>.
+                  A profile uses one account per provider, so choosing a provider you already have
+                  attached will replace it.
+                </p>
+                <div class="accounts-list">
+                  ${accounts.map((account) =>
+                    this.renderAccountItem(account, nothing, () => this.handleAttachAccount(account))
+                  )}
+                </div>
+              `}
+
+          <div class="form-section-title" style="margin-top: var(--spacing-lg);">
+            Connect a new account
+          </div>
+          <div style="display: flex; gap: var(--spacing-sm); flex-wrap: wrap; margin-top: var(--spacing-sm);">
+            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('github')}>
+              ${this.renderAccountIcon('github')}
+              GitHub
+            </button>
+            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('gitlab')}>
+              ${this.renderAccountIcon('gitlab')}
+              GitLab
+            </button>
+            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('bitbucket')}>
+              ${this.renderAccountIcon('bitbucket')}
+              Bitbucket
+            </button>
+            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('azure-devops')}>
+              ${this.renderAccountIcon('azure-devops')}
+              Azure DevOps
+            </button>
+          </div>
         </div>
       </div>
     `;
@@ -1635,45 +1841,6 @@ export class LvProfileManagerDialog extends LitElement {
   private renderAccountForm() {
     if (!this.editingAccount) return nothing;
 
-    const isEditMode = this.viewMode === 'edit-account';
-
-    // In add mode, show message directing user to integration dialogs
-    if (!isEditMode) {
-      return html`
-        <div class="empty-state" style="padding: var(--spacing-lg);">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="width: 48px; height: 48px; opacity: 0.5; margin-bottom: var(--spacing-md);">
-            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
-            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
-          </svg>
-          <div style="font-weight: var(--font-weight-medium); margin-bottom: var(--spacing-sm);">
-            Add accounts via integration dialogs
-          </div>
-          <p style="font-size: var(--font-size-sm); color: var(--color-text-secondary); margin-bottom: var(--spacing-lg); max-width: 400px;">
-            To add a new account, use the GitHub, GitLab, Bitbucket, or Azure DevOps dialogs from the toolbar.
-            Accounts are automatically linked to your active profile when you authenticate.
-          </p>
-          <div style="display: flex; gap: var(--spacing-sm); flex-wrap: wrap; justify-content: center;">
-            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('github')}>
-              ${this.renderAccountIcon('github')}
-              GitHub
-            </button>
-            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('gitlab')}>
-              ${this.renderAccountIcon('gitlab')}
-              GitLab
-            </button>
-            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('bitbucket')}>
-              ${this.renderAccountIcon('bitbucket')}
-              Bitbucket
-            </button>
-            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('azure-devops')}>
-              ${this.renderAccountIcon('azure-devops')}
-              Azure DevOps
-            </button>
-          </div>
-        </div>
-      `;
-    }
-
     // Edit mode - show form for editing existing account metadata
     return html`
       <div class="form-group">
@@ -1735,13 +1902,45 @@ export class LvProfileManagerDialog extends LitElement {
   }
 
   private dispatchIntegrationOpen(type: IntegrationType): void {
-    this.handleBack(); // Go back to edit view
+    // Remember which provider the user is connecting and the accounts that exist
+    // now, so that when the integration dialog closes we can auto-attach the
+    // account they just connected to the profile being edited.
+    this.pendingConnectType = type;
+    this.accountIdsBeforeConnect = new Set(this.getGlobalAccounts().map((a) => a.id));
+    // Stay on the picker view: the host stacks the integration dialog on top and
+    // reveals this one again on close.
     this.dispatchEvent(
-      new CustomEvent(`open-${type === 'azure-devops' ? 'azure-devops' : type}`, {
+      new CustomEvent(`open-${type}`, {
         bubbles: true,
         composed: true,
       })
     );
+  }
+
+  /**
+   * After an integration dialog opened from the picker closes, attach the account
+   * the user just connected to the profile being edited, then return to the form
+   * so it shows as attached (ready to Save). Matches the user's intent: clicking
+   * "Connect <provider>" while attaching to a profile means "use this account".
+   */
+  private async handleRevealAfterConnect(): Promise<void> {
+    await this.loadProfiles();
+    const type = this.pendingConnectType;
+    this.pendingConnectType = null;
+    if (!type || !this.editingProfile) return;
+    // Don't override an account already attached for this provider.
+    if (this.editingProfile.defaultAccounts?.[type]) return;
+
+    const accountsOfType = this.getGlobalAccounts().filter((a) => a.integrationType === type);
+    const toAttach =
+      accountsOfType.find((a) => !this.accountIdsBeforeConnect.has(a.id)) ?? // newly connected
+      accountsOfType.find((a) => a.isDefault) ?? // the default for this provider
+      (accountsOfType.length === 1 ? accountsOfType[0] : undefined); // the only one
+
+    if (toAttach) {
+      this.setEditingProfileAccount(type, toAttach.id);
+      this.viewMode = this.editingProfile.id ? 'edit' : 'create';
+    }
   }
 
   private renderAccountConfigFields() {


### PR DESCRIPTION
Closes #198

## What was wrong

The Manage Profiles dialog's "Integration Accounts" section was wired to **global account** operations instead of the **profile↔account association** (`UnifiedProfile.defaultAccounts`):

- **Remove** deleted the account for *all* profiles instead of detaching it.
- **Add** was a dead end — no way to actually attach an account.
- The list showed *all* global accounts, never the ones attached to the profile.

…plus the follow-on flow problems found while fixing it (no way back from the auth dialog, connected account not attached, stale red status dot, × instead of ←).

## What changed

- **List**: shows only accounts attached to the profile (resolved from `defaultAccounts`, dangling ids filtered).
- **Add → picker**: attach an existing global account (one per provider; re-picking replaces), or **connect a new one**.
- **Detach** (X on the list) removes from the profile only; global **Delete account** moved to the account's Edit screen.
- **Connect-and-return**: the integration dialog stacks over the profile manager (kept mounted, demoted); closing it reveals the picker, and the account you just connected is **auto-attached**.
- **Accurate status dots**: integration dialogs now write verified connection status to the shared store, so dots are correct immediately; the profile manager no longer re-checks on reveal and clobbers it.
- **Back vs. close**: `lv-modal` gains a `backButton` mode — opened from Manage Profiles, the dialog shows a **← Back** that returns to the profile instead of a **× Close**.

No backend/Rust changes.

## Tests

- Unit: profile manager (attach/detach/replace, persistence, auto-attach, dangling ids, status not overridden on reveal), `lv-modal` back-button, GitHub dialog writes status to the **shared store** (the cross-component contract that was missing).
- E2E (`profiles-integrations.spec.ts`): attach → save persists `defaultAccounts`; **detach never calls `delete_global_account`**; connect → Back → auto-attach; Back shown (not Close) when opened from Manage Profiles.
- Full suite green: 3050 unit, 55 e2e, lint, typecheck. (`cargo fmt --check` passes; clippy unaffected — no Rust changed.)

## Test plan

1. Manage Profiles → edit a profile → **Add**.
2. Pick an existing account → it attaches; **Save Profile** persists it.
3. Or **Connect a new account → GitHub** → authorize → **← Back** → you're back on the profile with the account **attached** and a **green** dot.
4. Remove (X) an attached account → it detaches but still exists for other profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)