### PR TITLE
fix(profiles): repair integrations + profiles account workflow (#211)

### DIFF
--- a/e2e/tests/profiles-integrations-flows.spec.ts
+++ b/e2e/tests/profiles-integrations-flows.spec.ts
@@ -10,7 +10,7 @@
  */
 
 import { test, expect, Page } from '@playwright/test';
-import { setupOpenRepository, setupProfilesAndAccounts } from '../fixtures/tauri-mock';
+import { setupOpenRepository, setupProfilesAndAccounts, setupTauriMocks } from '../fixtures/tauri-mock';
 import { AppPage } from '../pages/app.page';
 import { DialogsPage } from '../pages/dialogs.page';
 import {
@@ -2532,5 +2532,230 @@ test.describe('Parity - Azure DevOps dialog', () => {
     await page.locator('lv-azure-devops-dialog button:has-text("Disconnect")').first().click();
     await waitForCommand(page, 'delete_keyring_token');
     expect((await findCommand(page, 'delete_keyring_token')).length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. No repository open — connecting accounts must still work (#211 / #1, #2)
+//
+// Previously the integration dialogs were only rendered when a repository was
+// open, but the Profile Manager (and its "Connect <provider>" buttons) are
+// reachable with no repo. Clicking Connect dead-ended and left the manager
+// demoted into a transparent, unusable state. These tests assert the connect
+// flow works without a repository.
+// ---------------------------------------------------------------------------
+
+test.describe('No repository open - connect flow', () => {
+  // Boot the app with mocks but WITHOUT opening a repository, so activeRepository
+  // stays null and the welcome screen is shown.
+  async function bootWithoutRepository(page: Page): Promise<void> {
+    await setupTauriMocks(page);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await injectCommandMock(page, {
+      get_unified_profiles_config: { version: 3, profiles: [], accounts: [], repositoryAssignments: {} },
+      get_migration_backup_info: { hasBackup: false },
+    });
+    // No repo open → the welcome screen is visible (proves the precondition).
+    await expect(page.locator('lv-welcome')).toBeVisible({ timeout: 10000 });
+  }
+
+  test('Connect GitHub from the picker opens the integration dialog with no repo open', async ({ page }) => {
+    const dialogs = new DialogsPage(page);
+    await bootWithoutRepository(page);
+
+    await openProfileManager(page, dialogs);
+
+    // New profile → account picker → Connect GitHub
+    await dialogs.profileManager.addProfileButton.click();
+    await dialogs.profileManager.attachAccountButton.click();
+    await expect(
+      page.locator('lv-profile-manager-dialog .dialog-title'),
+    ).toContainText('Attach Account');
+
+    await page
+      .locator('lv-profile-manager-dialog')
+      .getByRole('button', { name: 'GitHub', exact: true })
+      .click();
+
+    // The GitHub dialog must actually open (previously it never mounted with no
+    // repo), and the Profile Manager must be demoted behind it — not left
+    // transparent with nothing on top.
+    await expect(dialogs.github.dialog).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('lv-profile-manager-dialog[open][demoted]')).toHaveCount(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. Standalone Accounts management view (#211 / #3, #4)
+//
+// Accounts are global, not owned by a profile. The Profile Manager now exposes
+// a dedicated "Manage Accounts" view so accounts can be edited/deleted without
+// first attaching them to a profile, and "Manage Accounts" from an integration
+// dialog routes there.
+// ---------------------------------------------------------------------------
+
+test.describe('Accounts management view', () => {
+  test('opens from the profile list "Accounts" button and lists all global accounts', async ({ page }) => {
+    const dialogs = new DialogsPage(page);
+    await setupProfilesAndAccounts(page, {
+      profiles: [workProfile],
+      accounts: [githubWork, githubPersonal],
+    });
+    await injectCommandMock(page, {
+      get_unified_profiles_config: {
+        version: 3,
+        profiles: [workProfile],
+        accounts: [githubWork, githubPersonal],
+        repositoryAssignments: {},
+      },
+      get_migration_backup_info: { hasBackup: false },
+    });
+
+    await openProfileManager(page, dialogs);
+    await page
+      .locator('lv-profile-manager-dialog .dialog-footer')
+      .getByRole('button', { name: 'Accounts' })
+      .click();
+
+    await expect(
+      page.locator('lv-profile-manager-dialog .dialog-title'),
+    ).toContainText('Manage Accounts');
+    // Both global accounts are listed with edit + delete affordances.
+    await expect(
+      page.locator('lv-profile-manager-dialog .accounts-list .account-item'),
+    ).toHaveCount(2);
+    await expect(
+      page.locator('lv-profile-manager-dialog .account-actions .action-btn.delete'),
+    ).toHaveCount(2);
+  });
+
+  test('deleting a global account from the accounts view stays in the view and removes it', async ({ page }) => {
+    const dialogs = new DialogsPage(page);
+    await setupProfilesAndAccounts(page, {
+      profiles: [workProfile],
+      accounts: [githubWork, githubPersonal],
+    });
+    await injectCommandMock(page, {
+      get_unified_profiles_config: {
+        version: 3,
+        profiles: [workProfile],
+        accounts: [githubWork, githubPersonal],
+        repositoryAssignments: {},
+      },
+      get_migration_backup_info: { hasBackup: false },
+      delete_global_account: null,
+    });
+    await autoConfirmDialogs(page);
+
+    await openProfileManager(page, dialogs);
+    await page
+      .locator('lv-profile-manager-dialog .dialog-footer')
+      .getByRole('button', { name: 'Accounts' })
+      .click();
+    await expect(
+      page.locator('lv-profile-manager-dialog .accounts-list .account-item'),
+    ).toHaveCount(2);
+
+    // Backend: after delete the config no longer contains the first account.
+    await startCommandCaptureWithMocks(page, {
+      delete_global_account: null,
+      get_unified_profiles_config: {
+        version: 3,
+        profiles: [workProfile],
+        accounts: [githubPersonal],
+        repositoryAssignments: {},
+      },
+    });
+
+    await page
+      .locator('lv-profile-manager-dialog .account-actions .action-btn.delete')
+      .first()
+      .click();
+    await waitForCommand(page, 'delete_global_account');
+
+    // Still on the accounts view, now showing only the remaining account.
+    await expect(
+      page.locator('lv-profile-manager-dialog .dialog-title'),
+    ).toContainText('Manage Accounts');
+    await expect(
+      page.locator('lv-profile-manager-dialog .accounts-list .account-item'),
+    ).toHaveCount(1);
+  });
+
+  test('"Manage Accounts" from an integration dialog lands on the accounts view', async ({ page }) => {
+    const dialogs = new DialogsPage(page);
+    await setupProfilesAndAccounts(page, {
+      profiles: [workProfile],
+      accounts: [githubWork, githubPersonal],
+      connectedAccounts: ['account-github-work'],
+    });
+    await injectCommandMock(page, {
+      get_unified_profiles_config: {
+        version: 3,
+        profiles: [workProfile],
+        accounts: [githubWork, githubPersonal],
+        repositoryAssignments: {},
+      },
+      get_migration_backup_info: { hasBackup: false },
+      load_unified_profile_for_repository: workProfile,
+    });
+
+    const app = new AppPage(page);
+    await app.executeCommand('GitHub');
+    await expect(dialogs.github.dialog).toBeVisible();
+
+    await page.locator('lv-github-dialog lv-account-selector .selector-btn').click();
+    await page
+      .locator('lv-github-dialog lv-account-selector .dropdown-action', { hasText: 'Manage Accounts' })
+      .click();
+
+    // The Profile Manager opens directly on the account-management view (not the
+    // profile list) and is on top (not demoted behind the integration dialog).
+    await expect(page.locator('lv-profile-manager-dialog[open] .dialog-overlay')).toBeVisible();
+    await expect(page.locator('lv-profile-manager-dialog[open][demoted]')).toHaveCount(0);
+    await expect(
+      page.locator('lv-profile-manager-dialog .dialog-title'),
+    ).toContainText('Manage Accounts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 14. Unsaved-changes guard on dialog dismissal (#211 / #6)
+// ---------------------------------------------------------------------------
+
+test.describe('Unsaved-changes guard', () => {
+  test('closing the dialog with unsaved profile edits prompts to confirm', async ({ page }) => {
+    const dialogs = new DialogsPage(page);
+    await setupProfilesAndAccounts(page, {
+      profiles: [workProfile],
+      accounts: [],
+    });
+    await injectCommandMock(page, {
+      get_unified_profiles_config: {
+        version: 3,
+        profiles: [workProfile],
+        accounts: [],
+        repositoryAssignments: {},
+      },
+      get_migration_backup_info: { hasBackup: false },
+    });
+
+    await openProfileManager(page, dialogs);
+    await page.locator('.profile-item').first().click();
+
+    // Make the form dirty
+    await page.getByPlaceholder(/Work, Personal/i).fill('Dirty Name');
+
+    // Auto-confirm the discard prompt, then dismiss via the X button.
+    await autoConfirmDialogs(page);
+    await startCommandCapture(page);
+    await page.locator('lv-profile-manager-dialog .close-btn').click();
+
+    // A confirm dialog was shown (the guard fired) and the dialog then closed.
+    await waitForCommand(page, 'plugin:dialog|message');
+    const confirms = await findCommand(page, 'plugin:dialog|message');
+    expect(confirms.length).toBeGreaterThan(0);
+    await expect(page.locator('lv-profile-manager-dialog[open]')).toHaveCount(0, { timeout: 5000 });
   });
 });

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -575,6 +575,9 @@ export class AppShell extends LitElement {
 
   // Profile Manager dialog
   @state() private showProfileManager = false;
+  // Which view the Profile Manager should open to. 'accounts' is set when the
+  // user picks "Manage Accounts" from an integration dialog; reset on close.
+  @state() private profileManagerView: '' | 'accounts' = '';
 
   // Migration dialog
   @state() private showMigrationDialog = false;
@@ -1739,6 +1742,17 @@ export class AppShell extends LitElement {
       this.refreshQueued = false;
       await this.handleRefresh();
     }
+  }
+
+  // "Manage Accounts" from an integration dialog: close the integration dialogs
+  // and open the Profile Manager directly on its account-management view.
+  private handleManageAccounts(): void {
+    this.showGitHub = false;
+    this.showGitLab = false;
+    this.showBitbucket = false;
+    this.showAzureDevOps = false;
+    this.profileManagerView = 'accounts';
+    this.showProfileManager = true;
   }
 
   private async handleRefreshAccount(e: CustomEvent<{ accountId: string }>): Promise<void> {
@@ -2981,75 +2995,44 @@ export class AppShell extends LitElement {
         ></lv-credentials-dialog>
       ` : ''}
 
-      ${this.activeRepository ? html`
-        <lv-github-dialog
-          ?open=${this.showGitHub}
-          ?backButton=${this.showProfileManager}
-          .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showGitHub = false; }}
-          @manage-accounts=${() => {
-            this.showGitHub = false;
-            this.showGitLab = false;
-            this.showBitbucket = false;
-            this.showAzureDevOps = false;
-            this.showProfileManager = true;
-          }}
-        ></lv-github-dialog>
-      ` : ''}
+      <lv-github-dialog
+        ?open=${this.showGitHub}
+        ?backButton=${this.showProfileManager}
+        .repositoryPath=${this.activeRepository?.repository.path ?? ''}
+        @close=${() => { this.showGitHub = false; }}
+        @manage-accounts=${this.handleManageAccounts}
+      ></lv-github-dialog>
 
-      ${this.activeRepository ? html`
-        <lv-gitlab-dialog
-          ?open=${this.showGitLab}
-          ?backButton=${this.showProfileManager}
-          .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showGitLab = false; }}
-          @manage-accounts=${() => {
-            this.showGitHub = false;
-            this.showGitLab = false;
-            this.showBitbucket = false;
-            this.showAzureDevOps = false;
-            this.showProfileManager = true;
-          }}
-        ></lv-gitlab-dialog>
-      ` : ''}
+      <lv-gitlab-dialog
+        ?open=${this.showGitLab}
+        ?backButton=${this.showProfileManager}
+        .repositoryPath=${this.activeRepository?.repository.path ?? ''}
+        @close=${() => { this.showGitLab = false; }}
+        @manage-accounts=${this.handleManageAccounts}
+      ></lv-gitlab-dialog>
 
-      ${this.activeRepository ? html`
-        <lv-bitbucket-dialog
-          ?open=${this.showBitbucket}
-          ?backButton=${this.showProfileManager}
-          .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showBitbucket = false; }}
-          @manage-accounts=${() => {
-            this.showGitHub = false;
-            this.showGitLab = false;
-            this.showBitbucket = false;
-            this.showAzureDevOps = false;
-            this.showProfileManager = true;
-          }}
-        ></lv-bitbucket-dialog>
-      ` : ''}
+      <lv-bitbucket-dialog
+        ?open=${this.showBitbucket}
+        ?backButton=${this.showProfileManager}
+        .repositoryPath=${this.activeRepository?.repository.path ?? ''}
+        @close=${() => { this.showBitbucket = false; }}
+        @manage-accounts=${this.handleManageAccounts}
+      ></lv-bitbucket-dialog>
 
-      ${this.activeRepository ? html`
-        <lv-azure-devops-dialog
-          ?open=${this.showAzureDevOps}
-          ?backButton=${this.showProfileManager}
-          .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showAzureDevOps = false; }}
-          @manage-accounts=${() => {
-            this.showGitHub = false;
-            this.showGitLab = false;
-            this.showBitbucket = false;
-            this.showAzureDevOps = false;
-            this.showProfileManager = true;
-          }}
-        ></lv-azure-devops-dialog>
-      ` : ''}
+      <lv-azure-devops-dialog
+        ?open=${this.showAzureDevOps}
+        ?backButton=${this.showProfileManager}
+        .repositoryPath=${this.activeRepository?.repository.path ?? ''}
+        @close=${() => { this.showAzureDevOps = false; }}
+        @manage-accounts=${this.handleManageAccounts}
+      ></lv-azure-devops-dialog>
 
       <lv-profile-manager-dialog
         ?open=${this.showProfileManager}
         ?demoted=${this.integrationDialogOpen}
         .repoPath=${this.activeRepository?.repository.path ?? ''}
-        @close=${() => { this.showProfileManager = false; }}
+        .initialView=${this.profileManagerView}
+        @close=${() => { this.showProfileManager = false; this.profileManagerView = ''; }}
         @open-github=${() => { this.showGitHub = true; }}
         @open-gitlab=${() => { this.showGitLab = true; }}
         @open-bitbucket=${() => { this.showBitbucket = true; }}

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -514,5 +514,22 @@ describe('lv-azure-devops-dialog', () => {
       expect(errorMsg).to.not.be.null;
       expect(errorMsg!.textContent).to.include('Organization not found');
     });
+
+    it('surfaces a backend error when repo detection fails (not silent)', async () => {
+      const origMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'detect_ado_repo') throw new Error('ado detect boom');
+        return origMock(command, args);
+      };
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      expect((el as unknown as { error: string | null }).error).to.include('ado detect boom');
+    });
   });
 });

--- a/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
@@ -21,6 +21,7 @@ const keyringStore = new Map<string, string>();
 
 import { expect, fixture, html } from '@open-wc/testing';
 import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
 import { createEmptyIntegrationAccount } from '../../../types/unified-profile.types.ts';
 import type { IntegrationAccount } from '../../../types/unified-profile.types.ts';
 import '../lv-bitbucket-dialog.ts';
@@ -505,6 +506,52 @@ describe('lv-bitbucket-dialog', () => {
       const errorMsg = el.shadowRoot!.querySelector('.error');
       expect(errorMsg).to.not.be.null;
       expect(errorMsg!.textContent).to.include('Bitbucket API rate limited');
+    });
+
+    it('surfaces a backend error when repo detection fails (not silent)', async () => {
+      const origMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'detect_bitbucket_repo') throw new Error('bitbucket detect boom');
+        return origMock(command, args);
+      };
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      expect((el as unknown as { error: string | null }).error).to.include('bitbucket detect boom');
+    });
+  });
+
+  describe('OAuth completes after dialog closed', () => {
+    it('persists the account and surfaces a toast instead of failing silently', async () => {
+      connectionResponse = mockConnectedStatus;
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${false}></lv-bitbucket-dialog>
+      `);
+      await el.updateComplete;
+
+      uiStore.getState().toasts.length = 0;
+      invokeHistory.length = 0;
+
+      window.dispatchEvent(
+        new CustomEvent('oauth-complete', {
+          detail: { provider: 'bitbucket', tokens: { accessToken: 'bbp_oauth' } },
+        })
+      );
+      await new Promise((r) => setTimeout(r, 200));
+      await el.updateComplete;
+
+      const persisted = invokeHistory.filter(
+        (h) => h.command === 'save_global_account' || h.command === 'store_keyring_token'
+      );
+      expect(persisted.length).to.be.greaterThan(0);
+
+      const toasts = uiStore.getState().toasts;
+      expect(toasts.some((t) => t.type === 'success' && /Connected Bitbucket/.test(t.message))).to.be.true;
     });
   });
 });

--- a/src/components/dialogs/__tests__/lv-github-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-github-dialog.test.ts
@@ -21,6 +21,7 @@ const keyringStore = new Map<string, string>();
 
 import { expect, fixture, html } from '@open-wc/testing';
 import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
 import { createEmptyIntegrationAccount } from '../../../types/unified-profile.types.ts';
 import type { IntegrationAccount } from '../../../types/unified-profile.types.ts';
 import '../lv-github-dialog.ts';
@@ -632,6 +633,56 @@ describe('lv-github-dialog', () => {
       const errorMsg = el.shadowRoot!.querySelector('.error-message');
       expect(errorMsg).to.not.be.null;
       expect(errorMsg!.textContent).to.include('Network timeout');
+    });
+
+    it('surfaces a backend error when repo detection fails (not silent)', async () => {
+      const origMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'detect_github_repo') throw new Error('repo detect boom');
+        return origMock(command, args);
+      };
+
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      const errorMsg = el.shadowRoot!.querySelector('.error-message');
+      expect(errorMsg).to.not.be.null;
+      expect(errorMsg!.textContent).to.include('repo detect boom');
+    });
+  });
+
+  describe('OAuth completes after dialog closed', () => {
+    it('persists the account and surfaces a toast instead of failing silently', async () => {
+      connectionResponse = mockConnectedStatus;
+      // Dialog is mounted but closed — the window OAuth listener is still active.
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${false}></lv-github-dialog>
+      `);
+      await el.updateComplete;
+
+      uiStore.getState().toasts.length = 0;
+      invokeHistory.length = 0;
+
+      window.dispatchEvent(
+        new CustomEvent('oauth-complete', {
+          detail: { provider: 'github', tokens: { accessToken: 'ghp_oauth_token' } },
+        })
+      );
+      await new Promise((r) => setTimeout(r, 200));
+      await el.updateComplete;
+
+      // The auth was still persisted (the user completed it — don't lose it),
+      // either by creating a new account or storing the token on an existing one.
+      const persisted = invokeHistory.filter(
+        (h) => h.command === 'save_global_account' || h.command === 'store_keyring_token'
+      );
+      expect(persisted.length).to.be.greaterThan(0);
+
+      // And a success toast was shown since the inline status is invisible when closed.
+      const toasts = uiStore.getState().toasts;
+      expect(toasts.some((t) => t.type === 'success' && /Connected GitHub/.test(t.message))).to.be.true;
     });
   });
 });

--- a/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
@@ -21,6 +21,7 @@ const keyringStore = new Map<string, string>();
 
 import { expect, fixture, html } from '@open-wc/testing';
 import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
 import { createEmptyIntegrationAccount } from '../../../types/unified-profile.types.ts';
 import type { IntegrationAccount } from '../../../types/unified-profile.types.ts';
 import '../lv-gitlab-dialog.ts';
@@ -514,6 +515,56 @@ describe('lv-gitlab-dialog', () => {
       const errorMsg = el.shadowRoot!.querySelector('.error');
       expect(errorMsg).to.not.be.null;
       expect(errorMsg!.textContent).to.include('GitLab instance unreachable');
+    });
+
+    it('surfaces a backend error when repo detection fails (not silent)', async () => {
+      const origMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'detect_gitlab_repo') throw new Error('gitlab detect boom');
+        return origMock(command, args);
+      };
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      expect((el as unknown as { error: string | null }).error).to.include('gitlab detect boom');
+    });
+  });
+
+  describe('OAuth completes after dialog closed', () => {
+    it('persists the account and surfaces a toast instead of failing silently', async () => {
+      connectionResponse = mockConnectedStatus;
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${false}></lv-gitlab-dialog>
+      `);
+      await el.updateComplete;
+
+      uiStore.getState().toasts.length = 0;
+      invokeHistory.length = 0;
+
+      window.dispatchEvent(
+        new CustomEvent('oauth-complete', {
+          detail: {
+            provider: 'gitlab',
+            tokens: { accessToken: 'glpat_oauth' },
+            instanceUrl: 'https://gitlab.com',
+          },
+        })
+      );
+      await new Promise((r) => setTimeout(r, 200));
+      await el.updateComplete;
+
+      const persisted = invokeHistory.filter(
+        (h) => h.command === 'save_global_account' || h.command === 'store_keyring_token'
+      );
+      expect(persisted.length).to.be.greaterThan(0);
+
+      const toasts = uiStore.getState().toasts;
+      expect(toasts.some((t) => t.type === 'success' && /Connected GitLab/.test(t.message))).to.be.true;
     });
   });
 });

