### PR TITLE
deps(npm): bump playwright + @playwright/test + playwright-core to 1.61.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@open-wc/testing": "^4.0.0",
-        "@playwright/test": "1.60.0",
+        "@playwright/test": "1.61.0",
         "@tauri-apps/cli": "^2.11.2",
         "@types/mocha": "^10.0.10",
         "@web/dev-server-esbuild": "^1.0.5",
@@ -31,7 +31,7 @@
         "@web/test-runner-playwright": "^0.11.0",
         "eslint": "^10.5.0",
         "globals": "^17.6.0",
-        "playwright-core": "1.59.1",
+        "playwright-core": "1.61.0",
         "prettier": "^3.8.4",
         "sharp": "^0.34.5",
         "typescript": "^6.0.0",
@@ -1398,13 +1398,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6833,13 +6833,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6852,9 +6852,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@open-wc/testing": "^4.0.0",
-    "@playwright/test": "1.60.0",
+    "@playwright/test": "1.61.0",
     "@tauri-apps/cli": "^2.11.2",
     "@types/mocha": "^10.0.10",
     "@web/dev-server-esbuild": "^1.0.5",
@@ -45,7 +45,7 @@
     "@web/test-runner-playwright": "^0.11.0",
     "eslint": "^10.5.0",
     "globals": "^17.6.0",
-    "playwright-core": "1.59.1",
+    "playwright-core": "1.61.0",
     "prettier": "^3.8.4",
     "sharp": "^0.34.5",
     "typescript": "^6.0.0",
@@ -53,8 +53,8 @@
     "vite": "^8.0.16"
   },
   "overrides": {
-    "playwright": "1.59.1",
-    "playwright-core": "1.59.1",
+    "playwright": "1.61.0",
+    "playwright-core": "1.61.0",
     "koa": ">=2.16.4",
     "esbuild": "^0.28.1",
     "ws@^7.0.0": "^7.5.11"


### PR DESCRIPTION
## Summary

PR #218 bumped \`@playwright/test\` to 1.60.0 while the \`playwright\` / \`playwright-core\` overrides still pinned 1.59.1 — the same kind of version mismatch that motivated #181's lockstep bump policy.

Open Dependabot PR #215 (\`playwright-core\` 1.59.1 → 1.61.0) would have been a no-op against those overrides, so this rolls all three top-level pins and both override entries to 1.61.0 in one shot.

Closes #215.

## Test plan
- [x] \`npm run lint && npm run typecheck && npm test\` (3196 tests pass)
- [x] \`cargo fmt --check && cargo clippy -- -D warnings\`
- [ ] CI green
- [ ] Confirm \`npx playwright install\` step still works in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)