--- a/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
@@ -1787,4 +1787,35 @@ describe('lv-profile-manager-dialog', () => {
       expect(closeFired).to.be.true;
     });
   });
+
+  // ── Pending connect intent cleanup ─────────────────────────────────────────
+  describe('connect intent cleanup', () => {
+    it('clears a pending connect intent when the dialog is closed', async () => {
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+
+      // Open the picker and click a "Connect a new account" provider button,
+      // which records a pending connect intent.
+      const addBtn = Array.from(
+        el.shadowRoot!.querySelector('.accounts-section')!.querySelectorAll('button')
+      ).find((b) => b.textContent?.trim() === 'Add') as HTMLButtonElement;
+      addBtn.click();
+      await el.updateComplete;
+
+      const githubConnect = Array.from(
+        el.shadowRoot!.querySelectorAll('.form-section .btn.btn-sm')
+      ).find((b) => b.textContent?.trim() === 'GitHub') as HTMLButtonElement;
+      githubConnect.click();
+      await el.updateComplete;
+
+      const withPrivate = el as unknown as { pendingConnectType: string | null };
+      expect(withPrivate.pendingConnectType).to.equal('github');
+
+      // Closing the dialog must drop the pending intent so it can't auto-attach later.
+      (el.shadowRoot!.querySelector('.close-btn') as HTMLButtonElement).click();
+      await el.updateComplete;
+      expect(withPrivate.pendingConnectType).to.equal(null);
+    });
+  });
 });

--- a/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
@@ -25,6 +25,7 @@ let mockInvoke: MockInvoke = () => Promise.resolve(null);
 import { expect, fixture, html } from '@open-wc/testing';
 import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
 import { repositoryStore } from '../../../stores/repository.store.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
 import type { UnifiedProfile, IntegrationAccount } from '../../../types/unified-profile.types.ts';
 import { PROFILE_COLORS } from '../../../types/unified-profile.types.ts';
 
@@ -1596,6 +1597,194 @@ describe('lv-profile-manager-dialog', () => {
 
       const checkbox = el.shadowRoot!.querySelector('.checkbox-row input[type="checkbox"]') as HTMLInputElement;
       expect(checkbox.checked).to.be.true;
+    });
+  });
+
+  // ── Standalone Accounts view (Manage Accounts) ─────────────────────────────
+  describe('accounts manager view', () => {
+    function getAccountsButton(el: LvProfileManagerDialog): HTMLButtonElement {
+      return Array.from(
+        el.shadowRoot!.querySelectorAll('.dialog-footer .btn-secondary')
+      ).find((b) => b.textContent?.trim() === 'Accounts') as HTMLButtonElement;
+    }
+
+    it('opens the accounts view from the list footer "Accounts" button', async () => {
+      const el = await renderDialog();
+      getAccountsButton(el).click();
+      await el.updateComplete;
+
+      const title = el.shadowRoot!.querySelector('.dialog-title');
+      expect(title!.textContent).to.include('Manage Accounts');
+      // Lists every global account (both test accounts) with edit/delete actions
+      const rows = el.shadowRoot!.querySelectorAll('.accounts-list .account-item');
+      expect(rows.length).to.equal(2);
+      const editBtns = el.shadowRoot!.querySelectorAll('.account-actions .action-btn:not(.delete)');
+      const deleteBtns = el.shadowRoot!.querySelectorAll('.account-actions .action-btn.delete');
+      expect(editBtns.length).to.equal(2);
+      expect(deleteBtns.length).to.equal(2);
+    });
+
+    it('lands on the accounts view when opened with initialView="accounts"', async () => {
+      const el = await fixture<LvProfileManagerDialog>(
+        html`<lv-profile-manager-dialog
+          .open=${true}
+          .repoPath=${'/test/repo'}
+          .initialView=${'accounts'}
+        ></lv-profile-manager-dialog>`
+      );
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      const title = el.shadowRoot!.querySelector('.dialog-title');
+      expect(title!.textContent).to.include('Manage Accounts');
+    });
+
+    it('offers connect-new buttons for every provider in the accounts view', async () => {
+      const el = await renderDialog();
+      getAccountsButton(el).click();
+      await el.updateComplete;
+
+      const labels = Array.from(
+        el.shadowRoot!.querySelectorAll('.form-section .btn.btn-sm')
+      ).map((b) => b.textContent?.trim());
+      expect(labels).to.include('GitHub');
+      expect(labels).to.include('GitLab');
+      expect(labels).to.include('Bitbucket');
+      expect(labels).to.include('Azure DevOps');
+    });
+
+    it('dispatches open-<provider> when a connect button is clicked from the accounts view', async () => {
+      const el = await renderDialog();
+      getAccountsButton(el).click();
+      await el.updateComplete;
+
+      let opened = false;
+      el.addEventListener('open-github', () => { opened = true; });
+      const githubBtn = Array.from(
+        el.shadowRoot!.querySelectorAll('.form-section .btn.btn-sm')
+      ).find((b) => b.textContent?.trim() === 'GitHub') as HTMLButtonElement;
+      githubBtn.click();
+      await el.updateComplete;
+
+      expect(opened).to.be.true;
+    });
+
+    it('edits an account from the accounts view and returns to it on Back', async () => {
+      const el = await renderDialog();
+      getAccountsButton(el).click();
+      await el.updateComplete;
+
+      const editBtn = el.shadowRoot!.querySelector(
+        '.account-actions .action-btn:not(.delete)'
+      ) as HTMLButtonElement;
+      editBtn.click();
+      await el.updateComplete;
+      expect(el.shadowRoot!.querySelector('.dialog-title')!.textContent).to.include('Edit Account');
+
+      const backBtn = el.shadowRoot!.querySelector('.back-btn') as HTMLButtonElement;
+      backBtn.click();
+      await el.updateComplete;
+      // Returns to the accounts view, not the profile list
+      expect(el.shadowRoot!.querySelector('.dialog-title')!.textContent).to.include('Manage Accounts');
+    });
+
+    it('deletes a global account from the accounts view and stays in the view', async () => {
+      const el = await renderDialog();
+      getAccountsButton(el).click();
+      await el.updateComplete;
+
+      clearHistory();
+      const deleteBtn = el.shadowRoot!.querySelector(
+        '.account-actions .action-btn.delete'
+      ) as HTMLButtonElement;
+      deleteBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      expect(findCommands('delete_global_account').length).to.equal(1);
+      // Still on the accounts view after deleting
+      expect(el.shadowRoot!.querySelector('.dialog-title')!.textContent).to.include('Manage Accounts');
+    });
+  });
+
+  // ── Replacing a same-provider account (#5) ─────────────────────────────────
+  describe('same-provider account replacement', () => {
+    it('shows an info toast and replaces when attaching a second account of the same provider', async () => {
+      const gh1 = makeAccount({ id: 'gh1', name: 'GH One', integrationType: 'github' });
+      const gh2 = makeAccount({ id: 'gh2', name: 'GH Two', integrationType: 'github' });
+      const profile = makeProfile({ id: 'p1', name: 'P1', defaultAccounts: { github: 'gh1' } });
+      useConfig([profile], [gh1, gh2]);
+
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+
+      // Open the picker and choose the OTHER github account
+      const addBtn = Array.from(
+        el.shadowRoot!.querySelector('.accounts-section')!.querySelectorAll('button')
+      ).find((b) => b.textContent?.trim() === 'Add') as HTMLButtonElement;
+      addBtn.click();
+      await el.updateComplete;
+
+      uiStore.getState().toasts.length = 0;
+      const rows = el.shadowRoot!.querySelectorAll('.account-item.selectable');
+      const gh2Row = Array.from(rows).find((r) => r.textContent?.includes('GH Two'));
+      (gh2Row as HTMLElement).click();
+      await el.updateComplete;
+
+      // Toast surfaced about the replacement
+      const toasts = uiStore.getState().toasts;
+      expect(toasts.some((t) => t.message.includes('Replaced'))).to.be.true;
+
+      // The profile form now shows the replacement account, not the original
+      const attached = el.shadowRoot!.querySelector('.accounts-section .accounts-list .account-name');
+      expect(attached!.textContent).to.include('GH Two');
+    });
+  });
+
+  // ── Unsaved-changes guard on dismissal (#6) ────────────────────────────────
+  describe('unsaved-changes guard', () => {
+    it('prompts to confirm when closing the dialog with unsaved profile edits', async () => {
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+
+      // Make the form dirty
+      const nameInput = el.shadowRoot!.querySelector('input[type="text"]') as HTMLInputElement;
+      nameInput.value = 'Changed';
+      nameInput.dispatchEvent(new Event('input'));
+      await el.updateComplete;
+
+      clearHistory();
+      let closeFired = false;
+      el.addEventListener('close', () => { closeFired = true; });
+
+      const closeBtn = el.shadowRoot!.querySelector('.close-btn') as HTMLButtonElement;
+      closeBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      // A confirm dialog was shown, and (mock answers 'Ok') the dialog closed
+      expect(findCommands('plugin:dialog|message').length).to.equal(1);
+      expect(closeFired).to.be.true;
+    });
+
+    it('does not prompt when closing without unsaved edits', async () => {
+      const el = await renderDialog();
+      (el.shadowRoot!.querySelectorAll('.profile-item')[0] as HTMLElement).click();
+      await el.updateComplete;
+
+      clearHistory();
+      let closeFired = false;
+      el.addEventListener('close', () => { closeFired = true; });
+
+      const closeBtn = el.shadowRoot!.querySelector('.close-btn') as HTMLButtonElement;
+      closeBtn.click();
+      await el.updateComplete;
+
+      expect(findCommands('plugin:dialog|message').length).to.equal(0);
+      expect(closeFired).to.be.true;
     });
   });
 });

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -881,6 +881,10 @@ export class LvAzureDevOpsDialog extends LitElement {
       if (this.connectionStatus?.connected) {
         await this.loadAllData();
       }
+    } else if (!result.success) {
+      // A genuine backend failure (not merely "this isn't an Azure DevOps repo",
+      // which surfaces as success with null data) must not fail silently.
+      this.error = result.error?.message ?? 'Failed to detect Azure DevOps repository';
     }
   }
 

--- a/src/components/dialogs/lv-bitbucket-dialog.ts
+++ b/src/components/dialogs/lv-bitbucket-dialog.ts
@@ -845,6 +845,10 @@ export class LvBitbucketDialog extends LitElement {
       if (this.connectionStatus?.connected) {
         await this.loadAllData();
       }
+    } else if (!result.success) {
+      // A genuine backend failure (not merely "this isn't a Bitbucket repo",
+      // which surfaces as success with null data) must not fail silently.
+      this.error = result.error?.message ?? 'Failed to detect Bitbucket repository';
     }
   }
 
@@ -1061,6 +1065,10 @@ export class LvBitbucketDialog extends LitElement {
    * Handle OAuth completion
    */
   private async handleOAuthComplete(tokens: OAuthTokenResponse): Promise<void> {
+    // OAuth can complete after the dialog was closed; still persist the account
+    // but surface a toast instead of the (invisible) inline status.
+    const wasOpen = this.open;
+
     this.isLoading = true;
     this.error = null;
 
@@ -1146,8 +1154,17 @@ export class LvBitbucketDialog extends LitElement {
       this.connectionStatus = verifyResult.data;
       this.oauthState = { status: 'idle' };
 
+      // If the dialog was closed before OAuth completed, surface a toast so the
+      // connection isn't a silent no-op.
+      if (!wasOpen) {
+        showToast(
+          user?.username ? `Connected Bitbucket account @${user.username}` : 'Connected Bitbucket account',
+          'success'
+        );
+      }
+
       // Load data if connected and repo detected
-      if (this.connectionStatus?.connected && this.detectedRepo) {
+      if (wasOpen && this.connectionStatus?.connected && this.detectedRepo) {
         await this.loadAllData();
       }
     } catch (err) {

--- a/src/components/dialogs/lv-github-dialog.ts
+++ b/src/components/dialogs/lv-github-dialog.ts
@@ -1042,6 +1042,10 @@ export class LvGitHubDialog extends LitElement {
           this.loadReleases(),
         ]);
       }
+    } else if (!result.success) {
+      // A genuine backend failure (not merely "this isn't a GitHub repo", which
+      // surfaces as success with null data) must not fail silently.
+      this.error = result.error?.message ?? 'Failed to detect GitHub repository';
     }
   }
 
@@ -1178,6 +1182,12 @@ export class LvGitHubDialog extends LitElement {
     });
     if (provider !== 'github') return;
 
+    // The OAuth callback arrives via a window event and can fire after the user
+    // has closed the dialog. We still persist the account (the user completed
+    // auth — don't throw it away), but the dialog's inline status is invisible
+    // when closed, so remember this to surface a toast instead.
+    const wasOpen = this.open;
+
     this.isLoading = true;
     this.error = null;
 
@@ -1185,7 +1195,7 @@ export class LvGitHubDialog extends LitElement {
       // IMPORTANT: Ensure profiles are loaded before trying to save the account
       // The OAuth callback fires via window event and may complete before loadInitialData
       await unifiedProfileService.loadUnifiedProfiles();
-      if (this.repositoryPath) {
+      if (wasOpen && this.repositoryPath) {
         await unifiedProfileService.loadUnifiedProfileForRepository(this.repositoryPath);
       }
 
@@ -1242,8 +1252,17 @@ export class LvGitHubDialog extends LitElement {
       this.syncSharedConnectionStatus(true);
       this.oauthState = { status: 'idle' };
 
+      // If the dialog was closed before OAuth completed, its inline status is
+      // not visible — surface a toast so the connection isn't a silent no-op.
+      if (!wasOpen) {
+        showToast(
+          user?.login ? `Connected GitHub account @${user.login}` : 'Connected GitHub account',
+          'success'
+        );
+      }
+
       // Load data if connected and repo detected
-      if (this.connectionStatus?.connected && this.detectedRepo) {
+      if (wasOpen && this.connectionStatus?.connected && this.detectedRepo) {
         await Promise.all([
           this.loadPullRequests(tokens.accessToken),
           this.loadWorkflowRuns(tokens.accessToken),

--- a/src/components/dialogs/lv-gitlab-dialog.ts
+++ b/src/components/dialogs/lv-gitlab-dialog.ts
@@ -866,6 +866,10 @@ export class LvGitLabDialog extends LitElement {
       if (this.connectionStatus?.connected) {
         await this.loadAllData();
       }
+    } else if (!result.success) {
+      // A genuine backend failure (not merely "this isn't a GitLab repo", which
+      // surfaces as success with null data) must not fail silently.
+      this.error = result.error?.message ?? 'Failed to detect GitLab repository';
     }
   }
 
@@ -1114,6 +1118,10 @@ export class LvGitLabDialog extends LitElement {
       currentInstanceUrl: this.instanceUrlInput,
     });
 
+    // OAuth can complete after the dialog was closed; still persist the account
+    // but surface a toast instead of the (invisible) inline status.
+    const wasOpen = this.open;
+
     this.isLoading = true;
     this.error = null;
 
@@ -1221,8 +1229,17 @@ export class LvGitLabDialog extends LitElement {
       this.connectionStatus = verifyResult.data;
       this.oauthState = { status: 'idle' };
 
+      // If the dialog was closed before OAuth completed, surface a toast so the
+      // connection isn't a silent no-op.
+      if (!wasOpen) {
+        showToast(
+          user?.username ? `Connected GitLab account @${user.username}` : 'Connected GitLab account',
+          'success'
+        );
+      }
+
       // Load data if connected and repo detected
-      if (this.connectionStatus?.connected && this.detectedRepo) {
+      if (wasOpen && this.connectionStatus?.connected && this.detectedRepo) {
         await this.loadAllData();
       }
     } catch (err) {

--- a/src/components/dialogs/lv-profile-manager-dialog.ts
+++ b/src/components/dialogs/lv-profile-manager-dialog.ts
@@ -835,6 +835,10 @@ export class LvProfileManagerDialog extends LitElement {
     this.editingAccount = null;
     this.profileFormDirty = false;
     this.accountFormDirty = false;
+    // Drop any in-flight "connect a new account" intent so it can't auto-attach
+    // to an unrelated profile the next time the dialog is revealed.
+    this.pendingConnectType = null;
+    this.accountIdsBeforeConnect = new Set();
     this.dispatchEvent(new CustomEvent('close'));
   }
 

--- a/src/components/dialogs/lv-profile-manager-dialog.ts
+++ b/src/components/dialogs/lv-profile-manager-dialog.ts
@@ -14,7 +14,7 @@ import { PROFILE_COLORS, ACCOUNT_COLORS, INTEGRATION_TYPE_NAMES } from '../../ty
 import { showConfirm } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 
-type ViewMode = 'list' | 'edit' | 'create' | 'select-account' | 'edit-account' | 'assign-repos';
+type ViewMode = 'list' | 'edit' | 'create' | 'select-account' | 'edit-account' | 'assign-repos' | 'accounts';
 
 @customElement('lv-profile-manager-dialog')
 export class LvProfileManagerDialog extends LitElement {
@@ -608,6 +608,13 @@ export class LvProfileManagerDialog extends LitElement {
    * off — no fragile "return" state to lose across an auth round trip.
    */
   @property({ type: Boolean, reflect: true }) demoted = false;
+  /**
+   * When the dialog is opened to manage integration accounts (e.g. via the
+   * "Manage Accounts" action in an integration dialog), the host sets this to
+   * 'accounts' so we land on the account-management view instead of the profile
+   * list. Cleared by the host on close.
+   */
+  @property({ type: String }) initialView: '' | 'accounts' = '';
 
   @state() private viewMode: ViewMode = 'list';
   @state() private profiles: UnifiedProfile[] = [];
@@ -622,6 +629,12 @@ export class LvProfileManagerDialog extends LitElement {
   @state() private backupInfo: MigrationBackupInfo | null = null;
   @state() private showBackupSection = false;
   @state() private isRestoringBackup = false;
+  // Tracks unsaved edits so we can warn before discarding them (back/close).
+  @state() private profileFormDirty = false;
+  @state() private accountFormDirty = false;
+  // Where the account edit form should return to (it can be reached from the
+  // profile form or from the standalone Accounts view).
+  private accountReturnView: ViewMode = 'edit';
 
   private unsubscribeStore?: () => void;
   private unsubscribeRepoStore?: () => void;
@@ -682,6 +695,14 @@ export class LvProfileManagerDialog extends LitElement {
       this.handleBack();
     }
   };
+
+  willUpdate(changedProperties: Map<string, unknown>): void {
+    // Land on the requested view before render so opening doesn't flash the
+    // list view first (and avoids a redundant update if set in updated()).
+    if (changedProperties.has('open') && this.open) {
+      this.viewMode = this.initialView === 'accounts' ? 'accounts' : 'list';
+    }
+  }
 
   updated(changedProperties: Map<string, unknown>): void {
     if (changedProperties.has('open') && this.open) {
@@ -781,11 +802,39 @@ export class LvProfileManagerDialog extends LitElement {
     }
   }
 
+  /**
+   * Whether there are unsaved edits to a profile or account form. Used to warn
+   * before the whole dialog is dismissed (X / overlay / Escape). The explicit
+   * Cancel/Back controls intentionally discard without prompting.
+   */
+  private isFormDirty(): boolean {
+    return (
+      (this.profileFormDirty && !!this.editingProfile) ||
+      (this.accountFormDirty && !!this.editingAccount)
+    );
+  }
+
   private handleClose(): void {
+    if (this.isFormDirty()) {
+      void showConfirm(
+        'Discard changes?',
+        'You have unsaved changes. Are you sure you want to discard them?',
+        'warning'
+      ).then((confirmed) => {
+        if (confirmed) this.performClose();
+      });
+      return;
+    }
+    this.performClose();
+  }
+
+  private performClose(): void {
     this.open = false;
     this.viewMode = 'list';
     this.editingProfile = null;
     this.editingAccount = null;
+    this.profileFormDirty = false;
+    this.accountFormDirty = false;
     this.dispatchEvent(new CustomEvent('close'));
   }
 
@@ -800,11 +849,13 @@ export class LvProfileManagerDialog extends LitElement {
       color: PROFILE_COLORS[0],
       defaultAccounts: {},
     };
+    this.profileFormDirty = false;
     this.viewMode = 'create';
   }
 
   private handleEdit(profile: UnifiedProfile): void {
     this.editingProfile = { ...profile, defaultAccounts: { ...profile.defaultAccounts } };
+    this.profileFormDirty = false;
     this.viewMode = 'edit';
   }
 
@@ -818,19 +869,33 @@ export class LvProfileManagerDialog extends LitElement {
       isDefault: false, // Don't copy default status
       defaultAccounts: { ...profile.defaultAccounts }, // Copy default account preferences
     };
+    this.profileFormDirty = false;
     this.viewMode = 'create';
   }
 
   private handleBack(): void {
-    if (this.viewMode === 'select-account' || this.viewMode === 'edit-account') {
-      this.viewMode = this.editingProfile?.id ? 'edit' : 'create';
-      this.editingAccount = null;
-    } else if (this.viewMode === 'assign-repos') {
-      this.viewMode = 'edit';
-      this.selectedReposForAssignment = new Set();
-    } else {
-      this.viewMode = 'list';
-      this.editingProfile = null;
+    switch (this.viewMode) {
+      case 'select-account':
+        this.viewMode = this.editingProfile?.id ? 'edit' : 'create';
+        this.editingAccount = null;
+        break;
+      case 'edit-account':
+        this.viewMode = this.accountReturnView;
+        this.editingAccount = null;
+        this.accountFormDirty = false;
+        break;
+      case 'assign-repos':
+        this.viewMode = 'edit';
+        this.selectedReposForAssignment = new Set();
+        break;
+      case 'accounts':
+        this.viewMode = 'list';
+        break;
+      default:
+        // create / edit
+        this.viewMode = 'list';
+        this.editingProfile = null;
+        this.profileFormDirty = false;
     }
   }
 
@@ -923,6 +988,7 @@ export class LvProfileManagerDialog extends LitElement {
   private updateEditingProfile(field: keyof UnifiedProfile, value: unknown): void {
     if (this.editingProfile) {
       this.editingProfile = { ...this.editingProfile, [field]: value };
+      this.profileFormDirty = true;
     }
   }
 
@@ -967,6 +1033,9 @@ export class LvProfileManagerDialog extends LitElement {
       if (this.repoPath) {
         await unifiedProfileService.loadUnifiedProfileForRepository(this.repoPath);
       }
+      // Changes are persisted — clear the dirty flag so navigating back doesn't
+      // prompt to discard.
+      this.profileFormDirty = false;
       this.handleBack();
     } catch (error) {
       showToast(`Failed to save profile: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error');
@@ -1016,6 +1085,7 @@ export class LvProfileManagerDialog extends LitElement {
       ...this.editingProfile,
       defaultAccounts: { ...this.editingProfile.defaultAccounts, [type]: accountId },
     };
+    this.profileFormDirty = true;
   }
 
   private removeEditingProfileAccount(type: IntegrationType): void {
@@ -1023,11 +1093,18 @@ export class LvProfileManagerDialog extends LitElement {
     const defaultAccounts = { ...this.editingProfile.defaultAccounts };
     delete defaultAccounts[type];
     this.editingProfile = { ...this.editingProfile, defaultAccounts };
+    this.profileFormDirty = true;
   }
 
   // Account management - attaches existing global accounts to the profile
   private handleOpenAccountPicker(): void {
     this.viewMode = 'select-account';
+  }
+
+  // Opens the standalone account-management view (edit/delete/connect global
+  // accounts independent of any profile).
+  private handleOpenAccountsManager(): void {
+    this.viewMode = 'accounts';
   }
 
   /**
@@ -1036,7 +1113,14 @@ export class LvProfileManagerDialog extends LitElement {
    * account already attached for the same type. Persisted on "Save Profile".
    */
   private handleAttachAccount(account: IntegrationAccount): void {
+    const previous = this.editingProfile?.defaultAccounts?.[account.integrationType];
     this.setEditingProfileAccount(account.integrationType, account.id);
+    if (previous && previous !== account.id) {
+      showToast(
+        `Replaced the previously attached ${INTEGRATION_TYPE_NAMES[account.integrationType]} account`,
+        'info'
+      );
+    }
     this.viewMode = this.editingProfile?.id ? 'edit' : 'create';
   }
 
@@ -1050,6 +1134,10 @@ export class LvProfileManagerDialog extends LitElement {
 
   private handleEditAccount(account: IntegrationAccount): void {
     this.editingAccount = { ...account };
+    this.accountFormDirty = false;
+    // Remember where to return: the standalone Accounts view, or the profile form.
+    this.accountReturnView =
+      this.viewMode === 'accounts' ? 'accounts' : this.editingProfile?.id ? 'edit' : 'create';
     this.viewMode = 'edit-account';
   }
 
@@ -1075,7 +1163,14 @@ export class LvProfileManagerDialog extends LitElement {
         this.removeEditingProfileAccount(attachedType);
       }
       showToast('Account deleted', 'success');
-      this.handleBack();
+      // Deletion is intentional — skip the unsaved-changes guard and return to
+      // wherever the edit form was opened from. When deleting from the Accounts
+      // view, stay there; the store subscription re-renders the trimmed list.
+      this.editingAccount = null;
+      this.accountFormDirty = false;
+      if (this.viewMode === 'edit-account') {
+        this.viewMode = this.accountReturnView;
+      }
     } catch (error) {
       showToast(`Failed to delete account: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error');
     }
@@ -1084,6 +1179,7 @@ export class LvProfileManagerDialog extends LitElement {
   private updateEditingAccount(field: keyof IntegrationAccount, value: unknown): void {
     if (this.editingAccount) {
       this.editingAccount = { ...this.editingAccount, [field]: value };
+      this.accountFormDirty = true;
     }
   }
 
@@ -1112,6 +1208,8 @@ export class LvProfileManagerDialog extends LitElement {
       // Save to global accounts
       await unifiedProfileService.saveGlobalAccount(account);
       showToast('Account saved', 'success');
+      // Persisted — clear the dirty flag so navigating back doesn't prompt.
+      this.accountFormDirty = false;
       this.handleBack();
     } catch (error) {
       showToast(`Failed to save account: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error');
@@ -1173,6 +1271,8 @@ export class LvProfileManagerDialog extends LitElement {
         return 'Edit Account';
       case 'assign-repos':
         return 'Assign Repositories';
+      case 'accounts':
+        return 'Manage Accounts';
       default:
         return 'Profiles';
     }
@@ -1191,6 +1291,8 @@ export class LvProfileManagerDialog extends LitElement {
         return this.renderAccountForm();
       case 'assign-repos':
         return this.renderRepoAssignment();
+      case 'accounts':
+        return this.renderAccountsManager();
       default:
         return nothing;
     }
@@ -1200,6 +1302,16 @@ export class LvProfileManagerDialog extends LitElement {
     switch (this.viewMode) {
       case 'list':
         return html`
+          <button class="btn btn-secondary" @click=${this.handleOpenAccountsManager}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+              <circle cx="9" cy="7" r="4"></circle>
+              <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+              <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+            </svg>
+            Accounts
+          </button>
+          <div style="flex: 1;"></div>
           <button class="btn btn-primary" @click=${this.handleCreateNew}>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="12" y1="5" x2="12" y2="19"></line>
@@ -1207,6 +1319,10 @@ export class LvProfileManagerDialog extends LitElement {
             </svg>
             New Profile
           </button>
+        `;
+      case 'accounts':
+        return html`
+          <button class="btn btn-secondary" @click=${this.handleBack}>Back</button>
         `;
       case 'create':
       case 'edit':
@@ -1226,6 +1342,7 @@ export class LvProfileManagerDialog extends LitElement {
           <button
             class="btn btn-danger"
             ?disabled=${!this.editingAccount?.id}
+            title="Permanently delete this account for all profiles"
             @click=${() => this.editingAccount?.id && this.handleDeleteGlobalAccount(this.editingAccount.id)}
           >
             Delete Account
@@ -1747,30 +1864,93 @@ export class LvProfileManagerDialog extends LitElement {
                 </div>
               `}
 
-          <div class="form-section-title" style="margin-top: var(--spacing-lg);">
-            Connect a new account
-          </div>
-          <div style="display: flex; gap: var(--spacing-sm); flex-wrap: wrap; margin-top: var(--spacing-sm);">
-            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('github')}>
-              ${this.renderAccountIcon('github')}
-              GitHub
-            </button>
-            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('gitlab')}>
-              ${this.renderAccountIcon('gitlab')}
-              GitLab
-            </button>
-            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('bitbucket')}>
-              ${this.renderAccountIcon('bitbucket')}
-              Bitbucket
-            </button>
-            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen('azure-devops')}>
-              ${this.renderAccountIcon('azure-devops')}
-              Azure DevOps
-            </button>
-          </div>
+          ${this.renderConnectButtons()}
         </div>
       </div>
     `;
+  }
+
+  /**
+   * "Connect a new account" provider buttons, shared by the attach picker and
+   * the standalone Accounts view. Each opens the matching integration dialog.
+   */
+  private renderConnectButtons() {
+    const providers: IntegrationType[] = ['github', 'gitlab', 'bitbucket', 'azure-devops'];
+    return html`
+      <div class="form-section-title" style="margin-top: var(--spacing-lg);">
+        Connect a new account
+      </div>
+      <div style="display: flex; gap: var(--spacing-sm); flex-wrap: wrap; margin-top: var(--spacing-sm);">
+        ${providers.map(
+          (type) => html`
+            <button class="btn btn-secondary btn-sm" @click=${() => this.dispatchIntegrationOpen(type)}>
+              ${this.renderAccountIcon(type)}
+              ${INTEGRATION_TYPE_NAMES[type]}
+            </button>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  /**
+   * Standalone account-management view: lists every global account with edit /
+   * delete affordances and offers connect-new buttons. Reachable from the
+   * profile list ("Accounts") and from an integration dialog's "Manage
+   * Accounts" action — independent of editing any profile, so orphan accounts
+   * (attached to no profile) are manageable here.
+   */
+  private renderAccountsManager() {
+    const accounts = this.getGlobalAccounts();
+
+    return html`
+      <div class="form-content">
+        <div class="form-section">
+          ${accounts.length === 0
+            ? html`
+                <div class="empty-accounts">
+                  No integration accounts yet. Connect one below.
+                </div>
+              `
+            : html`
+                <div class="accounts-list">
+                  ${accounts.map((account) => this.renderManagedAccountItem(account))}
+                </div>
+              `}
+          ${this.renderConnectButtons()}
+        </div>
+      </div>
+    `;
+  }
+
+  /**
+   * An account row in the standalone Accounts view. Edit opens the account's
+   * Edit screen; Delete removes the global account for all profiles.
+   */
+  private renderManagedAccountItem(account: IntegrationAccount) {
+    return this.renderAccountItem(
+      account,
+      html`
+        <div class="account-actions">
+          <button class="action-btn" @click=${() => this.handleEditAccount(account)} title="Edit account">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+              <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+            </svg>
+          </button>
+          <button
+            class="action-btn delete"
+            @click=${() => this.handleDeleteGlobalAccount(account.id)}
+            title="Delete account (all profiles)"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="3 6 5 6 21 6"></polyline>
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+            </svg>
+          </button>
+        </div>
+      `
+    );
   }
 
   private renderAccountIcon(type: IntegrationType) {
@@ -1955,12 +2135,27 @@ export class LvProfileManagerDialog extends LitElement {
     const type = this.pendingConnectType;
     this.pendingConnectType = null;
     if (!type || !this.editingProfile) return;
-    // Don't override an account already attached for this provider.
-    if (this.editingProfile.defaultAccounts?.[type]) return;
 
     const accountsOfType = this.getGlobalAccounts().filter((a) => a.integrationType === type);
+    const previous = this.editingProfile.defaultAccounts?.[type];
+    const newlyConnected = accountsOfType.find((a) => !this.accountIdsBeforeConnect.has(a.id));
+
+    if (newlyConnected) {
+      // The user explicitly connected this account while attaching to the
+      // profile — honor that intent even if another account was already
+      // attached for this provider (a profile holds one account per provider).
+      if (previous && previous !== newlyConnected.id) {
+        showToast(`Replaced the previously attached ${INTEGRATION_TYPE_NAMES[type]} account`, 'info');
+      }
+      this.setEditingProfileAccount(type, newlyConnected.id);
+      this.viewMode = this.editingProfile.id ? 'edit' : 'create';
+      return;
+    }
+
+    // No new account was connected (e.g. the user backed out). Only auto-fill
+    // when nothing is attached yet — never override an existing choice.
+    if (previous) return;
     const toAttach =
-      accountsOfType.find((a) => !this.accountIdsBeforeConnect.has(a.id)) ?? // newly connected
       accountsOfType.find((a) => a.isDefault) ?? // the default for this provider
       (accountsOfType.length === 1 ? accountsOfType[0] : undefined); // the only one
 


### PR DESCRIPTION
Address user-facing workflow holes in the Profile Manager and integration
dialogs:

- #1/#2: render the four integration dialogs unconditionally (repositoryPath
  is now optional; the dialogs already guard empty paths). Previously they
  were gated behind an open repository, so "Connect <provider>" from the
  profile account picker dead-ended with no repo and demoted the Profile
  Manager into an invisible, transparent state. Now the connect flow works
  with or without a repo, and the demoted manager always has a dialog stacked
  on top.
- #3/#4: add a standalone "Manage Accounts" view that lists every global
  account with edit/delete affordances and connect-new buttons. Reachable
  from the profile list ("Accounts") and routed to from an integration
  dialog's "Manage Accounts" action (via initialView). Orphan accounts
  attached to no profile are now manageable.
- #5: show an info toast when attaching/auto-attaching an account replaces an
  existing same-provider account. handleRevealAfterConnect now honors an
  explicitly newly-connected account even when one is already attached.
- #6: warn before discarding unsaved profile/account edits when the dialog is
  dismissed (X / overlay / Escape). Explicit Cancel/Back still discard
  silently.
- #7: clarify that "Delete Account" removes the account for all profiles.

Adds unit tests for the accounts view, initialView routing, same-provider
replacement, and the unsaved-changes guard.

https://claude.ai/code/session_01ASsWSpGfBYvggq6Nkcs5cX