### PR TITLE
Multi-repo overhaul: correct per-repo state, usable tab bar, and scalable performance

### DIFF
--- a/e2e/tests/graph.spec.ts
+++ b/e2e/tests/graph.spec.ts
@@ -676,16 +676,15 @@ test.describe('Graph Error Handling', () => {
     // Inject an error so the next call to get_commit_history will fail
     await injectCommandError(page, 'get_commit_history', 'Failed to read commit history: corrupt object');
 
-    // Force the graph to re-fetch commit history by resetting repositoryPath
+    // Switch the graph to a NEVER-loaded repo so the failing load runs in
+    // the foreground. (Re-setting the same path would serve the per-repo
+    // graph cache and retry in the background, which deliberately does not
+    // surface an error state over the still-valid cached graph.)
     const handle = await getGraphCanvasHandle(page);
     await page.evaluate(
       (el) => {
         const canvas = el as HTMLElement & { repositoryPath: string };
-        if (canvas) {
-          const path = canvas.repositoryPath;
-          canvas.repositoryPath = '';
-          canvas.repositoryPath = path;
-        }
+        canvas.repositoryPath = '/tmp/never-loaded-repo';
       },
       handle
     );
@@ -704,5 +703,35 @@ test.describe('Graph Error Handling', () => {
         page.locator('.info-panel, .toast.error, .toast, .error, .error-banner').first()
       ).toBeVisible({ timeout: 5000 });
     }
+  });
+
+  test('keeps showing the cached graph when a background refetch fails', async ({ page }) => {
+    // The repo is already loaded (and cached) from beforeEach
+    const handle = await getGraphCanvasHandle(page);
+    const nodesBefore = await getSortedNodeCount(page);
+    expect(nodesBefore).toBeGreaterThan(0);
+
+    await startCommandCapture(page);
+    await injectCommandError(page, 'get_commit_history', 'repository temporarily unavailable');
+
+    // Re-setting the same path serves the cache and revalidates in the
+    // background; the failing revalidation must not blank the graph or
+    // paint an error banner over it
+    await page.evaluate(
+      (el) => {
+        const canvas = el as HTMLElement & { repositoryPath: string };
+        const path = canvas.repositoryPath;
+        canvas.repositoryPath = '';
+        canvas.repositoryPath = path;
+      },
+      handle
+    );
+
+    // Wait until the (failing) background reload actually ran
+    await waitForCommand(page, 'get_commit_history');
+
+    await expect(graph.canvas).toBeVisible();
+    expect(await getSortedNodeCount(page)).toBe(nodesBefore);
+    await expect(page.locator('.error-state, .load-error')).toHaveCount(0);
   });
 });

--- a/e2e/tests/graph.spec.ts
+++ b/e2e/tests/graph.spec.ts
@@ -732,6 +732,9 @@ test.describe('Graph Error Handling', () => {
 
     await expect(graph.canvas).toBeVisible();
     expect(await getSortedNodeCount(page)).toBe(nodesBefore);
-    await expect(page.locator('.error-state, .load-error')).toHaveCount(0);
+    // The graph's real error surface is the info panel with "Error" text
+    await expect(
+      page.locator('lv-graph-canvas .info-panel', { hasText: 'Error' })
+    ).toHaveCount(0);
   });
 });

--- a/e2e/tests/repo-tabs.spec.ts
+++ b/e2e/tests/repo-tabs.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupOpenRepository } from '../fixtures/tauri-mock';
+
+/**
+ * E2E tests for the multi-repository tab bar:
+ * tooltips, duplicate-name disambiguation, active-tab indication, the
+ * all-repositories dropdown, middle-click close, the tab context menu, and
+ * keyboard tab switching.
+ *
+ * setupOpenRepository() opens the default repo (/tmp/test-repo); extra repos
+ * are added through the repository store like the welcome/restore flows do.
+ */
+
+async function addRepo(page: Page, path: string, name: string): Promise<void> {
+  await page.evaluate(
+    ({ path, name }) => {
+      const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as {
+        repositoryStore: {
+          getState: () => { addRepository: (repo: unknown) => void };
+        };
+      };
+      stores.repositoryStore.getState().addRepository({
+        path,
+        name,
+        isValid: true,
+        isBare: false,
+        headRef: 'main',
+        state: 'clean',
+        isShallow: false,
+        isPartialClone: false,
+        cloneFilter: null,
+      });
+    },
+    { path, name }
+  );
+}
+
+async function activeTabName(page: Page): Promise<string | null> {
+  return page.locator('lv-toolbar .tab.active .tab-name').textContent();
+}
+
+test.describe('Repository Tabs - multiple repos', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+    await addRepo(page, '/work/client-a/api', 'api');
+    await addRepo(page, '/work/client-b/api', 'api');
+  });
+
+  test('renders one tab per open repo with full-path tooltips', async ({ page }) => {
+    const tabs = page.locator('lv-toolbar .tab');
+    await expect(tabs).toHaveCount(3);
+    await expect(tabs.nth(1)).toHaveAttribute('title', '/work/client-a/api');
+    await expect(tabs.nth(2)).toHaveAttribute('title', '/work/client-b/api');
+  });
+
+  test('disambiguates duplicate repo names with the parent directory', async ({ page }) => {
+    const hints = page.locator('lv-toolbar .tab .tab-hint');
+    await expect(hints).toHaveCount(2);
+    await expect(hints.nth(0)).toHaveText('client-a');
+    await expect(hints.nth(1)).toHaveText('client-b');
+  });
+
+  test('clicking a tab activates it and updates the visual indicator', async ({ page }) => {
+    // Last added repo is active
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveAttribute(
+      'title',
+      '/work/client-b/api'
+    );
+
+    await page.locator('lv-toolbar .tab').first().click();
+
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveCount(1);
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveAttribute('title', '/tmp/test-repo');
+    await expect(page.locator('lv-toolbar .tab').first()).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('the all-repositories dropdown lists every repo and switches tabs', async ({ page }) => {
+    await page.locator('lv-toolbar .tab-list-btn').click();
+
+    const items = page.locator('lv-toolbar .tab-list-item');
+    await expect(items).toHaveCount(3);
+    await expect(items.nth(0).locator('.item-path')).toContainText('/tmp/test-repo');
+
+    await items.nth(0).click();
+
+    // Menu closes and the first repo becomes active
+    await expect(page.locator('lv-toolbar .tab-list-menu')).toHaveCount(0);
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveAttribute('title', '/tmp/test-repo');
+  });
+
+  test('middle-click closes a tab', async ({ page }) => {
+    await page.locator('lv-toolbar .tab').nth(1).click({ button: 'middle' });
+
+    await expect(page.locator('lv-toolbar .tab')).toHaveCount(2);
+    await expect(page.locator('lv-toolbar .tab[title="/work/client-a/api"]')).toHaveCount(0);
+  });
+
+  test('context menu Close Others keeps only the clicked tab', async ({ page }) => {
+    await page.locator('lv-toolbar .tab').nth(1).click({ button: 'right' });
+
+    const closeOthers = page.locator('lv-toolbar .context-menu-item', { hasText: 'Close Others' });
+    await expect(closeOthers).toBeVisible();
+    await closeOthers.click();
+
+    await expect(page.locator('lv-toolbar .tab')).toHaveCount(1);
+    await expect(page.locator('lv-toolbar .tab')).toHaveAttribute('title', '/work/client-a/api');
+  });
+
+  test('context menu Close Tabs to the Right', async ({ page }) => {
+    await page.locator('lv-toolbar .tab').first().click({ button: 'right' });
+
+    await page
+      .locator('lv-toolbar .context-menu-item', { hasText: 'Close Tabs to the Right' })
+      .click();
+
+    await expect(page.locator('lv-toolbar .tab')).toHaveCount(1);
+    await expect(page.locator('lv-toolbar .tab')).toHaveAttribute('title', '/tmp/test-repo');
+  });
+
+  test('context menu Close All empties the tab strip', async ({ page }) => {
+    await page.locator('lv-toolbar .tab').first().click({ button: 'right' });
+
+    await page.locator('lv-toolbar .context-menu-item', { hasText: 'Close All' }).click();
+
+    await expect(page.locator('lv-toolbar .tab')).toHaveCount(0);
+    await expect(page.locator('lv-toolbar .no-repos')).toBeVisible();
+  });
+
+  test('Ctrl+Tab cycles to the next tab and wraps', async ({ page }) => {
+    // Active: client-b (index 2). Ctrl+Tab wraps to index 0.
+    await page.keyboard.press('Control+Tab');
+    expect(await activeTabName(page)).toBe('test-repo');
+
+    await page.keyboard.press('Control+Tab');
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveAttribute(
+      'title',
+      '/work/client-a/api'
+    );
+
+    await page.keyboard.press('Control+Shift+Tab');
+    expect(await activeTabName(page)).toBe('test-repo');
+  });
+
+  test('Ctrl+digit jumps directly to that tab', async ({ page }) => {
+    await page.keyboard.press('Control+1');
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveAttribute('title', '/tmp/test-repo');
+
+    await page.keyboard.press('Control+3');
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveAttribute(
+      'title',
+      '/work/client-b/api'
+    );
+  });
+});
+
+test.describe('Repository Tabs - single repo', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+  });
+
+  test('shows no disambiguation hint for a unique name', async ({ page }) => {
+    await expect(page.locator('lv-toolbar .tab')).toHaveCount(1);
+    await expect(page.locator('lv-toolbar .tab .tab-hint')).toHaveCount(0);
+  });
+
+  test('Ctrl+Tab with a single repo keeps it active', async ({ page }) => {
+    await page.keyboard.press('Control+Tab');
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveCount(1);
+  });
+
+  test('context menu disables Close Others and Close Tabs to the Right', async ({ page }) => {
+    await page.locator('lv-toolbar .tab').first().click({ button: 'right' });
+
+    await expect(
+      page.locator('lv-toolbar .context-menu-item', { hasText: 'Close Others' })
+    ).toBeDisabled();
+    await expect(
+      page.locator('lv-toolbar .context-menu-item', { hasText: 'Close Tabs to the Right' })
+    ).toBeDisabled();
+  });
+});

--- a/src-tauri/src/commands/search_index.rs
+++ b/src-tauri/src/commands/search_index.rs
@@ -30,7 +30,15 @@ pub async fn build_search_index(
 
     let count = index.len();
     let mut guard = index_state.write().await;
-    guard.insert_if_current(path, index, start_generation);
+    if !guard.insert_if_current(path, index, start_generation) {
+        // A drop (tab close) bumped the generation while we were building, so
+        // this index was NOT stored. Report it so the frontend leaves the
+        // repo un-ready instead of marking it ready over an empty backend
+        // slot — it will rebuild on next activation.
+        return Err(LeviathanError::OperationFailed(
+            "Search index build superseded by a newer generation".to_string(),
+        ));
+    }
     Ok(count)
 }
 
@@ -87,7 +95,11 @@ pub async fn refresh_search_index(
 
         let count = updated.len();
         let mut guard = index_state.write().await;
-        guard.insert_if_current(path, updated, start_generation);
+        if !guard.insert_if_current(path, updated, start_generation) {
+            return Err(LeviathanError::OperationFailed(
+                "Search index refresh superseded by a newer generation".to_string(),
+            ));
+        }
         Ok(count)
     } else {
         // No index exists, build from scratch

--- a/src-tauri/src/commands/search_index.rs
+++ b/src-tauri/src/commands/search_index.rs
@@ -14,6 +14,15 @@ pub async fn build_search_index(
     index_state: tauri::State<'_, SharedCommitIndex>,
     path: String,
 ) -> Result<usize> {
+    // Capture the path's generation BEFORE the (slow) blocking build. If the
+    // tab is closed while we build, drop_search_index bumps the generation
+    // and our result is discarded on insert — so a build that started before
+    // a close-then-reopen can't clobber the index the reopen build created.
+    let start_generation = {
+        let guard = index_state.read().await;
+        guard.generation(&path)
+    };
+
     let path_clone = path.clone();
     let index = tokio::task::spawn_blocking(move || CommitIndex::build(&path_clone))
         .await
@@ -21,7 +30,7 @@ pub async fn build_search_index(
 
     let count = index.len();
     let mut guard = index_state.write().await;
-    guard.insert(path, index);
+    guard.insert_if_current(path, index, start_generation);
     Ok(count)
 }
 
@@ -60,9 +69,11 @@ pub async fn refresh_search_index(
 ) -> Result<usize> {
     // Take this repo's index out for updating so the lock isn't held across
     // the blocking revwalk; other repos' indexes stay available meanwhile.
-    let existing = {
+    // Capture the generation with it so a close during the walk discards the
+    // reinsert (same guard as build_search_index).
+    let (existing, start_generation) = {
         let mut guard = index_state.write().await;
-        guard.remove(&path)
+        (guard.take(&path), guard.generation(&path))
     };
 
     if let Some(mut index) = existing {
@@ -76,7 +87,7 @@ pub async fn refresh_search_index(
 
         let count = updated.len();
         let mut guard = index_state.write().await;
-        guard.insert(path, updated);
+        guard.insert_if_current(path, updated, start_generation);
         Ok(count)
     } else {
         // No index exists, build from scratch
@@ -91,6 +102,6 @@ pub async fn drop_search_index(
     path: String,
 ) -> Result<()> {
     let mut guard = index_state.write().await;
-    guard.remove(&path);
+    guard.drop_index(&path);
     Ok(())
 }

--- a/src-tauri/src/commands/search_index.rs
+++ b/src-tauri/src/commands/search_index.rs
@@ -1,9 +1,12 @@
 //! Search index command handlers
+//!
+//! Indexes are kept per repository path so multiple open repositories never
+//! share (or corrupt) each other's index.
 
 use tauri::command;
 
 use crate::error::{LeviathanError, Result};
-use crate::services::commit_index::{IndexedCommit, SharedCommitIndex};
+use crate::services::commit_index::{CommitIndex, IndexedCommit, SharedCommitIndex};
 
 /// Build the search index for a repository
 #[command]
@@ -12,22 +15,21 @@ pub async fn build_search_index(
     path: String,
 ) -> Result<usize> {
     let path_clone = path.clone();
-    let index = tokio::task::spawn_blocking(move || {
-        crate::services::commit_index::CommitIndex::build(&path_clone)
-    })
-    .await
-    .map_err(|e| LeviathanError::Custom(format!("Index build failed: {}", e)))??;
+    let index = tokio::task::spawn_blocking(move || CommitIndex::build(&path_clone))
+        .await
+        .map_err(|e| LeviathanError::Custom(format!("Index build failed: {}", e)))??;
 
     let count = index.len();
     let mut guard = index_state.write().await;
-    *guard = Some(index);
+    guard.insert(path, index);
     Ok(count)
 }
 
-/// Search the commit index
+/// Search the commit index of a specific repository
 #[command]
 pub async fn search_index(
     index_state: tauri::State<'_, SharedCommitIndex>,
+    path: String,
     query: Option<String>,
     author: Option<String>,
     date_from: Option<i64>,
@@ -36,7 +38,7 @@ pub async fn search_index(
 ) -> Result<Vec<IndexedCommit>> {
     let guard = index_state.read().await;
     let index = guard
-        .as_ref()
+        .get(&path)
         .ok_or_else(|| LeviathanError::OperationFailed("Search index not built yet".to_string()))?;
 
     let results = index.search(
@@ -50,33 +52,45 @@ pub async fn search_index(
     Ok(results.into_iter().cloned().collect())
 }
 
-/// Refresh the search index incrementally
+/// Refresh the search index of a repository incrementally
 #[command]
 pub async fn refresh_search_index(
     index_state: tauri::State<'_, SharedCommitIndex>,
     path: String,
 ) -> Result<usize> {
-    // Take the index out for updating
+    // Take this repo's index out for updating so the lock isn't held across
+    // the blocking revwalk; other repos' indexes stay available meanwhile.
     let existing = {
         let mut guard = index_state.write().await;
-        guard.take()
+        guard.remove(&path)
     };
 
     if let Some(mut index) = existing {
         let path_clone = path.clone();
         let updated = tokio::task::spawn_blocking(move || {
-            let new_count = index.update_incremental(&path_clone)?;
-            Ok::<_, LeviathanError>((index, new_count))
+            index.update_incremental(&path_clone)?;
+            Ok::<_, LeviathanError>(index)
         })
         .await
         .map_err(|e| LeviathanError::Custom(format!("Index refresh failed: {}", e)))??;
 
-        let count = updated.0.len();
+        let count = updated.len();
         let mut guard = index_state.write().await;
-        *guard = Some(updated.0);
+        guard.insert(path, updated);
         Ok(count)
     } else {
         // No index exists, build from scratch
         build_search_index(index_state, path).await
     }
+}
+
+/// Drop the search index of a repository (e.g., when its tab is closed)
+#[command]
+pub async fn drop_search_index(
+    index_state: tauri::State<'_, SharedCommitIndex>,
+    path: String,
+) -> Result<()> {
+    let mut guard = index_state.write().await;
+    guard.remove(&path);
+    Ok(())
 }

--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -71,13 +71,23 @@ pub async fn start_watching(
 
         thread::spawn(move || {
             loop {
-                // Poll for events; exit when the last watcher is gone
+                // Poll for events; exit when the last watcher is gone.
+                //
+                // The exit flag MUST be flipped while the service lock is
+                // still held: start_watching registers its watcher under this
+                // same lock BEFORE checking the flag, so either it sees the
+                // flag already false (and spawns a replacement poller) or
+                // this thread sees the new watcher and keeps running. Storing
+                // the flag after releasing the lock would open a window where
+                // a watcher is registered but no poller ever serves it.
                 let events = {
                     let Ok(service) = service.lock() else {
                         // Mutex poisoned — nothing sane left to do
+                        poller_running.store(false, Ordering::SeqCst);
                         break;
                     };
                     if service.watcher_count() == 0 {
+                        poller_running.store(false, Ordering::SeqCst);
                         break;
                     }
                     service.poll_events()
@@ -114,7 +124,6 @@ pub async fn start_watching(
                 // Sleep before next poll
                 thread::sleep(Duration::from_millis(500));
             }
-            poller_running.store(false, Ordering::SeqCst);
         });
     }
 

--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -1,6 +1,13 @@
 //! File system watcher commands
+//!
+//! Any number of repositories can be watched at once (one per open tab).
+//! Events emitted to the frontend carry the repository path they belong to.
+//! A single poller thread serves all watchers; it exits when the last
+//! watcher is removed and is restarted on demand, so threads never
+//! accumulate no matter how often watching starts and stops.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -13,14 +20,16 @@ use crate::services::WatcherService;
 /// Managed state for the file watcher
 pub struct WatcherState {
     pub service: Arc<Mutex<WatcherService>>,
-    pub watching_path: Arc<Mutex<Option<String>>>,
+    /// True while the poller thread is alive. Guards against spawning more
+    /// than one poller.
+    pub poller_running: Arc<AtomicBool>,
 }
 
 impl Default for WatcherState {
     fn default() -> Self {
         Self {
             service: Arc::new(Mutex::new(WatcherService::new())),
-            watching_path: Arc::new(Mutex::new(None)),
+            poller_running: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -29,113 +38,103 @@ impl Default for WatcherState {
 #[derive(Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FileChangeEvent {
+    pub repo_path: String,
     pub event_type: String,
     pub paths: Vec<String>,
 }
 
-/// Start watching a repository for file changes
+/// Start watching a repository for file changes. Repositories already being
+/// watched are unaffected; watching the same repository twice is a no-op.
 #[command]
 pub async fn start_watching(
     app: AppHandle,
     state: State<'_, WatcherState>,
     path: String,
 ) -> Result<()> {
-    let repo_path = Path::new(&path);
-
-    // Stop any existing watcher
     {
         let mut service = state.service.lock().map_err(|_| {
             crate::error::LeviathanError::OperationFailed("Watcher lock poisoned".to_string())
         })?;
-        let mut watching = state.watching_path.lock().map_err(|_| {
-            crate::error::LeviathanError::OperationFailed("Watcher lock poisoned".to_string())
-        })?;
-
-        if let Some(ref old_path) = *watching {
-            let _ = service.unwatch(Path::new(old_path));
-        }
-
-        // Start watching the new path
-        service.watch(repo_path)?;
-        *watching = Some(path.clone());
+        service.watch(Path::new(&path))?;
     }
 
-    // Spawn a thread to poll for events and emit them to the frontend
-    let service = Arc::clone(&state.service);
-    let watching_path = Arc::clone(&state.watching_path);
+    // Spawn the shared poller thread if it isn't already running. The
+    // compare_exchange guarantees at most one poller exists regardless of how
+    // many repos are watched or how often watching is toggled.
+    if state
+        .poller_running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        let service = Arc::clone(&state.service);
+        let poller_running = Arc::clone(&state.poller_running);
 
-    thread::spawn(move || {
-        loop {
-            // Check if we're still watching
-            {
-                let Ok(watching) = watching_path.lock() else {
-                    break;
+        thread::spawn(move || {
+            loop {
+                // Poll for events; exit when the last watcher is gone
+                let events = {
+                    let Ok(service) = service.lock() else {
+                        // Mutex poisoned — nothing sane left to do
+                        break;
+                    };
+                    if service.watcher_count() == 0 {
+                        break;
+                    }
+                    service.poll_events()
                 };
-                if watching.is_none() {
-                    break;
+
+                // Emit events to frontend
+                for (repo_path, event) in events {
+                    let (event_type, paths) = match event {
+                        crate::services::watcher_service::WatcherEvent::WorkdirChanged(p) => (
+                            "workdir-changed",
+                            p.iter().map(|p| p.to_string_lossy().to_string()).collect(),
+                        ),
+                        crate::services::watcher_service::WatcherEvent::IndexChanged => {
+                            ("index-changed", vec![])
+                        }
+                        crate::services::watcher_service::WatcherEvent::RefsChanged => {
+                            ("refs-changed", vec![])
+                        }
+                        crate::services::watcher_service::WatcherEvent::ConfigChanged => {
+                            ("config-changed", vec![])
+                        }
+                    };
+
+                    let _ = app.emit(
+                        "file-change",
+                        FileChangeEvent {
+                            repo_path: repo_path.clone(),
+                            event_type: event_type.to_string(),
+                            paths,
+                        },
+                    );
                 }
+
+                // Sleep before next poll
+                thread::sleep(Duration::from_millis(500));
             }
-
-            // Poll for events
-            let events = {
-                let Ok(service) = service.lock() else {
-                    // Mutex poisoned — sleep to avoid CPU spin, then retry
-                    thread::sleep(Duration::from_millis(500));
-                    continue;
-                };
-                service.poll_events()
-            };
-
-            // Emit events to frontend
-            for event in events {
-                let (event_type, paths) = match event {
-                    crate::services::watcher_service::WatcherEvent::WorkdirChanged(p) => (
-                        "workdir-changed",
-                        p.iter().map(|p| p.to_string_lossy().to_string()).collect(),
-                    ),
-                    crate::services::watcher_service::WatcherEvent::IndexChanged => {
-                        ("index-changed", vec![])
-                    }
-                    crate::services::watcher_service::WatcherEvent::RefsChanged => {
-                        ("refs-changed", vec![])
-                    }
-                    crate::services::watcher_service::WatcherEvent::ConfigChanged => {
-                        ("config-changed", vec![])
-                    }
-                };
-
-                let _ = app.emit(
-                    "file-change",
-                    FileChangeEvent {
-                        event_type: event_type.to_string(),
-                        paths,
-                    },
-                );
-            }
-
-            // Sleep before next poll
-            thread::sleep(Duration::from_millis(500));
-        }
-    });
+            poller_running.store(false, Ordering::SeqCst);
+        });
+    }
 
     Ok(())
 }
 
-/// Stop watching the current repository
+/// Stop watching a repository. With no path, stop watching all repositories
+/// (used on app shutdown).
 #[command]
-pub async fn stop_watching(state: State<'_, WatcherState>) -> Result<()> {
+pub async fn stop_watching(state: State<'_, WatcherState>, path: Option<String>) -> Result<()> {
     let mut service = state.service.lock().map_err(|_| {
         crate::error::LeviathanError::OperationFailed("Watcher lock poisoned".to_string())
     })?;
-    let mut watching = state.watching_path.lock().map_err(|_| {
-        crate::error::LeviathanError::OperationFailed("Watcher lock poisoned".to_string())
-    })?;
 
-    if let Some(ref path) = *watching {
-        service.unwatch(Path::new(path))?;
+    match path {
+        Some(p) => service.unwatch(Path::new(&p))?,
+        None => service.unwatch_all(),
     }
-
-    *watching = None;
+    // When the last watcher is removed the poller thread notices
+    // watcher_count() == 0 on its next tick and exits.
     Ok(())
 }
 
@@ -152,26 +151,16 @@ mod tests {
         // Should have an empty watcher service
         let service = state.service.lock().unwrap();
         assert!(service.poll_events().is_empty());
+        assert_eq!(service.watcher_count(), 0);
 
-        // Should have no watching path
-        let watching = state.watching_path.lock().unwrap();
-        assert!(watching.is_none());
-    }
-
-    #[test]
-    fn test_watcher_state_new() {
-        let state = WatcherState {
-            service: Arc::new(Mutex::new(WatcherService::new())),
-            watching_path: Arc::new(Mutex::new(None)),
-        };
-
-        let watching = state.watching_path.lock().unwrap();
-        assert!(watching.is_none());
+        // No poller thread yet
+        assert!(!state.poller_running.load(Ordering::SeqCst));
     }
 
     #[test]
     fn test_file_change_event_serialization() {
         let event = FileChangeEvent {
+            repo_path: "/repo/one".to_string(),
             event_type: "workdir-changed".to_string(),
             paths: vec![
                 "/path/to/file.txt".to_string(),
@@ -182,6 +171,8 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
 
         // Check camelCase serialization
+        assert!(json.contains("repoPath"));
+        assert!(json.contains("/repo/one"));
         assert!(json.contains("eventType"));
         assert!(json.contains("workdir-changed"));
         assert!(json.contains("paths"));
@@ -191,6 +182,7 @@ mod tests {
     #[test]
     fn test_file_change_event_empty_paths() {
         let event = FileChangeEvent {
+            repo_path: "/repo/one".to_string(),
             event_type: "index-changed".to_string(),
             paths: vec![],
         };
@@ -207,10 +199,52 @@ mod tests {
 
         let result = service.watch(&repo.path);
         assert!(result.is_ok());
+        assert_eq!(service.watcher_count(), 1);
 
         // Should be able to unwatch
         let unwatch_result = service.unwatch(&repo.path);
         assert!(unwatch_result.is_ok());
+        assert_eq!(service.watcher_count(), 0);
+    }
+
+    #[test]
+    fn test_watcher_service_watch_multiple_repos_concurrently() {
+        let repo1 = TestRepo::with_initial_commit();
+        let repo2 = TestRepo::with_initial_commit();
+        let mut service = WatcherService::new();
+
+        service.watch(&repo1.path).unwrap();
+        service.watch(&repo2.path).unwrap();
+        assert_eq!(service.watcher_count(), 2);
+
+        // Unwatching one repo must not affect the other
+        service.unwatch(&repo1.path).unwrap();
+        assert_eq!(service.watcher_count(), 1);
+
+        service.unwatch(&repo2.path).unwrap();
+        assert_eq!(service.watcher_count(), 0);
+    }
+
+    #[test]
+    fn test_watcher_service_watch_same_repo_twice_is_noop() {
+        let repo = TestRepo::with_initial_commit();
+        let mut service = WatcherService::new();
+
+        service.watch(&repo.path).unwrap();
+        service.watch(&repo.path).unwrap();
+        assert_eq!(service.watcher_count(), 1);
+    }
+
+    #[test]
+    fn test_watcher_service_unwatch_all() {
+        let repo1 = TestRepo::with_initial_commit();
+        let repo2 = TestRepo::with_initial_commit();
+        let mut service = WatcherService::new();
+
+        service.watch(&repo1.path).unwrap();
+        service.watch(&repo2.path).unwrap();
+        service.unwatch_all();
+        assert_eq!(service.watcher_count(), 0);
     }
 
     #[test]
@@ -239,10 +273,9 @@ mod tests {
         let mut service = WatcherService::new();
         let path = Path::new("/some/path");
 
-        // Unwatching when not watching should work (no-op or error, but not panic)
+        // Unwatching when not watching should be a no-op, not a panic
         let result = service.unwatch(path);
-        // Result can be Ok or Err depending on implementation, just ensure no panic
-        let _ = result;
+        assert!(result.is_ok());
     }
 
     #[test]
@@ -267,6 +300,32 @@ mod tests {
 
         // Unwatch again
         service.unwatch(&repo.path).unwrap();
+    }
+
+    #[test]
+    fn test_watcher_events_are_tagged_with_repo_path() {
+        let repo = TestRepo::with_initial_commit();
+        let mut service = WatcherService::new();
+        service.watch(&repo.path).unwrap();
+
+        // Touch a file in the working directory
+        std::fs::write(repo.path.join("watched-file.txt"), "hello").unwrap();
+
+        // The notify backend delivers asynchronously; poll with a deadline
+        let expected_key = repo.path.to_string_lossy().to_string();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let mut tagged_correctly = false;
+        while std::time::Instant::now() < deadline {
+            for (repo_path, _event) in service.poll_events() {
+                assert_eq!(repo_path, expected_key);
+                tagged_correctly = true;
+            }
+            if tagged_correctly {
+                break;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(tagged_correctly, "expected at least one tagged event");
     }
 
     #[test]
@@ -325,15 +384,12 @@ mod tests {
 
         let state = WatcherState::default();
         let service_clone = Arc::clone(&state.service);
-        let watching_clone = Arc::clone(&state.watching_path);
 
         // Spawn a thread that reads the state
         let handle = thread::spawn(move || {
             let service = service_clone.lock().unwrap();
-            let _events = service.poll_events();
-
-            let watching = watching_clone.lock().unwrap();
-            watching.is_none()
+            let events = service.poll_events();
+            events.is_empty()
         });
 
         // Main thread also reads
@@ -346,124 +402,8 @@ mod tests {
         assert!(result);
     }
 
-    #[test]
-    fn test_watcher_state_set_watching_path() {
-        let state = WatcherState::default();
-
-        // Set a watching path
-        {
-            let mut watching = state.watching_path.lock().unwrap();
-            *watching = Some("/test/path".to_string());
-        }
-
-        // Verify it was set
-        {
-            let watching = state.watching_path.lock().unwrap();
-            assert_eq!(watching.as_ref().unwrap(), "/test/path");
-        }
-
-        // Clear it
-        {
-            let mut watching = state.watching_path.lock().unwrap();
-            *watching = None;
-        }
-
-        // Verify it was cleared
-        {
-            let watching = state.watching_path.lock().unwrap();
-            assert!(watching.is_none());
-        }
-    }
-
     // Note: Testing the actual start_watching and stop_watching commands requires
     // a Tauri State wrapper which is only available in a running Tauri application context.
     // These functions are better tested through integration tests.
     // However, we can test the underlying WatcherService functionality directly.
-
-    #[test]
-    fn test_watcher_state_concurrent_read_write() {
-        use std::thread;
-
-        let state = WatcherState::default();
-        let watching_clone = Arc::clone(&state.watching_path);
-
-        // Writer thread sets a path
-        let writer = thread::spawn(move || {
-            let mut watching = watching_clone.lock().unwrap();
-            *watching = Some("/test/concurrent".to_string());
-        });
-
-        writer.join().unwrap();
-
-        // Verify the write was visible
-        let watching = state.watching_path.lock().unwrap();
-        assert_eq!(watching.as_ref().unwrap(), "/test/concurrent");
-    }
-
-    #[test]
-    fn test_watcher_state_multiple_path_transitions() {
-        let state = WatcherState::default();
-
-        // Simulate a sequence of watch path changes
-        let paths = vec!["/repo/one", "/repo/two", "/repo/three"];
-        for p in &paths {
-            let mut watching = state.watching_path.lock().unwrap();
-            *watching = Some(p.to_string());
-        }
-
-        // Final state should be the last path
-        let watching = state.watching_path.lock().unwrap();
-        assert_eq!(watching.as_ref().unwrap(), "/repo/three");
-    }
-
-    #[test]
-    fn test_file_change_event_all_event_types() {
-        let event_types = vec![
-            "workdir-changed",
-            "index-changed",
-            "refs-changed",
-            "config-changed",
-        ];
-
-        for event_type in event_types {
-            let event = FileChangeEvent {
-                event_type: event_type.to_string(),
-                paths: vec![],
-            };
-
-            let json = serde_json::to_string(&event).unwrap();
-            assert!(json.contains(event_type));
-        }
-    }
-
-    #[test]
-    fn test_watcher_service_watch_unwatch_different_paths() {
-        let repo1 = TestRepo::with_initial_commit();
-        let repo2 = TestRepo::with_initial_commit();
-        let mut service = WatcherService::new();
-
-        // Watch first path
-        assert!(service.watch(&repo1.path).is_ok());
-        assert!(service.unwatch(&repo1.path).is_ok());
-
-        // Watch second path
-        assert!(service.watch(&repo2.path).is_ok());
-        assert!(service.unwatch(&repo2.path).is_ok());
-    }
-
-    #[test]
-    fn test_watcher_state_service_and_path_independent() {
-        // Verify that service and watching_path are independent Arcs
-        let state = WatcherState::default();
-
-        let service_ptr = Arc::as_ptr(&state.service);
-        let path_ptr = Arc::as_ptr(&state.watching_path);
-
-        // They should be different allocations
-        assert_ne!(service_ptr as *const u8, path_ptr as *const u8);
-
-        // Each should have reference count of 1
-        assert_eq!(Arc::strong_count(&state.service), 1);
-        assert_eq!(Arc::strong_count(&state.watching_path), 1);
-    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -732,6 +732,7 @@ pub fn run() {
             commands::search_index::build_search_index,
             commands::search_index::search_index,
             commands::search_index::refresh_search_index,
+            commands::search_index::drop_search_index,
             // Embedding index (semantic search)
             commands::embedding_index::build_embedding_index,
             commands::embedding_index::refresh_embedding_index,

--- a/src-tauri/src/services/autofetch_service.rs
+++ b/src-tauri/src/services/autofetch_service.rs
@@ -42,11 +42,14 @@ impl AutoFetchService {
 
         let path = repo_path.clone();
         let interval = Duration::from_secs(interval_minutes as u64 * 60);
+        let initial_delay = interval + stagger_offset(&repo_path, interval);
 
         let task = tokio::spawn(async move {
+            // The first tick is staggered per repo so that many open repos
+            // don't all fetch at the same instant (thundering herd on every
+            // interval boundary); afterwards each repo keeps its own cadence.
+            tokio::time::sleep(initial_delay).await;
             loop {
-                tokio::time::sleep(interval).await;
-
                 // Perform fetch
                 tracing::info!("Auto-fetching repository: {}", path);
 
@@ -93,6 +96,8 @@ impl AutoFetchService {
                         );
                     }
                 }
+
+                tokio::time::sleep(interval).await;
             }
         });
 
@@ -147,6 +152,22 @@ struct RemoteUpdatesEvent {
     repo_path: String,
     behind: usize,
     ahead: usize,
+}
+
+/// Deterministic per-repo stagger within [0, interval/2), derived from the
+/// repo path. Keeps simultaneous fetches for many open repos spread out
+/// without needing shared state or randomness.
+fn stagger_offset(repo_path: &str, interval: Duration) -> Duration {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let half = interval.as_secs() / 2;
+    if half == 0 {
+        return Duration::ZERO;
+    }
+    let mut hasher = DefaultHasher::new();
+    repo_path.hash(&mut hasher);
+    Duration::from_secs(hasher.finish() % half)
 }
 
 /// Perform a fetch operation
@@ -232,4 +253,50 @@ pub type AutoFetchState = Arc<RwLock<AutoFetchService>>;
 /// Create default auto-fetch state
 pub fn create_autofetch_state() -> AutoFetchState {
     Arc::new(RwLock::new(AutoFetchService::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stagger_offset_is_deterministic() {
+        let interval = Duration::from_secs(300);
+        assert_eq!(
+            stagger_offset("/repo/one", interval),
+            stagger_offset("/repo/one", interval)
+        );
+    }
+
+    #[test]
+    fn test_stagger_offset_within_half_interval() {
+        let interval = Duration::from_secs(300);
+        for path in ["/a", "/b", "/c/deep/path", "/repo with spaces"] {
+            let offset = stagger_offset(path, interval);
+            assert!(
+                offset < Duration::from_secs(150),
+                "offset {offset:?} for {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_stagger_offset_spreads_different_repos() {
+        let interval = Duration::from_secs(600);
+        let offsets: std::collections::HashSet<u64> = (0..20)
+            .map(|i| stagger_offset(&format!("/repo/{i}"), interval).as_secs())
+            .collect();
+        // 20 repos over a 300s window: requiring at least a few distinct
+        // slots keeps the test robust while catching a constant offset.
+        assert!(offsets.len() > 5, "expected spread, got {offsets:?}");
+    }
+
+    #[test]
+    fn test_stagger_offset_zero_interval() {
+        assert_eq!(stagger_offset("/repo", Duration::ZERO), Duration::ZERO);
+        assert_eq!(
+            stagger_offset("/repo", Duration::from_secs(1)),
+            Duration::ZERO
+        );
+    }
 }

--- a/src-tauri/src/services/commit_index.rs
+++ b/src-tauri/src/services/commit_index.rs
@@ -139,6 +139,16 @@ impl CommitIndex {
 
     /// Incrementally update the index with new commits
     pub fn update_incremental(&mut self, repo_path: &str) -> Result<usize> {
+        // An incremental walk stops at the first already-known commit. If this
+        // index was built from a DIFFERENT repository, no commit ever matches
+        // and the entire other history would be prepended into this index.
+        // Rebuild from scratch instead.
+        if self.repo_path != repo_path {
+            let rebuilt = Self::build(repo_path)?;
+            let count = rebuilt.len();
+            *self = rebuilt;
+            return Ok(count);
+        }
         let repo = git2::Repository::open(repo_path)?;
         let mut revwalk = repo.revwalk()?;
 
@@ -215,8 +225,9 @@ impl CommitIndex {
     }
 }
 
-/// Shared commit index state
-pub type SharedCommitIndex = Arc<RwLock<Option<CommitIndex>>>;
+/// Shared commit index state, keyed by repository path so that every open
+/// repository keeps its own independent index.
+pub type SharedCommitIndex = Arc<RwLock<HashMap<String, CommitIndex>>>;
 
 #[cfg(test)]
 mod tests {
@@ -289,6 +300,33 @@ mod tests {
 
         let new_count = index.update_incremental(&repo.path_str()).unwrap();
         assert_eq!(new_count, 0);
+    }
+
+    #[test]
+    fn test_incremental_update_different_repo_rebuilds_instead_of_merging() {
+        let repo_a = TestRepo::with_initial_commit();
+        repo_a.create_commit("Repo A feature", &[("a.txt", "a")]);
+        let repo_b = TestRepo::with_initial_commit();
+        repo_b.create_commit("Repo B feature", &[("b.txt", "b")]);
+
+        let mut index = CommitIndex::build(&repo_a.path_str()).unwrap();
+        assert!(!index
+            .search(Some("Repo A feature"), None, None, None, None)
+            .is_empty());
+
+        // Refreshing against a DIFFERENT repo must rebuild for that repo,
+        // never prepend its whole history into the existing index.
+        index.update_incremental(&repo_b.path_str()).unwrap();
+
+        assert!(!index
+            .search(Some("Repo B feature"), None, None, None, None)
+            .is_empty());
+        assert!(
+            index
+                .search(Some("Repo A feature"), None, None, None, None)
+                .is_empty(),
+            "index must not contain commits from a different repository"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/commit_index.rs
+++ b/src-tauri/src/services/commit_index.rs
@@ -225,9 +225,60 @@ impl CommitIndex {
     }
 }
 
+/// Commit index store: the per-path indexes plus a per-path generation
+/// counter. The generation is bumped whenever a path is dropped, so a build
+/// or refresh that started before a drop can detect (on completion) that its
+/// result is stale and must not overwrite a fresher index inserted after the
+/// drop (e.g. by a rebuild for a reopened tab).
+#[derive(Default)]
+pub struct CommitIndexStore {
+    indexes: HashMap<String, CommitIndex>,
+    generations: HashMap<String, u64>,
+}
+
+impl CommitIndexStore {
+    /// Current generation for a path (0 if never dropped).
+    pub fn generation(&self, path: &str) -> u64 {
+        self.generations.get(path).copied().unwrap_or(0)
+    }
+
+    /// Insert an index for a path only if `expected_generation` still matches
+    /// the current generation — i.e. the path was not dropped while this
+    /// index was being built. Returns true if the index was stored.
+    pub fn insert_if_current(
+        &mut self,
+        path: String,
+        index: CommitIndex,
+        expected_generation: u64,
+    ) -> bool {
+        if self.generation(&path) != expected_generation {
+            return false;
+        }
+        self.indexes.insert(path, index);
+        true
+    }
+
+    /// Take a path's index out for updating (used by incremental refresh).
+    pub fn take(&mut self, path: &str) -> Option<CommitIndex> {
+        self.indexes.remove(path)
+    }
+
+    /// Look up a path's index (for searching).
+    pub fn get(&self, path: &str) -> Option<&CommitIndex> {
+        self.indexes.get(path)
+    }
+
+    /// Drop a path's index and bump its generation so any in-flight build or
+    /// refresh for that path discards its result on completion.
+    pub fn drop_index(&mut self, path: &str) {
+        self.indexes.remove(path);
+        *self.generations.entry(path.to_string()).or_insert(0) += 1;
+    }
+}
+
 /// Shared commit index state, keyed by repository path so that every open
 /// repository keeps its own independent index.
-pub type SharedCommitIndex = Arc<RwLock<HashMap<String, CommitIndex>>>;
+pub type SharedCommitIndex = Arc<RwLock<CommitIndexStore>>;
 
 #[cfg(test)]
 mod tests {
@@ -239,6 +290,36 @@ mod tests {
         let repo = TestRepo::with_initial_commit();
         let index = CommitIndex::build(&repo.path_str()).unwrap();
         assert!(index.len() >= 1);
+    }
+
+    #[test]
+    fn test_store_insert_if_current_respects_generation() {
+        let repo = TestRepo::with_initial_commit();
+        let mut store = CommitIndexStore::default();
+
+        // A build that captured generation 0 and finished normally is stored
+        let idx0 = CommitIndex::build(&repo.path_str()).unwrap();
+        assert!(store.insert_if_current(repo.path_str(), idx0, 0));
+        assert!(store.get(&repo.path_str()).is_some());
+
+        // Tab closed: drop bumps the generation to 1
+        store.drop_index(&repo.path_str());
+        assert!(store.get(&repo.path_str()).is_none());
+        assert_eq!(store.generation(&repo.path_str()), 1);
+
+        // Reopen build (started at generation 1) inserts fine
+        let reopen = CommitIndex::build(&repo.path_str()).unwrap();
+        assert!(store.insert_if_current(repo.path_str(), reopen, 1));
+        assert!(store.get(&repo.path_str()).is_some());
+
+        // A STALE pre-drop build (generation 0) finishing late must NOT
+        // overwrite the reopened tab's fresh index
+        let stale = CommitIndex::build(&repo.path_str()).unwrap();
+        assert!(!store.insert_if_current(repo.path_str(), stale, 0));
+        assert!(
+            store.get(&repo.path_str()).is_some(),
+            "the reopen index must survive the stale build's late completion"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/watcher_service.rs
+++ b/src-tauri/src/services/watcher_service.rs
@@ -1,7 +1,11 @@
 //! File system watcher service
+//!
+//! Watches any number of repositories at once. Every event is tagged with the
+//! repository path it came from so consumers can route it to the right repo.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{channel, Receiver};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::time::Duration;
 
 use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
@@ -21,72 +25,82 @@ pub enum WatcherEvent {
     ConfigChanged,
 }
 
-/// Service for watching file system changes in a repository
+/// Service for watching file system changes across open repositories
 pub struct WatcherService {
-    watcher: Option<RecommendedWatcher>,
-    event_rx: Option<Receiver<Result<Event>>>,
+    watchers: HashMap<String, RecommendedWatcher>,
+    event_tx: Sender<(String, Result<Event>)>,
+    event_rx: Receiver<(String, Result<Event>)>,
 }
 
 impl WatcherService {
     /// Create a new WatcherService
     pub fn new() -> Self {
+        let (event_tx, event_rx) = channel();
         Self {
-            watcher: None,
-            event_rx: None,
+            watchers: HashMap::new(),
+            event_tx,
+            event_rx,
         }
     }
 
-    /// Start watching a repository
+    /// Start watching a repository. Watching the same path again is a no-op;
+    /// other repositories already being watched are unaffected.
     pub fn watch(&mut self, repo_path: &Path) -> Result<()> {
-        let (tx, rx) = channel();
+        let key = repo_path.to_string_lossy().to_string();
+        if self.watchers.contains_key(&key) {
+            return Ok(());
+        }
 
         let config = Config::default().with_poll_interval(Duration::from_secs(1));
 
-        let tx_clone = tx.clone();
-        let watcher = RecommendedWatcher::new(
+        let tx = self.event_tx.clone();
+        let event_key = key.clone();
+        let mut watcher = RecommendedWatcher::new(
             move |result: std::result::Result<Event, notify::Error>| {
                 let event = result
                     .map_err(|e| LeviathanError::OperationFailed(format!("Watch error: {}", e)));
-                let _ = tx_clone.send(event);
+                let _ = tx.send((event_key.clone(), event));
             },
             config,
         )
         .map_err(|e| LeviathanError::OperationFailed(format!("Failed to create watcher: {}", e)))?;
 
-        self.watcher = Some(watcher);
-        self.event_rx = Some(rx);
+        watcher
+            .watch(repo_path, RecursiveMode::Recursive)
+            .map_err(|e| LeviathanError::OperationFailed(format!("Failed to watch: {}", e)))?;
 
-        // Watch the repository directory
-        if let Some(ref mut w) = self.watcher {
-            w.watch(repo_path, RecursiveMode::Recursive)
-                .map_err(|e| LeviathanError::OperationFailed(format!("Failed to watch: {}", e)))?;
-        }
-
+        self.watchers.insert(key, watcher);
         Ok(())
     }
 
-    /// Stop watching
+    /// Stop watching a repository. Other repositories keep their watchers.
     pub fn unwatch(&mut self, repo_path: &Path) -> Result<()> {
-        if let Some(ref mut w) = self.watcher {
-            w.unwatch(repo_path).map_err(|e| {
-                LeviathanError::OperationFailed(format!("Failed to unwatch: {}", e))
-            })?;
+        let key = repo_path.to_string_lossy().to_string();
+        if let Some(mut watcher) = self.watchers.remove(&key) {
+            let _ = watcher.unwatch(repo_path);
         }
-        self.watcher = None;
-        self.event_rx = None;
         Ok(())
     }
 
-    /// Get pending events (non-blocking)
-    pub fn poll_events(&self) -> Vec<WatcherEvent> {
+    /// Stop watching all repositories
+    pub fn unwatch_all(&mut self) {
+        self.watchers.clear();
+    }
+
+    /// Number of repositories currently being watched
+    pub fn watcher_count(&self) -> usize {
+        self.watchers.len()
+    }
+
+    /// Get pending events (non-blocking), each tagged with the repository
+    /// path the event came from
+    pub fn poll_events(&self) -> Vec<(String, WatcherEvent)> {
         let mut events = Vec::new();
 
-        if let Some(ref rx) = self.event_rx {
-            while let Ok(result) = rx.try_recv() {
-                if let Ok(event) = result {
-                    if let Some(watcher_event) = Self::classify_event(&event) {
-                        events.push(watcher_event);
-                    }
+        while let Ok((repo_path, result)) = self.event_rx.try_recv() {
+            if let Ok(event) = result {
+                if let Some(watcher_event) = Self::classify_event(&event) {
+                    events.push((repo_path, watcher_event));
                 }
             }
         }

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -172,6 +172,39 @@ describe('app-shell multi-repo behavior', () => {
     });
   });
 
+  describe('tab cycling shortcuts', () => {
+    it('cycles forward and wraps at the end', () => {
+      const el = createAppShell();
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+      repositoryStore.getState().addRepository(mockRepo('/repo/three', 'three'));
+      // active is 2 (last added)
+
+      (el as any).cycleRepositoryTab(1);
+      expect(repositoryStore.getState().activeIndex).to.equal(0);
+      (el as any).cycleRepositoryTab(1);
+      expect(repositoryStore.getState().activeIndex).to.equal(1);
+    });
+
+    it('cycles backward and wraps at the start', () => {
+      const el = createAppShell();
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+      repositoryStore.getState().setActiveIndex(0);
+
+      (el as any).cycleRepositoryTab(-1);
+      expect(repositoryStore.getState().activeIndex).to.equal(1);
+    });
+
+    it('is a no-op with fewer than two repos', () => {
+      const el = createAppShell();
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+
+      (el as any).cycleRepositoryTab(1);
+      expect(repositoryStore.getState().activeIndex).to.equal(0);
+    });
+  });
+
   describe('background repo staleness', () => {
     it('marks a background repo stale on watcher events instead of refreshing it', () => {
       const el = createAppShell();

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -401,38 +401,77 @@ describe('app-shell multi-repo behavior', () => {
   });
 
   describe('tab badge hydration', () => {
-    it('loads status and branches into the store for newly opened repos', async () => {
+    const oneBranch = [
+      {
+        name: 'main',
+        shorthand: 'main',
+        isHead: true,
+        isRemote: false,
+        upstream: 'origin/main',
+        targetOid: 'abc',
+        isStale: false,
+      },
+    ];
+
+    it('hydrates BOTH status and branches for a background repo', async () => {
       mockResponses['get_status'] = () => [
         { path: 'a.txt', status: 'modified', isStaged: false, isConflicted: false },
       ];
-      mockResponses['get_branches'] = () => [
-        {
-          name: 'main',
-          shorthand: 'main',
-          isHead: true,
-          isRemote: false,
-          upstream: 'origin/main',
-          targetOid: 'abc',
-          isStale: false,
-        },
-      ];
+      mockResponses['get_branches'] = () => oneBranch;
 
       const el = createAppShell();
       document.body.appendChild(el);
       try {
-        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        // Open the way restore/workspace does: activate: false keeps /repo/bg
+        // a background tab that is never transiently active.
+        repositoryStore.getState().addRepository(mockRepo('/repo/active', 'active'));
+        repositoryStore.getState().addRepository(mockRepo('/repo/bg', 'bg'), { activate: false });
         await waitUntil(
-          () => repositoryStore.getState().openRepositories[0]?.status.length > 0,
-          'expected status to be hydrated into the store'
+          () => {
+            const bg = repositoryStore
+              .getState()
+              .openRepositories.find((r) => r.repository.path === '/repo/bg');
+            return !!bg && bg.status.length > 0;
+          },
+          'expected the background repo status to be hydrated'
         );
 
-        const repo = repositoryStore.getState().openRepositories[0];
-        expect(repo.status.length).to.equal(1);
-        expect(repo.unstagedFiles.length).to.equal(1);
-        expect(repo.currentBranch?.name).to.equal('main');
+        const bg = repositoryStore
+          .getState()
+          .openRepositories.find((r) => r.repository.path === '/repo/bg')!;
+        expect(bg.status.length).to.equal(1);
+        expect(bg.unstagedFiles.length).to.equal(1);
+        // Background repos have no mounted branch list — hydration supplies it
+        expect(bg.currentBranch?.name).to.equal('main');
       } finally {
         el.remove();
       }
+    });
+
+    it('hydrates status but NOT branches for the active repo (the branch list owns branches)', async () => {
+      // Drive hydrateRepoBadges directly on a disconnected shell so only the
+      // hydration path runs (a mounted branch list would also call
+      // get_branches, masking whether hydration itself skips it).
+      let branchCalls = 0;
+      mockResponses['get_status'] = () => [
+        { path: 'a.txt', status: 'modified', isStaged: false, isConflicted: false },
+      ];
+      mockResponses['get_branches'] = () => {
+        branchCalls++;
+        return oneBranch;
+      };
+
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/one', 'one') };
+
+      await (el as any).hydrateRepoBadges('/repo/one');
+
+      const repo = repositoryStore.getState().openRepositories[0];
+      expect(repo.status.length).to.equal(1);
+      // Active repo's branches come from the branch list, not hydration
+      expect(branchCalls).to.equal(0);
+      expect(invokeCallArgs.some((c) => c.command === 'get_status')).to.be.true;
     });
   });
 

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -519,6 +519,44 @@ describe('app-shell multi-repo behavior', () => {
     });
   });
 
+  describe('search filter does not leak across tab switches', () => {
+    it("clears the graph canvas's searchFilter when the active repo changes", async () => {
+      // Regression: the canvas searchFilter was set imperatively and never
+      // bound in the template, so a tab switch left it holding the previous
+      // repo's filter — dimming the new repo's graph for a query never
+      // applied to it. It's now a reactive `.searchFilter` binding cleared
+      // by app-shell's repo-change handler.
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        // Apply a filter on repo A
+        (el as any).handleSearchChange(
+          new CustomEvent('search-change', {
+            detail: { filter: { query: 'wip', author: '', dateFrom: '', dateTo: '', filePath: '', branch: '', searchMode: 'keyword' } },
+          })
+        );
+        await el.updateComplete;
+        const canvas = el.shadowRoot!.querySelector('lv-graph-canvas') as unknown as {
+          searchFilter: unknown;
+        };
+        expect(canvas.searchFilter, 'filter applied to active repo').to.not.be.null;
+
+        // Switch to repo B — the binding must clear the canvas filter
+        repositoryStore.getState().setActiveByPath('/repo/b');
+        await el.updateComplete;
+        expect((el as any).searchFilter, 'app-shell clears its filter on switch').to.be.null;
+        expect(canvas.searchFilter, 'canvas filter cleared via binding').to.be.null;
+      } finally {
+        el.remove();
+      }
+    });
+  });
+
   describe('watcher lifecycle across open repos', () => {
     it('starts a watcher for every opened repo, not just the active one', async () => {
       const el = createAppShell();

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -222,6 +222,79 @@ describe('app-shell multi-repo behavior', () => {
     });
   });
 
+  describe('footer ahead/behind badge on tab switch', () => {
+    it("resets to the newly active repo's last-known counts", async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().updateRepoData('/repo/a', {
+          currentBranch: {
+            name: 'main',
+            shorthand: 'main',
+            isHead: true,
+            isRemote: false,
+            upstream: 'origin/main',
+            targetOid: 'abc',
+            isStale: false,
+            aheadBehind: { ahead: 0, behind: 3 },
+          },
+        });
+        // Simulate a badge left over from the previously active repo
+        (el as any).remoteStatus = { ahead: 9, behind: 9 };
+
+        repositoryStore.getState().setActiveIndex(0);
+        await new Promise((r) => setTimeout(r, 0));
+        expect((el as any).remoteStatus).to.deep.equal({ ahead: 0, behind: 3 });
+
+        // Switching to a repo with no known counts clears the badge instead
+        // of showing the previous repo's numbers
+        repositoryStore.getState().setActiveIndex(1);
+        await new Promise((r) => setTimeout(r, 0));
+        expect((el as any).remoteStatus).to.be.null;
+      } finally {
+        el.remove();
+      }
+    });
+  });
+
+  describe('tab badge hydration', () => {
+    it('loads status and branches into the store for newly opened repos', async () => {
+      mockResponses['get_status'] = () => [
+        { path: 'a.txt', status: 'modified', isStaged: false, isConflicted: false },
+      ];
+      mockResponses['get_branches'] = () => [
+        {
+          name: 'main',
+          shorthand: 'main',
+          isHead: true,
+          isRemote: false,
+          upstream: 'origin/main',
+          targetOid: 'abc',
+          isStale: false,
+        },
+      ];
+
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        await waitUntil(
+          () => repositoryStore.getState().openRepositories[0]?.status.length > 0,
+          'expected status to be hydrated into the store'
+        );
+
+        const repo = repositoryStore.getState().openRepositories[0];
+        expect(repo.status.length).to.equal(1);
+        expect(repo.unstagedFiles.length).to.equal(1);
+        expect(repo.currentBranch?.name).to.equal('main');
+      } finally {
+        el.remove();
+      }
+    });
+  });
+
   describe('watcher lifecycle across open repos', () => {
     it('starts a watcher for every opened repo, not just the active one', async () => {
       const el = createAppShell();

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -8,21 +8,25 @@
 
 // ── Tauri mock (must be set before any imports) ────────────────────────────
 const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
+// Per-command mock responses; commands without a handler resolve to null
+const mockResponses: Record<string, (args: Record<string, unknown>) => unknown> = {};
 
 let cbId = 0;
 (globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
   invoke: (command: string, args?: Record<string, unknown>) => {
     invokeCallArgs.push({ command, args: args || {} });
-    return Promise.resolve(null);
+    const handler = mockResponses[command];
+    return Promise.resolve(handler ? handler(args || {}) : null);
   },
   transformCallback: () => cbId++,
 };
 
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
-import { expect } from '@open-wc/testing';
+import { expect, waitUntil } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import '../app-shell.ts';
 import { uiStore, repositoryStore } from '../stores/index.ts';
+import { searchIndexService } from '../services/search-index.service.ts';
 import type { Repository } from '../types/git.types.ts';
 
 function createAppShell(): AppShell {
@@ -48,8 +52,12 @@ function mockRepo(path: string, name: string): Repository {
 describe('app-shell multi-repo behavior', () => {
   beforeEach(() => {
     invokeCallArgs.length = 0;
+    for (const key of Object.keys(mockResponses)) {
+      delete mockResponses[key];
+    }
     uiStore.setState({ toasts: [] });
     repositoryStore.getState().reset();
+    searchIndexService.invalidate();
   });
 
   describe('autofetch badge scoping', () => {
@@ -166,6 +174,69 @@ describe('app-shell multi-repo behavior', () => {
         const dropCall = invokeCallArgs.find((c) => c.command === 'drop_search_index');
         expect(dropCall).to.not.be.undefined;
         expect(dropCall!.args.path).to.equal('/repo/one');
+      } finally {
+        el.remove();
+      }
+    });
+  });
+
+  describe('startup restore', () => {
+    it('opens every persisted repo but builds indexes only for the active one', async () => {
+      mockResponses['open_repository'] = (args) => mockRepo(args.path as string, 'restored');
+      repositoryStore.setState({
+        persistedOpenRepos: [
+          { path: '/repo/one', name: 'one' },
+          { path: '/repo/two', name: 'two' },
+          { path: '/repo/three', name: 'three' },
+        ],
+      });
+
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        await waitUntil(
+          () => repositoryStore.getState().openRepositories.length === 3,
+          'expected all three persisted repos to be restored'
+        );
+        // Allow post-restore async work (remotes, index kick-off) to settle
+        await new Promise((r) => setTimeout(r, 50));
+
+        const openedPaths = invokeCallArgs
+          .filter((c) => c.command === 'open_repository')
+          .map((c) => c.args.path);
+        expect(openedPaths).to.have.members(['/repo/one', '/repo/two', '/repo/three']);
+
+        // Index builds are lazy: only the ACTIVE repo (last restored) gets
+        // one at startup — a search-index walk plus an embedding pass per
+        // background repo made startup CPU-bound with many tabs.
+        const buildPaths = invokeCallArgs
+          .filter((c) => c.command === 'build_search_index')
+          .map((c) => c.args.path);
+        expect(buildPaths).to.deep.equal(['/repo/three']);
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('builds a repo index lazily when its tab is first activated', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+        await new Promise((r) => setTimeout(r, 0));
+        // Simulate repos restored without indexes (the startup path skips
+        // background repos' builds)
+        searchIndexService.invalidate();
+        invokeCallArgs.length = 0;
+
+        repositoryStore.getState().setActiveIndex(0);
+        await new Promise((r) => setTimeout(r, 0));
+
+        const buildPaths = invokeCallArgs
+          .filter((c) => c.command === 'build_search_index')
+          .map((c) => c.args.path);
+        expect(buildPaths).to.deep.equal(['/repo/one']);
       } finally {
         el.remove();
       }

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -25,7 +25,7 @@ let cbId = 0;
 import { expect, waitUntil } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import '../app-shell.ts';
-import { uiStore, repositoryStore } from '../stores/index.ts';
+import { uiStore, repositoryStore, settingsStore } from '../stores/index.ts';
 import { searchIndexService } from '../services/search-index.service.ts';
 import type { Repository } from '../types/git.types.ts';
 
@@ -136,6 +136,92 @@ describe('app-shell multi-repo behavior', () => {
     });
   });
 
+  describe('auto-fetch lifecycle across open repos', () => {
+    it('starts auto-fetch for newly opened repos when an interval is set', async () => {
+      settingsStore.setState({ autoFetchInterval: 5 });
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        await new Promise((r) => setTimeout(r, 0));
+
+        const startCall = invokeCallArgs.find((c) => c.command === 'start_auto_fetch');
+        expect(startCall).to.not.be.undefined;
+        expect(startCall!.args.path).to.equal('/repo/one');
+      } finally {
+        el.remove();
+        settingsStore.setState({ autoFetchInterval: 0 });
+      }
+    });
+
+    it('does not start auto-fetch when the interval is disabled', async () => {
+      settingsStore.setState({ autoFetchInterval: 0 });
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(invokeCallArgs.find((c) => c.command === 'start_auto_fetch')).to.be.undefined;
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('stops auto-fetch when a repo tab is closed', async () => {
+      settingsStore.setState({ autoFetchInterval: 5 });
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+        await new Promise((r) => setTimeout(r, 0));
+        invokeCallArgs.length = 0;
+
+        repositoryStore.getState().removeRepository('/repo/one');
+        await new Promise((r) => setTimeout(r, 0));
+
+        const stopCall = invokeCallArgs.find((c) => c.command === 'stop_auto_fetch');
+        expect(stopCall).to.not.be.undefined;
+        expect(stopCall!.args.path).to.equal('/repo/one');
+      } finally {
+        el.remove();
+        settingsStore.setState({ autoFetchInterval: 0 });
+      }
+    });
+  });
+
+  describe('background autofetch results update tab badge data', () => {
+    it("writes a background repo's ahead/behind into the store", () => {
+      const el = createAppShell();
+      repositoryStore.getState().addRepository(mockRepo('/repo/bg', 'bg'));
+      repositoryStore.getState().updateRepoData('/repo/bg', {
+        currentBranch: {
+          name: 'main',
+          shorthand: 'main',
+          isHead: true,
+          isRemote: false,
+          upstream: 'origin/main',
+          targetOid: 'abc',
+          isStale: false,
+        },
+      });
+      (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
+
+      (el as any).handleAutoFetchCompleted({
+        repoPath: '/repo/bg',
+        success: true,
+        ahead: 3,
+        behind: 7,
+      });
+
+      const bg = repositoryStore.getState().openRepositories[0];
+      expect(bg.currentBranch?.aheadBehind).to.deep.equal({ ahead: 3, behind: 7 });
+      // The toolbar badge still only follows the ACTIVE repo
+      expect((el as any).remoteStatus).to.be.null;
+    });
+  });
+
   describe('watcher lifecycle across open repos', () => {
     it('starts a watcher for every opened repo, not just the active one', async () => {
       const el = createAppShell();
@@ -213,6 +299,69 @@ describe('app-shell multi-repo behavior', () => {
           .filter((c) => c.command === 'build_search_index')
           .map((c) => c.args.path);
         expect(buildPaths).to.deep.equal(['/repo/three']);
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('restores the tab that was active last session', async () => {
+      mockResponses['open_repository'] = (args) => mockRepo(args.path as string, 'restored');
+      repositoryStore.setState({
+        persistedOpenRepos: [
+          { path: '/repo/one', name: 'one' },
+          { path: '/repo/two', name: 'two' },
+          { path: '/repo/three', name: 'three' },
+        ],
+        persistedActivePath: '/repo/two',
+      });
+
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        await waitUntil(
+          () => repositoryStore.getState().openRepositories.length === 3,
+          'expected all three persisted repos to be restored'
+        );
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(repositoryStore.getState().activeIndex).to.equal(1);
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('reports and prunes repos that fail to restore', async () => {
+      mockResponses['open_repository'] = (args) => {
+        if (args.path === '/repo/gone') {
+          throw new Error('repository not found');
+        }
+        return mockRepo(args.path as string, 'restored');
+      };
+      repositoryStore.setState({
+        persistedOpenRepos: [
+          { path: '/repo/one', name: 'one' },
+          { path: '/repo/gone', name: 'gone' },
+        ],
+      });
+
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        await waitUntil(
+          () => repositoryStore.getState().openRepositories.length === 1,
+          'expected the healthy repo to be restored'
+        );
+        await waitUntil(
+          () => uiStore.getState().toasts.length > 0,
+          'expected a toast for the failed restore'
+        );
+
+        const toasts = uiStore.getState().toasts;
+        expect(toasts[0].message).to.contain('gone');
+        expect(toasts[0].type).to.equal('error');
+        // Pruned: the failure is not silently retried on every launch
+        const persisted = repositoryStore.getState().persistedOpenRepos.map((r) => r.path);
+        expect(persisted).to.deep.equal(['/repo/one']);
       } finally {
         el.remove();
       }

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Multi-repo correctness tests for app-shell:
+ * - autofetch results from BACKGROUND repos must not drive the toolbar badge
+ * - remote-update toasts must name the repo they belong to
+ * - watcher events for background repos mark them stale instead of refreshing
+ * - closing a repo tears down its watcher and search index
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCallArgs.push({ command, args: args || {} });
+    return Promise.resolve(null);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect } from '@open-wc/testing';
+import type { AppShell } from '../app-shell.ts';
+import '../app-shell.ts';
+import { uiStore, repositoryStore } from '../stores/index.ts';
+import type { Repository } from '../types/git.types.ts';
+
+function createAppShell(): AppShell {
+  return document.createElement('lv-app-shell') as AppShell;
+}
+
+function mockRepo(path: string, name: string): Repository {
+  return {
+    path,
+    name,
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('app-shell multi-repo behavior', () => {
+  beforeEach(() => {
+    invokeCallArgs.length = 0;
+    uiStore.setState({ toasts: [] });
+    repositoryStore.getState().reset();
+  });
+
+  describe('autofetch badge scoping', () => {
+    it('updates the badge when the ACTIVE repo fetched', () => {
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
+
+      (el as any).handleAutoFetchCompleted({
+        repoPath: '/repo/active',
+        success: true,
+        ahead: 1,
+        behind: 2,
+      });
+
+      expect((el as any).remoteStatus).to.deep.equal({ ahead: 1, behind: 2 });
+    });
+
+    it('ignores results from BACKGROUND repos', () => {
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
+      (el as any).remoteStatus = { ahead: 0, behind: 0 };
+
+      (el as any).handleAutoFetchCompleted({
+        repoPath: '/repo/background',
+        success: true,
+        ahead: 9,
+        behind: 9,
+      });
+
+      expect((el as any).remoteStatus).to.deep.equal({ ahead: 0, behind: 0 });
+    });
+
+    it('ignores failed fetches', () => {
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
+      (el as any).remoteStatus = { ahead: 0, behind: 0 };
+
+      (el as any).handleAutoFetchCompleted({
+        repoPath: '/repo/active',
+        success: false,
+        ahead: 5,
+        behind: 5,
+      });
+
+      expect((el as any).remoteStatus).to.deep.equal({ ahead: 0, behind: 0 });
+    });
+  });
+
+  describe('remote-updates toast', () => {
+    it('names the repo the commits arrived in', () => {
+      const el = createAppShell();
+
+      (el as any).handleRemoteUpdatesAvailable({
+        repoPath: '/home/user/projects/api-server',
+        behind: 3,
+        ahead: 0,
+      });
+
+      const toasts = uiStore.getState().toasts;
+      expect(toasts.length).to.equal(1);
+      expect(toasts[0].message).to.contain('api-server');
+      expect(toasts[0].message).to.contain('3 new commits');
+    });
+
+    it('uses singular wording for one commit', () => {
+      const el = createAppShell();
+
+      (el as any).handleRemoteUpdatesAvailable({
+        repoPath: '/home/user/projects/api-server',
+        behind: 1,
+        ahead: 0,
+      });
+
+      const toasts = uiStore.getState().toasts;
+      expect(toasts[0].message).to.contain('1 new commit available');
+    });
+  });
+
+  describe('watcher lifecycle across open repos', () => {
+    it('starts a watcher for every opened repo, not just the active one', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+        await new Promise((r) => setTimeout(r, 0));
+
+        const watched = invokeCallArgs
+          .filter((c) => c.command === 'start_watching')
+          .map((c) => c.args.path);
+        expect(watched).to.include('/repo/one');
+        expect(watched).to.include('/repo/two');
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('closing a repo stops its watcher and drops its search index', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+        await new Promise((r) => setTimeout(r, 0));
+        invokeCallArgs.length = 0;
+
+        repositoryStore.getState().removeRepository('/repo/one');
+        await new Promise((r) => setTimeout(r, 0));
+
+        const stopCall = invokeCallArgs.find((c) => c.command === 'stop_watching');
+        expect(stopCall).to.not.be.undefined;
+        expect(stopCall!.args.path).to.equal('/repo/one');
+
+        const dropCall = invokeCallArgs.find((c) => c.command === 'drop_search_index');
+        expect(dropCall).to.not.be.undefined;
+        expect(dropCall!.args.path).to.equal('/repo/one');
+      } finally {
+        el.remove();
+      }
+    });
+  });
+
+  describe('background repo staleness', () => {
+    it('marks a background repo stale on watcher events instead of refreshing it', () => {
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
+      (el as any).watchedRepoPaths = new Set(['/repo/active', '/repo/background']);
+
+      let refreshed = 0;
+      (el as any).handleRefresh = () => {
+        refreshed++;
+        return Promise.resolve();
+      };
+
+      (el as any).handleWatcherEvent({
+        repoPath: '/repo/background',
+        eventType: 'refs-changed',
+        paths: [],
+      });
+
+      expect(refreshed).to.equal(0);
+      expect((el as any).staleRepoPaths.has('/repo/background')).to.be.true;
+    });
+
+    it('debounce-refreshes when the ACTIVE repo has ref changes', async () => {
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
+
+      let refreshed = 0;
+      (el as any).handleRefresh = () => {
+        refreshed++;
+        return Promise.resolve();
+      };
+
+      (el as any).handleWatcherEvent({
+        repoPath: '/repo/active',
+        eventType: 'refs-changed',
+        paths: [],
+      });
+
+      // refs-changed refresh is debounced by 200ms
+      await new Promise((r) => setTimeout(r, 250));
+      expect(refreshed).to.equal(1);
+    });
+
+    it('refreshes a stale repo when its tab becomes active', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        let refreshed = 0;
+        (el as any).handleRefresh = () => {
+          refreshed++;
+          return Promise.resolve();
+        };
+
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Repo one changes while it's a background tab
+        (el as any).handleWatcherEvent({
+          repoPath: '/repo/one',
+          eventType: 'refs-changed',
+          paths: [],
+        });
+        expect(refreshed).to.equal(0);
+
+        // Activating repo one triggers exactly one refresh and clears staleness
+        repositoryStore.getState().setActiveIndex(0);
+        await new Promise((r) => setTimeout(r, 0));
+        expect(refreshed).to.equal(1);
+        expect((el as any).staleRepoPaths.has('/repo/one')).to.be.false;
+
+        // Switching back and forth again without new events does NOT re-refresh
+        repositoryStore.getState().setActiveIndex(1);
+        repositoryStore.getState().setActiveIndex(0);
+        await new Promise((r) => setTimeout(r, 0));
+        expect(refreshed).to.equal(1);
+      } finally {
+        el.remove();
+      }
+    });
+  });
+});

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -222,6 +222,105 @@ describe('app-shell multi-repo behavior', () => {
     });
   });
 
+  describe('badge hydration throttling', () => {
+    it('caps concurrent hydrations instead of firing one per repo at once', async () => {
+      let releaseStatuses!: () => void;
+      const statusGate = new Promise<void>((resolve) => {
+        releaseStatuses = resolve;
+      });
+      mockResponses['get_status'] = () => statusGate.then(() => []);
+      mockResponses['get_branches'] = () => statusGate.then(() => []);
+
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        for (let i = 0; i < 5; i++) {
+          repositoryStore
+            .getState()
+            .addRepository(mockRepo(`/repo/${i}`, `r${i}`), { activate: false });
+        }
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Only 2 hydrations (one get_status each) may be in flight at once
+        const inFlight = invokeCallArgs.filter((c) => c.command === 'get_status').length;
+        expect(inFlight).to.equal(2);
+
+        releaseStatuses();
+        await waitUntil(
+          () => invokeCallArgs.filter((c) => c.command === 'get_status').length === 5,
+          'expected the queue to drain all five hydrations'
+        );
+      } finally {
+        el.remove();
+      }
+    });
+  });
+
+  describe('batch tab open (workspace-style)', () => {
+    it('runs activation work only for the repo activated at the end', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        searchIndexService.invalidate();
+        // Open three repos the way workspace-open now does
+        for (const p of ['/ws/one', '/ws/two', '/ws/three']) {
+          repositoryStore.getState().addRepository(mockRepo(p, p), { activate: false });
+        }
+        repositoryStore.getState().setActiveByPath('/ws/three');
+        await new Promise((r) => setTimeout(r, 10));
+
+        const buildPaths = invokeCallArgs
+          .filter((c) => c.command === 'build_search_index')
+          .map((c) => c.args.path);
+        expect(buildPaths).to.deep.equal(['/ws/three']);
+      } finally {
+        el.remove();
+      }
+    });
+  });
+
+  describe('tab close teardown extras', () => {
+    it('cancels an in-flight embedding build for the closed repo', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+        await new Promise((r) => setTimeout(r, 0));
+        invokeCallArgs.length = 0;
+
+        repositoryStore.getState().removeRepository('/repo/one');
+        await new Promise((r) => setTimeout(r, 0));
+
+        const cancelCall = invokeCallArgs.find((c) => c.command === 'cancel_embedding_build');
+        expect(cancelCall).to.not.be.undefined;
+        expect(cancelCall!.args.path).to.equal('/repo/one');
+      } finally {
+        el.remove();
+      }
+    });
+  });
+
+  describe('active repo badge liveness', () => {
+    it('schedules a badge refresh for the ACTIVE repo on workdir events', () => {
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
+      (el as any).watchedRepoPaths = new Set(['/repo/active']);
+
+      (el as any).handleWatcherEvent({
+        repoPath: '/repo/active',
+        eventType: 'workdir-changed',
+        paths: [],
+      });
+
+      // The 1s-debounced hydration is scheduled even though the repo is
+      // active (the status panel may be hidden)
+      expect((el as any).badgeHydrationTimers.has('/repo/active')).to.be.true;
+      // Cleanup the pending timer
+      clearTimeout((el as any).badgeHydrationTimers.get('/repo/active'));
+    });
+  });
+
   describe('footer ahead/behind badge on tab switch', () => {
     it("resets to the newly active repo's last-known counts", async () => {
       const el = createAppShell();

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -327,6 +327,50 @@ describe('app-shell multi-repo behavior', () => {
         el.remove();
       }
     });
+
+    it('disconnect tears down the SAME per-repo services as closing a tab', async () => {
+      // Regression: disconnectedCallback used to stop only the watcher and
+      // auto-fetch, leaking commit indexes and in-flight embedding builds on
+      // remount. It now runs the same teardown as a tab close.
+      const el = createAppShell();
+      document.body.appendChild(el);
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      await new Promise((r) => setTimeout(r, 0));
+      invokeCallArgs.length = 0;
+
+      el.remove(); // triggers disconnectedCallback
+      await new Promise((r) => setTimeout(r, 0));
+
+      const cmds = invokeCallArgs.map((c) => c.command);
+      expect(cmds).to.include('stop_watching');
+      expect(cmds).to.include('cancel_embedding_build');
+      expect(cmds).to.include('stop_auto_fetch');
+    });
+  });
+
+  describe('lazy embedding build guard', () => {
+    it('does not start an embedding build for a repo closed during getStatus', async () => {
+      // Regression: a close landing during ensureRepoIndexes' getStatus
+      // round-trip could still launch a multi-minute ONNX build for a gone
+      // repo (cancelBuild can't cancel a build that hadn't started).
+      let releaseStatus!: (v: unknown) => void;
+      mockResponses['get_embedding_index_status'] = () =>
+        new Promise((resolve) => {
+          releaseStatus = resolve;
+        });
+
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/one', 'one') };
+      // repo is NOT in the store → treated as closed when status resolves
+      (el as any).ensureRepoIndexes('/repo/one');
+      await new Promise((r) => setTimeout(r, 0));
+      invokeCallArgs.length = 0;
+
+      releaseStatus({ isReady: false, isBuilding: false, indexedCommits: 0, totalCommits: 0 });
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(invokeCallArgs.find((c) => c.command === 'build_embedding_index')).to.be.undefined;
+    });
   });
 
   describe('active repo badge liveness', () => {

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -168,6 +168,34 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('does not restart auto-fetch timers on unrelated settings changes', async () => {
+      // Regression: every settings write (theme, tray, ...) restarted every
+      // repo's fetch timer, indefinitely deferring the first fetch for users
+      // who tweak settings often.
+      settingsStore.setState({ autoFetchInterval: 5 });
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        await new Promise((r) => setTimeout(r, 0));
+        invokeCallArgs.length = 0;
+
+        settingsStore.setState({ minimizeToTray: true });
+        await new Promise((r) => setTimeout(r, 0));
+        expect(invokeCallArgs.find((c) => c.command === 'start_auto_fetch')).to.be.undefined;
+
+        // An ACTUAL interval change does restart
+        settingsStore.setState({ autoFetchInterval: 10 });
+        await new Promise((r) => setTimeout(r, 0));
+        const startCall = invokeCallArgs.find((c) => c.command === 'start_auto_fetch');
+        expect(startCall).to.not.be.undefined;
+        expect(startCall!.args.intervalMinutes).to.equal(10);
+      } finally {
+        el.remove();
+        settingsStore.setState({ autoFetchInterval: 0, minimizeToTray: false });
+      }
+    });
+
     it('stops auto-fetch when a repo tab is closed', async () => {
       settingsStore.setState({ autoFetchInterval: 5 });
       const el = createAppShell();
@@ -302,10 +330,11 @@ describe('app-shell multi-repo behavior', () => {
   });
 
   describe('active repo badge liveness', () => {
-    it('schedules a badge refresh for the ACTIVE repo on workdir events', () => {
+    it('schedules a badge refresh for the ACTIVE repo when the right panel is hidden', () => {
       const el = createAppShell();
       (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
       (el as any).watchedRepoPaths = new Set(['/repo/active']);
+      (el as any).rightPanelVisible = false;
 
       (el as any).handleWatcherEvent({
         repoPath: '/repo/active',
@@ -313,11 +342,24 @@ describe('app-shell multi-repo behavior', () => {
         paths: [],
       });
 
-      // The 1s-debounced hydration is scheduled even though the repo is
-      // active (the status panel may be hidden)
       expect((el as any).badgeHydrationTimers.has('/repo/active')).to.be.true;
       // Cleanup the pending timer
       clearTimeout((el as any).badgeHydrationTimers.get('/repo/active'));
+    });
+
+    it('skips the badge refresh while the right panel is mounted (it already mirrors status)', () => {
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
+      (el as any).watchedRepoPaths = new Set(['/repo/active']);
+      (el as any).rightPanelVisible = true;
+
+      (el as any).handleWatcherEvent({
+        repoPath: '/repo/active',
+        eventType: 'workdir-changed',
+        paths: [],
+      });
+
+      expect((el as any).badgeHydrationTimers.has('/repo/active')).to.be.false;
     });
   });
 

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -54,6 +54,7 @@ import { progressService } from './services/progress.service.ts';
 import type { ProgressOperation } from './components/common/lv-progress-indicator.ts';
 import './components/dashboard/lv-context-dashboard.ts';
 import type { CommitSelectedEvent, LvGraphCanvas } from './components/graph/lv-graph-canvas.ts';
+import { evictGraphCache } from './components/graph/lv-graph-canvas.ts';
 import type { LvCreateTagDialog } from './components/dialogs/lv-create-tag-dialog.ts';
 import type { LvCreateBranchDialog } from './components/dialogs/lv-create-branch-dialog.ts';
 import type { LvCherryPickDialog } from './components/dialogs/lv-cherry-pick-dialog.ts';
@@ -722,6 +723,11 @@ export class AppShell extends LitElement {
       }
       return;
     }
+    // The ACTIVE repo's tab badges must stay live too: lv-file-status only
+    // mirrors status into the store while the right panel is mounted, so
+    // with the panel hidden the active tab's dirty dot would go stale while
+    // background tabs kept updating.
+    this.scheduleBadgeHydration(event.repoPath);
     if (event.eventType === 'refs-changed') {
       this.handleRefsChanged();
     }
@@ -757,9 +763,42 @@ export class AppShell extends LitElement {
     }
   }
 
-  // Debounced badge refresh for background repos — watcher events can fire
-  // in bursts (builds, npm install), one status query per second per repo
-  // is plenty
+  // Badge hydrations run through a small queue: restoring N tabs must not
+  // fire 2×N git walks into the IPC pool at the same instant (the same
+  // stampede lazy indexes and staggered auto-fetch exist to avoid).
+  private badgeHydrationQueue: string[] = [];
+  private badgeHydrationActive = 0;
+  private static readonly BADGE_HYDRATION_CONCURRENCY = 2;
+
+  private enqueueBadgeHydration(repoPath: string): void {
+    if (this.badgeHydrationQueue.includes(repoPath)) return;
+    this.badgeHydrationQueue.push(repoPath);
+    this.pumpBadgeHydration();
+  }
+
+  private pumpBadgeHydration(): void {
+    while (
+      this.badgeHydrationActive < AppShell.BADGE_HYDRATION_CONCURRENCY &&
+      this.badgeHydrationQueue.length > 0
+    ) {
+      const repoPath = this.badgeHydrationQueue.shift()!;
+      // The repo may have been closed while queued. Checked against the
+      // store (not watchedRepoPaths, which the subscription only updates
+      // AFTER enqueueing newly opened repos).
+      const stillOpen = repositoryStore
+        .getState()
+        .openRepositories.some((r) => r.repository.path === repoPath);
+      if (!stillOpen) continue;
+      this.badgeHydrationActive++;
+      this.hydrateRepoBadges(repoPath).finally(() => {
+        this.badgeHydrationActive--;
+        this.pumpBadgeHydration();
+      });
+    }
+  }
+
+  // Debounced badge refresh for watcher events — they can fire in bursts
+  // (builds, npm install), one status query per second per repo is plenty
   private scheduleBadgeHydration(repoPath: string): void {
     if (this.badgeHydrationTimers.has(repoPath)) return;
     this.badgeHydrationTimers.set(
@@ -767,7 +806,7 @@ export class AppShell extends LitElement {
       setTimeout(() => {
         this.badgeHydrationTimers.delete(repoPath);
         if (this.watchedRepoPaths.has(repoPath)) {
-          this.hydrateRepoBadges(repoPath);
+          this.enqueueBadgeHydration(repoPath);
         }
       }, 1000)
     );
@@ -867,7 +906,7 @@ export class AppShell extends LitElement {
           // Populate tab badge data (dirty dot, ahead/behind) — background
           // tabs are never rendered by the status/branch panels, so without
           // this a restored-but-never-activated tab shows no badges at all
-          this.hydrateRepoBadges(path);
+          this.enqueueBadgeHydration(path);
         }
       }
       for (const path of this.watchedRepoPaths) {
@@ -879,6 +918,13 @@ export class AppShell extends LitElement {
           // Without this the backend keeps fetching (and toasting about) the
           // closed repo forever
           gitService.stopAutoFetch(path);
+          // An ONNX embedding build can run for minutes — don't keep burning
+          // CPU for a tab that no longer exists (no-op when nothing builds)
+          embeddingIndexService.cancelBuild(path).catch(() => {
+            /* nothing to cancel */
+          });
+          // A later repo at the same path must not flash this repo's graph
+          evictGraphCache(path);
           this.staleRepoPaths.delete(path);
           const pendingHydration = this.badgeHydrationTimers.get(path);
           if (pendingHydration) {
@@ -2536,9 +2582,12 @@ export class AppShell extends LitElement {
         })
       );
 
+      // Add without activating each one — activation side effects (index
+      // builds, profile/integration loads) belong to the single tab that
+      // ends up active, chosen below.
       for (const { repo } of results) {
         if (repo) {
-          repositoryStore.getState().addRepository(repo);
+          repositoryStore.getState().addRepository(repo, { activate: false });
         }
       }
 
@@ -2560,11 +2609,16 @@ export class AppShell extends LitElement {
           .map((r) => this.loadRepositoryRemotes(r.persisted.path))
       );
 
-      // Land on the tab the user had active last session, not just the last
-      // one restored
+      // Land on the tab the user had active last session; fall back to the
+      // last successfully restored repo when that one is gone
+      const restoredPaths = results.filter((r) => r.repo !== null).map((r) => r.persisted.path);
       const lastActivePath = repositoryStore.getState().persistedActivePath;
-      if (lastActivePath) {
-        repositoryStore.getState().setActiveByPath(lastActivePath);
+      const targetPath =
+        lastActivePath && restoredPaths.includes(lastActivePath)
+          ? lastActivePath
+          : restoredPaths[restoredPaths.length - 1];
+      if (targetPath) {
+        repositoryStore.getState().setActiveByPath(targetPath);
       }
 
       this.isRestoringRepositories = false;

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -738,25 +738,59 @@ export class AppShell extends LitElement {
     }
   };
 
+  // Per-path monotonic sequence for badge hydration: a superseded hydration
+  // (an older watcher tick's) must not overwrite a newer one's store write.
+  private badgeHydrationSeq = new Map<string, number>();
+
+  // Auto-fetch start/stop are fire-and-forget, but a failure must not be
+  // fully silent — log it (matching the watcher-start error handling) so a
+  // repo silently not auto-fetching is diagnosable.
+  private startAutoFetchLogged(path: string, intervalMinutes: number): void {
+    gitService
+      .startAutoFetch(path, intervalMinutes)
+      .then((r) => {
+        if (!r.success) log.warn('Failed to start auto-fetch for', path, r.error?.message);
+      })
+      .catch((err) => log.warn('Failed to start auto-fetch for', path, err));
+  }
+
+  private stopAutoFetchLogged(path: string): void {
+    gitService
+      .stopAutoFetch(path)
+      .then((r) => {
+        if (!r.success) log.warn('Failed to stop auto-fetch for', path, r.error?.message);
+      })
+      .catch((err) => log.warn('Failed to stop auto-fetch for', path, err));
+  }
+
   /**
-   * Load a repo's status + branches into the path-keyed store so its tab
-   * badges (dirty dot, ahead/behind) render without the repo ever having
-   * been activated. Deliberately light: two cheap queries, no graph or
-   * index work.
+   * Load a repo's status (and, for background repos, branches) into the
+   * path-keyed store so its tab badges (dirty dot, ahead/behind) render
+   * without the repo ever having been activated. Deliberately light: cheap
+   * queries, no graph or index work.
+   *
+   * For the ACTIVE repo the always-mounted branch list already mirrors
+   * branches into the store, so hydrating branches here too would race that
+   * (guarded) writer — hydrate only status for the active repo.
    */
   private async hydrateRepoBadges(repoPath: string): Promise<void> {
+    const seq = (this.badgeHydrationSeq.get(repoPath) ?? 0) + 1;
+    this.badgeHydrationSeq.set(repoPath, seq);
+    const isActive = repoPath === this.activeRepository?.repository.path;
     try {
       const [statusResult, branchesResult] = await Promise.all([
         gitService.getStatus(repoPath),
-        gitService.getBranches(repoPath),
+        isActive ? Promise.resolve(null) : gitService.getBranches(repoPath),
       ]);
+      // A newer hydration for this path superseded us while we were loading
+      if (this.badgeHydrationSeq.get(repoPath) !== seq) return;
       const data: Partial<Omit<OpenRepository, 'repository'>> = {};
       if (statusResult.success && statusResult.data) {
         data.status = statusResult.data;
         data.stagedFiles = statusResult.data.filter((s) => s.isStaged);
         data.unstagedFiles = statusResult.data.filter((s) => !s.isStaged);
       }
-      if (branchesResult.success && branchesResult.data) {
+      if (branchesResult && branchesResult.success && branchesResult.data) {
         data.branches = branchesResult.data;
         data.currentBranch = branchesResult.data.find((b) => b.isHead) ?? null;
       }
@@ -906,7 +940,7 @@ export class AppShell extends LitElement {
           });
           const autoFetchInterval = settingsStore.getState().autoFetchInterval;
           if (autoFetchInterval > 0) {
-            gitService.startAutoFetch(path, autoFetchInterval);
+            this.startAutoFetchLogged(path, autoFetchInterval);
           }
           // Populate tab badge data (dirty dot, ahead/behind) — background
           // tabs are never rendered by the status/branch panels, so without
@@ -922,7 +956,7 @@ export class AppShell extends LitElement {
           searchIndexService.drop(path);
           // Without this the backend keeps fetching (and toasting about) the
           // closed repo forever
-          gitService.stopAutoFetch(path);
+          this.stopAutoFetchLogged(path);
           // An ONNX embedding build can run for minutes — don't keep burning
           // CPU for a tab that no longer exists (no-op when nothing builds)
           embeddingIndexService.cancelBuild(path).catch(() => {
@@ -1110,6 +1144,18 @@ export class AppShell extends LitElement {
       clearTimeout(timer);
     }
     this.badgeHydrationTimers.clear();
+    // Tear down per-repo backend services so a remount (hot reload, tests)
+    // doesn't leave orphaned watchers/auto-fetch tasks running. The normal
+    // process-exit path cleans up implicitly, but explicit teardown keeps
+    // remounts leak-free.
+    for (const path of this.watchedRepoPaths) {
+      watcherService.stopWatching(path).catch(() => {
+        /* backend watcher already gone */
+      });
+      this.stopAutoFetchLogged(path);
+    }
+    this.watchedRepoPaths.clear();
+    this.staleRepoPaths.clear();
     document.removeEventListener('mousemove', this.boundHandleMouseMove);
     document.removeEventListener('mouseup', this.boundHandleMouseUp);
     document.removeEventListener('keydown', this.boundHandleKeyDown);
@@ -2697,11 +2743,11 @@ export class AppShell extends LitElement {
           .openRepositories.map((r) => r.repository.path);
         if (state.autoFetchInterval > 0) {
           for (const path of paths) {
-            gitService.startAutoFetch(path, state.autoFetchInterval);
+            this.startAutoFetchLogged(path, state.autoFetchInterval);
           }
         } else {
           for (const path of paths) {
-            gitService.stopAutoFetch(path);
+            this.stopAutoFetchLogged(path);
           }
         }
       }

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -663,6 +663,8 @@ export class AppShell extends LitElement {
   private watchedRepoPaths = new Set<string>();
   // Background repos that received watcher events and need a refresh when activated
   private staleRepoPaths = new Set<string>();
+  // Debounce timers for background tab-badge refreshes, keyed by repo path
+  private badgeHydrationTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private refsChangedDebounceTimer?: ReturnType<typeof setTimeout>;
   private updateUnlisteners: UnlistenFn[] = [];
   private shownIntegrationSuggestions: Set<string> = new Set();
@@ -709,12 +711,14 @@ export class AppShell extends LitElement {
   }
 
   // Route file-watcher events. Events for the active repo trigger a
-  // (debounced) refresh; events for background repos only mark them stale so
-  // they refresh when their tab becomes active again.
+  // (debounced) refresh; events for background repos mark them stale (full
+  // refresh happens when their tab activates) and refresh just their tab
+  // badge data so the dirty dot / ahead-behind stay live.
   private handleWatcherEvent = (event: watcherService.FileChangeEvent): void => {
     if (event.repoPath !== this.activeRepository?.repository.path) {
       if (this.watchedRepoPaths.has(event.repoPath)) {
         this.staleRepoPaths.add(event.repoPath);
+        this.scheduleBadgeHydration(event.repoPath);
       }
       return;
     }
@@ -722,6 +726,52 @@ export class AppShell extends LitElement {
       this.handleRefsChanged();
     }
   };
+
+  /**
+   * Load a repo's status + branches into the path-keyed store so its tab
+   * badges (dirty dot, ahead/behind) render without the repo ever having
+   * been activated. Deliberately light: two cheap queries, no graph or
+   * index work.
+   */
+  private async hydrateRepoBadges(repoPath: string): Promise<void> {
+    try {
+      const [statusResult, branchesResult] = await Promise.all([
+        gitService.getStatus(repoPath),
+        gitService.getBranches(repoPath),
+      ]);
+      const data: Partial<Omit<OpenRepository, 'repository'>> = {};
+      if (statusResult.success && statusResult.data) {
+        data.status = statusResult.data;
+        data.stagedFiles = statusResult.data.filter((s) => s.isStaged);
+        data.unstagedFiles = statusResult.data.filter((s) => !s.isStaged);
+      }
+      if (branchesResult.success && branchesResult.data) {
+        data.branches = branchesResult.data;
+        data.currentBranch = branchesResult.data.find((b) => b.isHead) ?? null;
+      }
+      if (Object.keys(data).length > 0) {
+        repositoryStore.getState().updateRepoData(repoPath, data);
+      }
+    } catch (err) {
+      log.warn('Failed to hydrate tab badges for', repoPath, err);
+    }
+  }
+
+  // Debounced badge refresh for background repos — watcher events can fire
+  // in bursts (builds, npm install), one status query per second per repo
+  // is plenty
+  private scheduleBadgeHydration(repoPath: string): void {
+    if (this.badgeHydrationTimers.has(repoPath)) return;
+    this.badgeHydrationTimers.set(
+      repoPath,
+      setTimeout(() => {
+        this.badgeHydrationTimers.delete(repoPath);
+        if (this.watchedRepoPaths.has(repoPath)) {
+          this.hydrateRepoBadges(repoPath);
+        }
+      }, 1000)
+    );
+  }
 
   // Handle refs-changed from file watcher (debounced)
   private handleRefsChanged = (): void => {
@@ -814,6 +864,10 @@ export class AppShell extends LitElement {
           if (autoFetchInterval > 0) {
             gitService.startAutoFetch(path, autoFetchInterval);
           }
+          // Populate tab badge data (dirty dot, ahead/behind) — background
+          // tabs are never rendered by the status/branch panels, so without
+          // this a restored-but-never-activated tab shows no badges at all
+          this.hydrateRepoBadges(path);
         }
       }
       for (const path of this.watchedRepoPaths) {
@@ -826,6 +880,11 @@ export class AppShell extends LitElement {
           // closed repo forever
           gitService.stopAutoFetch(path);
           this.staleRepoPaths.delete(path);
+          const pendingHydration = this.badgeHydrationTimers.get(path);
+          if (pendingHydration) {
+            clearTimeout(pendingHydration);
+            this.badgeHydrationTimers.delete(path);
+          }
         }
       }
       this.watchedRepoPaths = openPaths;
@@ -848,6 +907,16 @@ export class AppShell extends LitElement {
 
         // Clear search filter
         this.searchFilter = null;
+
+        // The footer ahead/behind badge belongs to the previous repo —
+        // repopulate from the new repo's last-known counts (autofetch keeps
+        // these fresh) instead of showing repo A's counts under repo B
+        this.remoteStatus = newActiveRepo?.currentBranch?.aheadBehind
+          ? {
+              ahead: newActiveRepo.currentBranch.aheadBehind.ahead,
+              behind: newActiveRepo.currentBranch.aheadBehind.behind,
+            }
+          : null;
 
         // Load profile for new repository and check integration
         if (newActiveRepo) {
@@ -986,6 +1055,10 @@ export class AppShell extends LitElement {
     if (this.refsChangedDebounceTimer) {
       clearTimeout(this.refsChangedDebounceTimer);
     }
+    for (const timer of this.badgeHydrationTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.badgeHydrationTimers.clear();
     document.removeEventListener('mousemove', this.boundHandleMouseMove);
     document.removeEventListener('mouseup', this.boundHandleMouseUp);
     document.removeEventListener('keydown', this.boundHandleKeyDown);

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -742,6 +742,35 @@ export class AppShell extends LitElement {
   // (an older watcher tick's) must not overwrite a newer one's store write.
   private badgeHydrationSeq = new Map<string, number>();
 
+  /**
+   * Tear down every per-repo backend service and client-side cache for a
+   * path. Called both when a tab is closed and when the shell itself
+   * disconnects, so the two paths can never drift out of sync (a leak the
+   * closed-tab path fixed must not silently reappear on remount).
+   */
+  private teardownRepoServices(path: string): void {
+    watcherService.stopWatching(path).catch(() => {
+      /* backend watcher already gone */
+    });
+    searchIndexService.drop(path);
+    // Without this the backend keeps fetching (and toasting about) the
+    // closed repo forever
+    this.stopAutoFetchLogged(path);
+    // An ONNX embedding build can run for minutes — don't keep burning CPU
+    // for a tab that no longer exists (no-op when nothing builds)
+    embeddingIndexService.cancelBuild(path).catch(() => {
+      /* nothing to cancel */
+    });
+    // A later repo at the same path must not flash this repo's graph
+    evictGraphCache(path);
+    this.staleRepoPaths.delete(path);
+    const pendingHydration = this.badgeHydrationTimers.get(path);
+    if (pendingHydration) {
+      clearTimeout(pendingHydration);
+      this.badgeHydrationTimers.delete(path);
+    }
+  }
+
   // Auto-fetch start/stop are fire-and-forget, but a failure must not be
   // fully silent — log it (matching the watcher-start error handling) so a
   // repo silently not auto-fetching is diagnosable.
@@ -950,26 +979,7 @@ export class AppShell extends LitElement {
       }
       for (const path of this.watchedRepoPaths) {
         if (!openPaths.has(path)) {
-          watcherService.stopWatching(path).catch(() => {
-            /* backend watcher already gone */
-          });
-          searchIndexService.drop(path);
-          // Without this the backend keeps fetching (and toasting about) the
-          // closed repo forever
-          this.stopAutoFetchLogged(path);
-          // An ONNX embedding build can run for minutes — don't keep burning
-          // CPU for a tab that no longer exists (no-op when nothing builds)
-          embeddingIndexService.cancelBuild(path).catch(() => {
-            /* nothing to cancel */
-          });
-          // A later repo at the same path must not flash this repo's graph
-          evictGraphCache(path);
-          this.staleRepoPaths.delete(path);
-          const pendingHydration = this.badgeHydrationTimers.get(path);
-          if (pendingHydration) {
-            clearTimeout(pendingHydration);
-            this.badgeHydrationTimers.delete(path);
-          }
+          this.teardownRepoServices(path);
         }
       }
       this.watchedRepoPaths = openPaths;
@@ -1145,14 +1155,11 @@ export class AppShell extends LitElement {
     }
     this.badgeHydrationTimers.clear();
     // Tear down per-repo backend services so a remount (hot reload, tests)
-    // doesn't leave orphaned watchers/auto-fetch tasks running. The normal
-    // process-exit path cleans up implicitly, but explicit teardown keeps
-    // remounts leak-free.
+    // doesn't leave orphaned watchers, auto-fetch tasks, commit indexes, or
+    // in-flight embedding builds running. Uses the exact same teardown as
+    // closing a tab so the two paths can't drift.
     for (const path of this.watchedRepoPaths) {
-      watcherService.stopWatching(path).catch(() => {
-        /* backend watcher already gone */
-      });
-      this.stopAutoFetchLogged(path);
+      this.teardownRepoServices(path);
     }
     this.watchedRepoPaths.clear();
     this.staleRepoPaths.clear();
@@ -2701,7 +2708,13 @@ export class AppShell extends LitElement {
     embeddingIndexService
       .getStatus(repoPath)
       .then((status) => {
-        if (!status.isReady) {
+        // The tab may have been closed during the status round-trip — don't
+        // launch a multi-minute ONNX build for a repo that's gone (the
+        // close-time cancelBuild can't cancel a build that hadn't started).
+        const stillOpen = repositoryStore
+          .getState()
+          .openRepositories.some((r) => r.repository.path === repoPath);
+        if (!status.isReady && stillOpen) {
           return embeddingIndexService.buildIndex(repoPath).then(() => undefined);
         }
         return undefined;

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -810,6 +810,10 @@ export class AppShell extends LitElement {
           watcherService.startWatching(path).catch((err) => {
             log.warn('Failed to start file watcher:', err);
           });
+          const autoFetchInterval = settingsStore.getState().autoFetchInterval;
+          if (autoFetchInterval > 0) {
+            gitService.startAutoFetch(path, autoFetchInterval);
+          }
         }
       }
       for (const path of this.watchedRepoPaths) {
@@ -818,6 +822,9 @@ export class AppShell extends LitElement {
             /* backend watcher already gone */
           });
           searchIndexService.drop(path);
+          // Without this the backend keeps fetching (and toasting about) the
+          // closed repo forever
+          gitService.stopAutoFetch(path);
           this.staleRepoPaths.delete(path);
         }
       }
@@ -2444,28 +2451,48 @@ export class AppShell extends LitElement {
       // sequential open blocks startup for the sum of every repo's open
       // time. Results are added in the original order so tab order is
       // stable regardless of which open finishes first.
-      const opened = await Promise.all(
+      const results = await Promise.all(
         persistedRepos.map(async (persisted) => {
           try {
             const result = await gitService.openRepository({ path: persisted.path });
-            return result.success && result.data ? result.data : null;
+            return { persisted, repo: result.success && result.data ? result.data : null };
           } catch (error) {
             console.warn(`Failed to restore repository: ${persisted.path}`, error);
-            return null;
+            return { persisted, repo: null };
           }
         })
       );
 
-      for (const repo of opened) {
+      for (const { repo } of results) {
         if (repo) {
           repositoryStore.getState().addRepository(repo);
         }
       }
 
+      // A repo that failed to restore (moved, deleted, corrupted) must be
+      // reported — a silently missing tab that silently fails again on every
+      // launch looks like data loss. Prune it so it isn't retried forever;
+      // it stays available in the Recent list.
+      for (const { persisted, repo } of results) {
+        if (!repo) {
+          repositoryStore.getState().prunePersistedRepo(persisted.path);
+          showToast(`Could not restore repository "${persisted.name}" (${persisted.path})`, 'error');
+        }
+      }
+
       // Remotes load in parallel too (path-keyed store update, order-free).
       await Promise.all(
-        opened.filter((r) => r !== null).map((r) => this.loadRepositoryRemotes(r.path))
+        results
+          .filter((r) => r.repo !== null)
+          .map((r) => this.loadRepositoryRemotes(r.persisted.path))
       );
+
+      // Land on the tab the user had active last session, not just the last
+      // one restored
+      const lastActivePath = repositoryStore.getState().persistedActivePath;
+      if (lastActivePath) {
+        repositoryStore.getState().setActiveByPath(lastActivePath);
+      }
 
       this.isRestoringRepositories = false;
 
@@ -2522,32 +2549,26 @@ export class AppShell extends LitElement {
     // Send initial tray settings to backend
     emit('update-tray-settings', { minimizeToTray: settings.minimizeToTray });
 
-    // Subscribe to settings changes to start/stop auto-fetch and update tray
+    // Subscribe to settings changes to start/stop auto-fetch and update tray.
+    // Newly OPENED repos get auto-fetch from the store subscription's
+    // open-set diff (see connectedCallback); this handles interval changes
+    // for repos that are already open.
     this.autoFetchUnsubscribe = settingsStore.subscribe((state) => {
-      const repos = repositoryStore.getState().getPersistedOpenRepos();
+      const paths = repositoryStore
+        .getState()
+        .openRepositories.map((r) => r.repository.path);
       if (state.autoFetchInterval > 0) {
-        for (const repo of repos) {
-          gitService.startAutoFetch(repo.path, state.autoFetchInterval);
+        for (const path of paths) {
+          gitService.startAutoFetch(path, state.autoFetchInterval);
         }
       } else {
-        for (const repo of repos) {
-          gitService.stopAutoFetch(repo.path);
+        for (const path of paths) {
+          gitService.stopAutoFetch(path);
         }
       }
       // Update tray settings
       emit('update-tray-settings', { minimizeToTray: state.minimizeToTray });
     });
-
-    // Start auto-fetch for any already-open repos if interval is set
-    if (settings.autoFetchInterval > 0) {
-      // Wait a bit for repos to be restored before starting auto-fetch
-      setTimeout(() => {
-        const repos = repositoryStore.getState().getPersistedOpenRepos();
-        for (const repo of repos) {
-          gitService.startAutoFetch(repo.path, settings.autoFetchInterval);
-        }
-      }, 3000);
-    }
   }
 
   /**
@@ -2571,8 +2592,10 @@ export class AppShell extends LitElement {
     this.updateUnlisteners.push(unlistenUpdates);
   }
 
-  // Auto-fetch runs for every open repo; only the ACTIVE repo's result may
-  // drive the toolbar ahead/behind badge.
+  // Auto-fetch runs for every open repo. Every successful result updates
+  // that repo's ahead/behind in the store (so tab badges stay fresh even for
+  // background tabs), but only the ACTIVE repo's result may drive the
+  // toolbar badge.
   private handleAutoFetchCompleted = (event: {
     repoPath: string;
     success: boolean;
@@ -2580,19 +2603,33 @@ export class AppShell extends LitElement {
     ahead: number;
     message?: string;
   }): void => {
-    if (event.success && event.repoPath === this.activeRepository?.repository.path) {
+    if (!event.success) return;
+
+    const store = repositoryStore.getState();
+    const repo = store.openRepositories.find((r) => r.repository.path === event.repoPath);
+    if (repo?.currentBranch) {
+      store.updateRepoData(event.repoPath, {
+        currentBranch: {
+          ...repo.currentBranch,
+          aheadBehind: { ahead: event.ahead, behind: event.behind },
+        },
+      });
+    }
+
+    if (event.repoPath === this.activeRepository?.repository.path) {
       this.remoteStatus = { ahead: event.ahead, behind: event.behind };
     }
   };
 
   // With several repos auto-fetching, an unattributed toast is noise — name
-  // the repo the commits arrived in.
+  // the repo the commits arrived in. Split on both separators: Windows is a
+  // shipped target and its paths use backslashes.
   private handleRemoteUpdatesAvailable = (event: {
     repoPath: string;
     behind: number;
     ahead: number;
   }): void => {
-    const repoName = event.repoPath.split('/').pop() || event.repoPath;
+    const repoName = event.repoPath.split(/[\\/]/).filter(Boolean).pop() || event.repoPath;
     showToast(
       `${repoName}: remote has ${event.behind} new commit${event.behind !== 1 ? 's' : ''} available`,
       'info',

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -666,6 +666,9 @@ export class AppShell extends LitElement {
   private staleRepoPaths = new Set<string>();
   // Debounce timers for background tab-badge refreshes, keyed by repo path
   private badgeHydrationTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // Last auto-fetch interval applied to the backend (settings subscription
+  // must only restart timers when THIS value actually changes)
+  private lastAutoFetchInterval = 0;
   private refsChangedDebounceTimer?: ReturnType<typeof setTimeout>;
   private updateUnlisteners: UnlistenFn[] = [];
   private shownIntegrationSuggestions: Set<string> = new Set();
@@ -723,11 +726,13 @@ export class AppShell extends LitElement {
       }
       return;
     }
-    // The ACTIVE repo's tab badges must stay live too: lv-file-status only
-    // mirrors status into the store while the right panel is mounted, so
-    // with the panel hidden the active tab's dirty dot would go stale while
-    // background tabs kept updating.
-    this.scheduleBadgeHydration(event.repoPath);
+    // The ACTIVE repo's tab badges must stay live too — but only when the
+    // right panel is hidden: while it's mounted, lv-file-status already
+    // reloads on these events and mirrors into the store, so hydrating here
+    // as well would just double every status query.
+    if (!this.rightPanelVisible) {
+      this.scheduleBadgeHydration(event.repoPath);
+    }
     if (event.eventType === 'refs-changed') {
       this.handleRefsChanged();
     }
@@ -2679,18 +2684,25 @@ export class AppShell extends LitElement {
     // Subscribe to settings changes to start/stop auto-fetch and update tray.
     // Newly OPENED repos get auto-fetch from the store subscription's
     // open-set diff (see connectedCallback); this handles interval changes
-    // for repos that are already open.
+    // for repos that are already open. Only an ACTUAL interval change may
+    // restart the timers — the subscription fires for every settings write
+    // (theme, tray, ...) and each backend restart resets the fetch delay, so
+    // reacting to unrelated changes would defer fetches indefinitely.
+    this.lastAutoFetchInterval = settings.autoFetchInterval;
     this.autoFetchUnsubscribe = settingsStore.subscribe((state) => {
-      const paths = repositoryStore
-        .getState()
-        .openRepositories.map((r) => r.repository.path);
-      if (state.autoFetchInterval > 0) {
-        for (const path of paths) {
-          gitService.startAutoFetch(path, state.autoFetchInterval);
-        }
-      } else {
-        for (const path of paths) {
-          gitService.stopAutoFetch(path);
+      if (state.autoFetchInterval !== this.lastAutoFetchInterval) {
+        this.lastAutoFetchInterval = state.autoFetchInterval;
+        const paths = repositoryStore
+          .getState()
+          .openRepositories.map((r) => r.repository.path);
+        if (state.autoFetchInterval > 0) {
+          for (const path of paths) {
+            gitService.startAutoFetch(path, state.autoFetchInterval);
+          }
+        } else {
+          for (const path of paths) {
+            gitService.stopAutoFetch(path);
+          }
         }
       }
       // Update tray settings

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -659,6 +659,10 @@ export class AppShell extends LitElement {
   private unsubscribe?: () => void;
   private unsubscribeUi?: () => void;
   private unsubscribeWatcher?: () => void;
+  // Repo paths that currently have a backend file watcher (i.e., all open tabs)
+  private watchedRepoPaths = new Set<string>();
+  // Background repos that received watcher events and need a refresh when activated
+  private staleRepoPaths = new Set<string>();
   private refsChangedDebounceTimer?: ReturnType<typeof setTimeout>;
   private updateUnlisteners: UnlistenFn[] = [];
   private shownIntegrationSuggestions: Set<string> = new Set();
@@ -693,6 +697,21 @@ export class AppShell extends LitElement {
     const detail = (e as CustomEvent).detail as { source?: string } | undefined;
     if (detail?.source === 'app-shell') return;
     this.handleRefresh();
+  };
+
+  // Route file-watcher events. Events for the active repo trigger a
+  // (debounced) refresh; events for background repos only mark them stale so
+  // they refresh when their tab becomes active again.
+  private handleWatcherEvent = (event: watcherService.FileChangeEvent): void => {
+    if (event.repoPath !== this.activeRepository?.repository.path) {
+      if (this.watchedRepoPaths.has(event.repoPath)) {
+        this.staleRepoPaths.add(event.repoPath);
+      }
+      return;
+    }
+    if (event.eventType === 'refs-changed') {
+      this.handleRefsChanged();
+    }
   };
 
   // Handle refs-changed from file watcher (debounced)
@@ -773,6 +792,28 @@ export class AppShell extends LitElement {
       const repoChanged = this.activeRepository?.repository.path !== newActiveRepo?.repository.path;
       this.activeRepository = newActiveRepo;
 
+      // Start/stop per-repo services as tabs open and close. Every OPEN repo
+      // gets a watcher (not just the active one) so background repos don't go
+      // silently stale; closed repos release their watcher and search index.
+      const openPaths = new Set(state.openRepositories.map((r) => r.repository.path));
+      for (const path of openPaths) {
+        if (!this.watchedRepoPaths.has(path)) {
+          watcherService.startWatching(path).catch((err) => {
+            log.warn('Failed to start file watcher:', err);
+          });
+        }
+      }
+      for (const path of this.watchedRepoPaths) {
+        if (!openPaths.has(path)) {
+          watcherService.stopWatching(path).catch(() => {
+            /* backend watcher already gone */
+          });
+          searchIndexService.drop(path);
+          this.staleRepoPaths.delete(path);
+        }
+      }
+      this.watchedRepoPaths = openPaths;
+
       // Clear view state when switching repositories
       if (repoChanged) {
         // Clear selected commit and refs
@@ -803,10 +844,11 @@ export class AppShell extends LitElement {
           if (!newActiveRepo.remotes || newActiveRepo.remotes.length === 0) {
             this.loadRepositoryRemotes(newActiveRepo.repository.path);
           }
-          // Start file watcher for the new repository
-          watcherService.startWatching(newActiveRepo.repository.path).catch((err) => {
-            log.warn('Failed to start file watcher:', err);
-          });
+          // If this repo changed while it was a background tab, its store
+          // data and graph are stale — refresh now that it's visible.
+          if (this.staleRepoPaths.delete(newActiveRepo.repository.path)) {
+            this.handleRefresh();
+          }
         }
       }
     });
@@ -815,12 +857,8 @@ export class AppShell extends LitElement {
       this.rightPanelVisible = state.panels.right.isVisible;
       this.globalLoading = state.globalLoading;
     });
-    // Subscribe to file watcher for refs-changed events (e.g., external pull/fetch)
-    this.unsubscribeWatcher = watcherService.onFileChange((event) => {
-      if (event.eventType === 'refs-changed') {
-        this.handleRefsChanged();
-      }
-    });
+    // Subscribe to file watcher events (routing logic in handleWatcherEvent)
+    this.unsubscribeWatcher = watcherService.onFileChange(this.handleWatcherEvent);
     document.addEventListener('keydown', this.boundHandleKeyDown);
     document.addEventListener('click', this.handleDocumentClick);
     document.addEventListener('contextmenu', this.handleContextMenu);
@@ -2471,26 +2509,45 @@ export class AppShell extends LitElement {
       behind: number;
       ahead: number;
       message?: string;
-    }>('autofetch-completed', (event) => {
-      if (event.success) {
-        this.remoteStatus = { ahead: event.ahead, behind: event.behind };
-      }
-    });
+    }>('autofetch-completed', this.handleAutoFetchCompleted);
     this.updateUnlisteners.push(unlistenFetch);
 
     const unlistenUpdates = await listenToEvent<{
       repoPath: string;
       behind: number;
       ahead: number;
-    }>('remote-updates-available', (event) => {
-      showToast(
-        `Remote has ${event.behind} new commit${event.behind !== 1 ? 's' : ''} available`,
-        'info',
-        5000,
-      );
-    });
+    }>('remote-updates-available', this.handleRemoteUpdatesAvailable);
     this.updateUnlisteners.push(unlistenUpdates);
   }
+
+  // Auto-fetch runs for every open repo; only the ACTIVE repo's result may
+  // drive the toolbar ahead/behind badge.
+  private handleAutoFetchCompleted = (event: {
+    repoPath: string;
+    success: boolean;
+    behind: number;
+    ahead: number;
+    message?: string;
+  }): void => {
+    if (event.success && event.repoPath === this.activeRepository?.repository.path) {
+      this.remoteStatus = { ahead: event.ahead, behind: event.behind };
+    }
+  };
+
+  // With several repos auto-fetching, an unattributed toast is noise — name
+  // the repo the commits arrived in.
+  private handleRemoteUpdatesAvailable = (event: {
+    repoPath: string;
+    behind: number;
+    ahead: number;
+  }): void => {
+    const repoName = event.repoPath.split('/').pop() || event.repoPath;
+    showToast(
+      `${repoName}: remote has ${event.behind} new commit${event.behind !== 1 ? 's' : ''} available`,
+      'info',
+      5000,
+    );
+  };
 
   /**
    * Load remotes for a repository and update the store
@@ -2499,18 +2556,7 @@ export class AppShell extends LitElement {
     try {
       const remotesResult = await gitService.getRemotes(repoPath);
       if (remotesResult.success && remotesResult.data) {
-        // Need to set active index to the repo first, then set remotes
-        const store = repositoryStore.getState();
-        const repoIndex = store.openRepositories.findIndex(r => r.repository.path === repoPath);
-        if (repoIndex >= 0) {
-          const currentIndex = store.activeIndex;
-          store.setActiveIndex(repoIndex);
-          store.setRemotes(remotesResult.data);
-          // Restore active index if different
-          if (currentIndex !== repoIndex && currentIndex >= 0) {
-            store.setActiveIndex(currentIndex);
-          }
-        }
+        repositoryStore.getState().updateRepoData(repoPath, { remotes: remotesResult.data });
       }
     } catch (error) {
       console.warn(`Failed to load remotes for ${repoPath}:`, error);

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2253,11 +2253,13 @@ export class AppShell extends LitElement {
   }
 
   private handleSearchChange(e: CustomEvent<{ filter: SearchFilter }>): void {
+    // The graph canvas receives this via the reactive `.searchFilter`
+    // template binding, so it stays in sync automatically — including being
+    // cleared to null when the active repo changes (tab switch). Pushing it
+    // imperatively here instead would leave the canvas holding the previous
+    // repo's filter on switch, dimming the new repo's graph for a query the
+    // user never applied to it.
     this.searchFilter = e.detail.filter;
-    // Pass filter to graph canvas
-    if (this.graphCanvas) {
-      this.graphCanvas.searchFilter = this.searchFilter;
-    }
   }
 
   private async openCommandPalette(): Promise<void> {
@@ -3126,6 +3128,7 @@ export class AppShell extends LitElement {
                 <div class="graph-area">
                   <lv-graph-canvas
                     repositoryPath=${this.activeRepository.repository.path}
+                    .searchFilter=${this.searchFilter}
                     @commit-selected=${this.handleCommitSelected}
                     @commit-context-menu=${this.handleCommitContextMenu}
                     @ref-context-menu=${this.handleRefContextMenu}

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -845,9 +845,12 @@ export class AppShell extends LitElement {
         // Load profile for new repository and check integration
         if (newActiveRepo) {
           gitService.loadProfileForRepository(newActiveRepo.repository.path);
-          // Only check integration if not restoring repos on startup
+          // Only check integration / build indexes if not restoring repos on
+          // startup (restore handles the final active repo itself)
           if (!this.isRestoringRepositories) {
             this.checkRepositoryIntegration(newActiveRepo.repository.path);
+            // Indexes build lazily on first activation of a tab
+            this.ensureRepoIndexes(newActiveRepo.repository.path);
           }
           // Load remotes if not already loaded
           if (!newActiveRepo.remotes || newActiveRepo.remotes.length === 0) {
@@ -2437,34 +2440,70 @@ export class AppShell extends LitElement {
     uiStore.getState().setGlobalLoading(true);
 
     try {
-      // Open each persisted repository
-      for (const persisted of persistedRepos) {
-        try {
-          const result = await gitService.openRepository({ path: persisted.path });
-          if (result.success && result.data) {
-            repositoryStore.getState().addRepository(result.data);
-            // Build search indexes in background (non-blocking)
-            searchIndexService.buildIndex(persisted.path);
-            embeddingIndexService.buildIndex(persisted.path);
-            // Load remotes for this repository
-            await this.loadRepositoryRemotes(persisted.path);
+      // Open all persisted repositories in PARALLEL — with many repos a
+      // sequential open blocks startup for the sum of every repo's open
+      // time. Results are added in the original order so tab order is
+      // stable regardless of which open finishes first.
+      const opened = await Promise.all(
+        persistedRepos.map(async (persisted) => {
+          try {
+            const result = await gitService.openRepository({ path: persisted.path });
+            return result.success && result.data ? result.data : null;
+          } catch (error) {
+            console.warn(`Failed to restore repository: ${persisted.path}`, error);
+            return null;
           }
-        } catch (error) {
-          console.warn(`Failed to restore repository: ${persisted.path}`, error);
+        })
+      );
+
+      for (const repo of opened) {
+        if (repo) {
+          repositoryStore.getState().addRepository(repo);
         }
       }
 
-      // Restore active index (already persisted, will be set from storage)
+      // Remotes load in parallel too (path-keyed store update, order-free).
+      await Promise.all(
+        opened.filter((r) => r !== null).map((r) => this.loadRepositoryRemotes(r.path))
+      );
+
       this.isRestoringRepositories = false;
 
-      // Check integration for the final active repo only
+      // Index builds are deliberately NOT started for every restored repo —
+      // a search index walk plus an embedding-model inference pass per repo
+      // makes startup CPU-bound with many tabs, and background repos may
+      // never be used. The active repo gets its indexes here; the others
+      // build lazily when their tab is first activated.
       const activeRepo = repositoryStore.getState().getActiveRepository();
       if (activeRepo) {
+        this.ensureRepoIndexes(activeRepo.repository.path);
         this.checkRepositoryIntegration(activeRepo.repository.path);
       }
     } finally {
       uiStore.getState().setGlobalLoading(false);
     }
+  }
+
+  /**
+   * Kick off background search/embedding index builds for a repo if they
+   * aren't ready yet. Safe to call repeatedly — build deduplication and
+   * readiness tracking are per repo.
+   */
+  private ensureRepoIndexes(repoPath: string): void {
+    if (!searchIndexService.isReady(repoPath)) {
+      searchIndexService.buildIndex(repoPath);
+    }
+    embeddingIndexService
+      .getStatus(repoPath)
+      .then((status) => {
+        if (!status.isReady) {
+          return embeddingIndexService.buildIndex(repoPath).then(() => undefined);
+        }
+        return undefined;
+      })
+      .catch(() => {
+        /* semantic search is optional — missing model/status is not an error */
+      });
   }
 
   private async loadWorkspaces(): Promise<void> {

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -699,6 +699,15 @@ export class AppShell extends LitElement {
     this.handleRefresh();
   };
 
+  // Cycle the active repository tab by offset (wraps around both ends)
+  private cycleRepositoryTab(offset: number): void {
+    const state = repositoryStore.getState();
+    const count = state.openRepositories.length;
+    if (count < 2) return;
+    const next = (state.activeIndex + offset + count) % count;
+    state.setActiveIndex(next);
+  }
+
   // Route file-watcher events. Events for the active repo trigger a
   // (debounced) refresh; events for background repos only mark them stale so
   // they refresh when their tab becomes active again.
@@ -946,6 +955,9 @@ export class AppShell extends LitElement {
       push: () => this.handlePush(),
       createStash: () => this.handleCreateStash(),
       closeDiff: () => this.handleCloseOverlay(),
+      nextTab: () => this.cycleRepositoryTab(1),
+      previousTab: () => this.cycleRepositoryTab(-1),
+      selectTab: (index) => repositoryStore.getState().setActiveIndex(index),
     });
 
     // Subscribe to progress updates

--- a/src/components/__tests__/lv-branch-list.test.ts
+++ b/src/components/__tests__/lv-branch-list.test.ts
@@ -984,11 +984,12 @@ describe('lv-branch-list', () => {
       const names = groups.flatMap((g) => g.branches.map((b) => b.name));
       expect(names).to.deep.equal(['fresh-branch']);
 
-      // ...while the stale result still reached the store for ITS repo
+      // ...and the store keeps the NEWEST result for that repo — the
+      // outdated first load is discarded by the per-path sequence guard
       const repoA = repositoryStore
         .getState()
         .openRepositories.find((r) => r.repository.path === REPO_PATH);
-      expect(repoA!.currentBranch!.name).to.equal('stale-branch');
+      expect(repoA!.currentBranch!.name).to.equal('fresh-branch');
     });
 
     it('mirrors loaded branches and current branch into the repository store', async () => {

--- a/src/components/__tests__/lv-branch-list.test.ts
+++ b/src/components/__tests__/lv-branch-list.test.ts
@@ -941,6 +941,56 @@ describe('lv-branch-list', () => {
       } as any);
     });
 
+    it('a stale branches result must not overwrite the newly active repo panel', async () => {
+      // Regression: switch tabs while a slow get_branches for the OLD repo
+      // is in flight; its late result used to render the old repo's
+      // branches under the new repo's tab (checkout/delete would then run
+      // against the wrong names).
+      let releaseSlow!: () => void;
+      const slowGate = new Promise<void>((resolve) => {
+        releaseSlow = resolve;
+      });
+      const slowBranches = [makeBranch({ name: 'stale-branch', shorthand: 'stale-branch', isHead: true })];
+      const fastBranches = [makeBranch({ name: 'fresh-branch', shorthand: 'fresh-branch', isHead: true })];
+      let branchCalls = 0;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_branches') {
+          branchCalls++;
+          if (branchCalls === 1) {
+            await slowGate;
+            return slowBranches;
+          }
+          return fastBranches;
+        }
+        return null;
+      };
+
+      const el = await fixture<LvBranchList>(
+        html`<lv-branch-list .repositoryPath=${REPO_PATH}></lv-branch-list>`
+      );
+      await el.updateComplete;
+
+      el.repositoryPath = '/other/repo';
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 20));
+
+      releaseSlow();
+      await new Promise((r) => setTimeout(r, 20));
+      await el.updateComplete;
+
+      // The visible panel keeps the ACTIVE repo's branches
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const groups = (el as any).localBranchGroups as Array<{ branches: Branch[] }>;
+      const names = groups.flatMap((g) => g.branches.map((b) => b.name));
+      expect(names).to.deep.equal(['fresh-branch']);
+
+      // ...while the stale result still reached the store for ITS repo
+      const repoA = repositoryStore
+        .getState()
+        .openRepositories.find((r) => r.repository.path === REPO_PATH);
+      expect(repoA!.currentBranch!.name).to.equal('stale-branch');
+    });
+
     it('mirrors loaded branches and current branch into the repository store', async () => {
       setupDefaultMocks();
       await renderBranchList();

--- a/src/components/__tests__/lv-branch-list.test.ts
+++ b/src/components/__tests__/lv-branch-list.test.ts
@@ -27,6 +27,7 @@ import type { LvBranchList } from '../sidebar/lv-branch-list.ts';
 
 // Import the actual component — registers <lv-branch-list> custom element
 import '../sidebar/lv-branch-list.ts';
+import { repositoryStore } from '../../stores/repository.store.ts';
 
 // ── Test data ──────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
@@ -919,6 +920,35 @@ describe('lv-branch-list', () => {
       // First attempt without force fails; a force retry follows the confirm.
       expect(deleteCalls.map((c) => c.force)).to.deep.equal([false, true]);
       expect(removed).to.be.true;
+    });
+  });
+
+  // ── Multi-repo store sync ────────────────────────────────────────────
+  describe('repository store sync', () => {
+    beforeEach(() => {
+      repositoryStore.getState().reset();
+      repositoryStore.getState().addRepository({
+        path: REPO_PATH,
+        name: 'test-repo',
+        isValid: true,
+        isBare: false,
+        headRef: 'main',
+        state: 'clean',
+        isShallow: false,
+        isPartialClone: false,
+        cloneFilter: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    });
+
+    it('mirrors loaded branches and current branch into the repository store', async () => {
+      setupDefaultMocks();
+      await renderBranchList();
+
+      const repo = repositoryStore.getState().openRepositories[0];
+      expect(repo.branches.length).to.be.greaterThan(0);
+      expect(repo.currentBranch).to.not.be.null;
+      expect(repo.currentBranch!.isHead).to.be.true;
     });
   });
 });

--- a/src/components/__tests__/lv-file-status.test.ts
+++ b/src/components/__tests__/lv-file-status.test.ts
@@ -833,6 +833,64 @@ describe('lv-file-status', () => {
       expect(findCommands('get_status').length).to.equal(0);
     });
 
+    it('a stale status result must not overwrite the newly active repo panel', async () => {
+      // Regression: switch tabs while a slow get_status for the OLD repo is
+      // in flight; its late result used to overwrite the panel now showing
+      // the NEW repo (destructive-action risk on same-named files).
+      openRepoInStore(REPO_PATH);
+      let releaseSlow!: () => void;
+      const slowGate = new Promise<void>((resolve) => {
+        releaseSlow = resolve;
+      });
+      const slowEntries = [
+        { path: 'stale-repo-file.ts', status: 'modified', isStaged: false, isConflicted: false },
+      ];
+      const fastEntries = [
+        { path: 'fresh-repo-file.ts', status: 'modified', isStaged: true, isConflicted: false },
+      ];
+      let statusCalls = 0;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_status') {
+          statusCalls++;
+          if (statusCalls === 1) {
+            await slowGate;
+            return slowEntries;
+          }
+          return fastEntries;
+        }
+        return null;
+      };
+
+      // First load (for REPO_PATH) hangs on the gate
+      const el = await fixture<LvFileStatus>(
+        html`<lv-file-status .repositoryPath=${REPO_PATH}></lv-file-status>`,
+      );
+      await el.updateComplete;
+
+      // Switch tabs; the second load resolves immediately
+      el.repositoryPath = '/other/repo';
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Now the stale first load lands
+      releaseSlow();
+      await new Promise((r) => setTimeout(r, 20));
+
+      // The visible panel keeps the ACTIVE repo's data
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const staged = (el as any).stagedFiles as Array<{ path: string }>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const unstaged = (el as any).unstagedFiles as Array<{ path: string }>;
+      expect(staged.map((f) => f.path)).to.deep.equal(['fresh-repo-file.ts']);
+      expect(unstaged).to.deep.equal([]);
+
+      // ...while the stale result still reached the store for ITS repo
+      const repoA = repositoryStore
+        .getState()
+        .openRepositories.find((r) => r.repository.path === REPO_PATH);
+      expect(repoA!.status.map((s) => s.path)).to.deep.equal(['stale-repo-file.ts']);
+    });
+
     it('reloads status on watcher events for ITS repo', async () => {
       setupDefaultMocks();
       const el = await renderFileStatus();

--- a/src/components/__tests__/lv-file-status.test.ts
+++ b/src/components/__tests__/lv-file-status.test.ts
@@ -25,6 +25,8 @@ let mockInvoke: MockInvoke = () => Promise.resolve(null);
 import { expect, fixture, html } from '@open-wc/testing';
 import type { LvFileStatus } from '../sidebar/lv-file-status.ts';
 import '../sidebar/lv-file-status.ts';
+import { repositoryStore } from '../../stores/repository.store.ts';
+import type { Repository } from '../../types/git.types.ts';
 
 // ── Test data ──────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
@@ -780,6 +782,71 @@ describe('lv-file-status', () => {
       expect(events.length).to.be.greaterThan(1);
       const lastEvent = events[events.length - 1];
       expect(lastEvent.stagedCount).to.equal(5); // 5 staged files now
+    });
+  });
+
+  // ── Multi-repo behavior ──────────────────────────────────────────────
+  describe('multi-repo behavior', () => {
+    function openRepoInStore(path: string): void {
+      repositoryStore.getState().addRepository({
+        path,
+        name: path.split('/').pop() ?? path,
+        isValid: true,
+        isBare: false,
+        headRef: 'main',
+        state: 'clean',
+        isShallow: false,
+        isPartialClone: false,
+        cloneFilter: null,
+      } as Repository);
+    }
+
+    beforeEach(() => {
+      repositoryStore.getState().reset();
+    });
+
+    it('mirrors loaded status into the repository store for the tab dirty badge', async () => {
+      openRepoInStore(REPO_PATH);
+      setupDefaultMocks();
+      const el = await renderFileStatus();
+      await el.updateComplete;
+
+      const repo = repositoryStore.getState().openRepositories[0];
+      expect(repo.status.length).to.equal(mockStatusEntries.length);
+      expect(repo.stagedFiles.length).to.equal(4);
+      expect(repo.unstagedFiles.length).to.equal(4);
+    });
+
+    it('ignores watcher events from OTHER repos', async () => {
+      setupDefaultMocks();
+      const el = await renderFileStatus();
+      clearHistory();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).handleWatcherEvent({
+        repoPath: '/some/other/repo',
+        eventType: 'workdir-changed',
+        paths: [],
+      });
+      await new Promise((r) => setTimeout(r, 400)); // past the 300ms debounce
+
+      expect(findCommands('get_status').length).to.equal(0);
+    });
+
+    it('reloads status on watcher events for ITS repo', async () => {
+      setupDefaultMocks();
+      const el = await renderFileStatus();
+      clearHistory();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).handleWatcherEvent({
+        repoPath: REPO_PATH,
+        eventType: 'workdir-changed',
+        paths: [],
+      });
+      await new Promise((r) => setTimeout(r, 400));
+
+      expect(findCommands('get_status').length).to.equal(1);
     });
   });
 });

--- a/src/components/__tests__/lv-file-status.test.ts
+++ b/src/components/__tests__/lv-file-status.test.ts
@@ -891,6 +891,61 @@ describe('lv-file-status', () => {
       expect(repoA!.status.map((s) => s.path)).to.deep.equal(['stale-repo-file.ts']);
     });
 
+    it('an A -> B -> A switch discards the outdated first A load', async () => {
+      // Regression: path-equality guards let a REORDERED pair of loads for
+      // the same repo apply the older result (reverting a staging change
+      // until the next watcher tick).
+      openRepoInStore(REPO_PATH);
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const outdatedEntries = [
+        { path: 'outdated.ts', status: 'modified', isStaged: false, isConflicted: false },
+      ];
+      const freshEntries = [
+        { path: 'fresh.ts', status: 'modified', isStaged: true, isConflicted: false },
+      ];
+      let statusCalls = 0;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_status') {
+          statusCalls++;
+          if (statusCalls === 1) {
+            await firstGate; // A's FIRST load is slow
+            return outdatedEntries;
+          }
+          return freshEntries; // B's load and A's second load are fast
+        }
+        return null;
+      };
+
+      const el = await fixture<LvFileStatus>(
+        html`<lv-file-status .repositoryPath=${REPO_PATH}></lv-file-status>`,
+      );
+      await el.updateComplete;
+
+      // A -> B -> A
+      el.repositoryPath = '/other/repo';
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 20));
+      el.repositoryPath = REPO_PATH;
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Now A's outdated first load finally lands — it must be discarded
+      releaseFirst();
+      await new Promise((r) => setTimeout(r, 20));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const staged = (el as any).stagedFiles as Array<{ path: string }>;
+      expect(staged.map((f) => f.path)).to.deep.equal(['fresh.ts']);
+
+      const repoA = repositoryStore
+        .getState()
+        .openRepositories.find((r) => r.repository.path === REPO_PATH);
+      expect(repoA!.status.map((s) => s.path)).to.deep.equal(['fresh.ts']);
+    });
+
     it('reloads status on watcher events for ITS repo', async () => {
       setupDefaultMocks();
       const el = await renderFileStatus();

--- a/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
@@ -28,6 +28,7 @@ import type { LvWorkspaceManagerDialog } from '../lv-workspace-manager-dialog.ts
 
 // Import the actual component — registers <lv-workspace-manager-dialog>
 import '../lv-workspace-manager-dialog.ts';
+import { uiStore, repositoryStore } from '../../../stores/index.ts';
 
 // ── Test data ──────────────────────────────────────────────────────────────
 function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
@@ -884,5 +885,80 @@ describe('lv-workspace-manager-dialog', () => {
 
       expect(closeFired).to.be.true;
     });
+  });
+
+  describe('open workspace partial-failure feedback', () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    function selectWorkspaceWithRepos(
+      el: LvWorkspaceManagerDialog,
+      paths: string[],
+    ): void {
+      const ws = makeWorkspace({
+        id: 'ws-open',
+        name: 'OpenMe',
+        repositories: paths.map((p) => ({ path: p, name: p.split('/').pop() ?? p })),
+      });
+      (el as any).workspaces = [ws];
+      (el as any).selectedWorkspaceId = 'ws-open';
+      // Mark every repo as existing + valid so the pre-check passes and the
+      // open attempt itself decides success/failure
+      const statuses = new Map<string, WorkspaceRepoStatus>();
+      for (const p of paths) {
+        statuses.set(p, { exists: true, isValidRepo: true } as unknown as WorkspaceRepoStatus);
+      }
+      (el as any).repoStatuses = statuses;
+    }
+
+    it('warns (not plain success) when some repos fail to open', async () => {
+      uiStore.setState({ toasts: [] });
+      repositoryStore.getState().reset();
+      setupDefaultMocks({});
+      mockInvoke = (command: string, args?: unknown) => {
+        const params = args as Record<string, unknown> | undefined;
+        if (command === 'open_repository') {
+          if (params?.path === '/ws/gone') return Promise.reject(new Error('not found'));
+          return Promise.resolve({ path: params?.path as string, name: 'repo' });
+        }
+        if (command === 'update_workspace_last_opened') return Promise.resolve(undefined);
+        return Promise.resolve(null);
+      };
+
+      const el = await renderDialog();
+      selectWorkspaceWithRepos(el, ['/ws/ok', '/ws/gone']);
+
+      await (el as any).handleOpenWorkspace();
+      await tick(el);
+
+      const toasts = uiStore.getState().toasts;
+      const last = toasts[toasts.length - 1];
+      expect(last.type).to.equal('warning');
+      expect(last.message).to.contain('1 of 2');
+      // The repo that opened is still added
+      expect(
+        repositoryStore.getState().openRepositories.map((r) => r.repository.path),
+      ).to.deep.equal(['/ws/ok']);
+    });
+
+    it('errors when NO repo in the workspace could be opened', async () => {
+      uiStore.setState({ toasts: [] });
+      repositoryStore.getState().reset();
+      setupDefaultMocks({});
+      mockInvoke = (command: string) => {
+        if (command === 'open_repository') return Promise.reject(new Error('not found'));
+        if (command === 'update_workspace_last_opened') return Promise.resolve(undefined);
+        return Promise.resolve(null);
+      };
+
+      const el = await renderDialog();
+      selectWorkspaceWithRepos(el, ['/ws/gone-1', '/ws/gone-2']);
+
+      await (el as any).handleOpenWorkspace();
+      await tick(el);
+
+      const toasts = uiStore.getState().toasts;
+      expect(toasts[toasts.length - 1].type).to.equal('error');
+      expect(repositoryStore.getState().openRepositories.length).to.equal(0);
+    });
+    /* eslint-enable @typescript-eslint/no-explicit-any */
   });
 });

--- a/src/components/dialogs/lv-workspace-manager-dialog.ts
+++ b/src/components/dialogs/lv-workspace-manager-dialog.ts
@@ -12,7 +12,6 @@ import { openRepositoryDialog, openDialog, saveDialog } from '../../services/dia
 import { showToast } from '../../services/notification.service.ts';
 import { repositoryStore } from '../../stores/index.ts';
 import { workspaceStore } from '../../stores/workspace.store.ts';
-import { searchIndexService } from '../../services/search-index.service.ts';
 import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
 import type { Workspace, WorkspaceRepoStatus, WorkspaceSearchResult } from '../../types/git.types.ts';
 
@@ -903,7 +902,11 @@ export class LvWorkspaceManagerDialog extends LitElement {
       const result = await gitService.openRepository({ path: repo.path });
       if (result.success && result.data) {
         store.addRepository(result.data);
-        searchIndexService.buildIndex(repo.path);
+        // Index builds are deliberately NOT started here: opening a
+        // workspace with many repos would kick off that many concurrent
+        // history walks at once. The repo that ends up active gets its
+        // indexes from app-shell's activation hook; the rest build lazily
+        // when their tab is first activated.
       }
     }
 

--- a/src/components/dialogs/lv-workspace-manager-dialog.ts
+++ b/src/components/dialogs/lv-workspace-manager-dialog.ts
@@ -895,19 +895,24 @@ export class LvWorkspaceManagerDialog extends LitElement {
 
     const store = repositoryStore.getState();
 
+    // Open WITHOUT activating each repo: addRepository's default activation
+    // would fire the per-activation side effects (index builds, integration
+    // checks) once per repo — a 10-repo workspace would still kick off 10
+    // concurrent history walks. Activate only the final repo; the rest get
+    // their indexes lazily when their tab is first activated.
+    let lastOpenedPath: string | null = null;
     for (const repo of ws.repositories) {
       const status = this.repoStatuses.get(repo.path);
       if (status && (!status.exists || !status.isValidRepo)) continue;
 
       const result = await gitService.openRepository({ path: repo.path });
       if (result.success && result.data) {
-        store.addRepository(result.data);
-        // Index builds are deliberately NOT started here: opening a
-        // workspace with many repos would kick off that many concurrent
-        // history walks at once. The repo that ends up active gets its
-        // indexes from app-shell's activation hook; the rest build lazily
-        // when their tab is first activated.
+        store.addRepository(result.data, { activate: false });
+        lastOpenedPath = result.data.path;
       }
+    }
+    if (lastOpenedPath) {
+      store.setActiveByPath(lastOpenedPath);
     }
 
     workspaceStore.getState().setActiveWorkspaceId(ws.id);

--- a/src/components/dialogs/lv-workspace-manager-dialog.ts
+++ b/src/components/dialogs/lv-workspace-manager-dialog.ts
@@ -901,14 +901,20 @@ export class LvWorkspaceManagerDialog extends LitElement {
     // concurrent history walks. Activate only the final repo; the rest get
     // their indexes lazily when their tab is first activated.
     let lastOpenedPath: string | null = null;
+    let failedCount = 0;
     for (const repo of ws.repositories) {
       const status = this.repoStatuses.get(repo.path);
-      if (status && (!status.exists || !status.isValidRepo)) continue;
+      if (status && (!status.exists || !status.isValidRepo)) {
+        failedCount++;
+        continue;
+      }
 
       const result = await gitService.openRepository({ path: repo.path });
       if (result.success && result.data) {
         store.addRepository(result.data, { activate: false });
         lastOpenedPath = result.data.path;
+      } else {
+        failedCount++;
       }
     }
     if (lastOpenedPath) {
@@ -919,7 +925,18 @@ export class LvWorkspaceManagerDialog extends LitElement {
     await workspaceService.updateWorkspaceLastOpened(ws.id);
 
     this.close();
-    showToast(`Opened workspace: ${ws.name}`, 'success');
+    // A repo that failed to open (moved, deleted, invalid) must not hide
+    // behind a green success toast
+    if (failedCount === 0) {
+      showToast(`Opened workspace: ${ws.name}`, 'success');
+    } else if (lastOpenedPath) {
+      showToast(
+        `Opened workspace: ${ws.name} (${failedCount} of ${ws.repositories.length} repositories failed to open)`,
+        'warning',
+      );
+    } else {
+      showToast(`Could not open workspace: ${ws.name} — no repository could be opened`, 'error');
+    }
   }
 
   private async handleSearch(): Promise<void> {

--- a/src/components/graph/__tests__/lv-graph-canvas.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas.test.ts
@@ -854,6 +854,53 @@ describe('lv-graph-canvas', () => {
       expect(findCommands('get_commit_history').length).to.equal(1);
     });
 
+    it('a successful background reload clears a previous load error', async () => {
+      const el = await renderCanvas();
+      // Foreground load fails on a fresh repo -> error panel state
+      mockInvoke = async (command: string) => {
+        if (command === 'get_commit_history') throw new Error('boom');
+        if (command === 'get_refs_by_commit') return defaultRefs;
+        return null;
+      };
+      await switchRepo(el, '/failing/repo');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).loadError).to.contain('boom');
+
+      // The repo recovers; a queued/background reload succeeds
+      setupDefaultMocks();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).loadCommits({ background: true });
+      await new Promise((r) => setTimeout(r, 200));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).loadError).to.be.null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).commits.length).to.equal(defaultCommits.length);
+    });
+
+    it('clearing the search filter during a tab switch keeps the instant cached render', async () => {
+      const el = await renderCanvas();
+      await switchRepo(el, '/other/repo');
+      clearHistory();
+
+      // Tab switch back: app-shell clears the filter in the same update
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).searchFilter = null;
+      el.repositoryPath = REPO_PATH;
+      await el.updateComplete;
+
+      // Cached render applied instantly, no foreground spinner
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).isLoading).to.be.false;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).commits.length).to.equal(defaultCommits.length);
+
+      // Exactly ONE (background) reload — the filter branch must not fire a
+      // second, cancelling foreground load
+      await new Promise((r) => setTimeout(r, 200));
+      expect(findCommands('get_commit_history').length).to.equal(1);
+    });
+
     it('background revalidation updates the graph when the repo changed', async () => {
       const el = await renderCanvas();
       await switchRepo(el, '/other/repo');

--- a/src/components/graph/__tests__/lv-graph-canvas.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas.test.ts
@@ -758,6 +758,47 @@ describe('lv-graph-canvas', () => {
       expect((el as any).commits.length).to.equal(defaultCommits.length);
     });
 
+    it('a refresh during an in-flight load queues exactly one follow-up load', async () => {
+      // Regression: refresh() used to silently no-op while a load was in
+      // flight — a commit made right after a tab switch never appeared
+      // because the in-flight snapshot predated it.
+      const el = await renderCanvas();
+      clearHistory();
+
+      let releaseLoad!: () => void;
+      const loadGate = new Promise<void>((resolve) => {
+        releaseLoad = resolve;
+      });
+      let gated = true;
+      mockInvoke = async (command: string) => {
+        switch (command) {
+          case 'get_commit_history':
+            if (gated) {
+              gated = false; // only the first call blocks
+              await loadGate;
+            }
+            return defaultCommits;
+          case 'get_refs_by_commit':
+            return defaultRefs;
+          default:
+            return null;
+        }
+      };
+
+      // Start a slow load, then refresh twice while it's in flight
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).loadCommits();
+      await new Promise((r) => setTimeout(r, 10));
+      el.refresh();
+      el.refresh();
+
+      releaseLoad();
+      await new Promise((r) => setTimeout(r, 250));
+
+      // The in-flight load plus exactly ONE queued follow-up
+      expect(findCommands('get_commit_history').length).to.equal(2);
+    });
+
     it('background revalidation updates the graph when the repo changed', async () => {
       const el = await renderCanvas();
       await switchRepo(el, '/other/repo');

--- a/src/components/graph/__tests__/lv-graph-canvas.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas.test.ts
@@ -32,7 +32,7 @@ import type { Commit, RefsByCommit } from '../../../types/git.types.ts';
 // Import the actual component — registers <lv-graph-canvas> custom element
 import '../lv-graph-canvas.ts';
 import type { LvGraphCanvas } from '../lv-graph-canvas.ts';
-import { clearGraphCacheForTests } from '../lv-graph-canvas.ts';
+import { clearGraphCacheForTests, evictGraphCache } from '../lv-graph-canvas.ts';
 
 // ── Test data ──────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
@@ -797,6 +797,61 @@ describe('lv-graph-canvas', () => {
 
       // The in-flight load plus exactly ONE queued follow-up
       expect(findCommands('get_commit_history').length).to.equal(2);
+    });
+
+    it('a failed background revalidation does not paint an error over the cached graph', async () => {
+      const el = await renderCanvas();
+      await switchRepo(el, '/other/repo');
+
+      // The repo becomes temporarily unreachable for the background reload
+      mockInvoke = async (command: string) => {
+        if (command === 'get_commit_history') {
+          throw new Error('repository temporarily unavailable');
+        }
+        if (command === 'get_refs_by_commit') return defaultRefs;
+        return null;
+      };
+
+      await switchRepo(el, REPO_PATH);
+
+      // The cached graph still shows; no error banner over working content
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).commits.length).to.equal(defaultCommits.length);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).loadError).to.be.null;
+    });
+
+    it('a failed FOREGROUND load still surfaces the error', async () => {
+      const el = await renderCanvas();
+      mockInvoke = async (command: string) => {
+        if (command === 'get_commit_history') {
+          throw new Error('boom');
+        }
+        if (command === 'get_refs_by_commit') return defaultRefs;
+        return null;
+      };
+
+      await switchRepo(el, '/never/visited');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).loadError).to.contain('boom');
+    });
+
+    it('evictGraphCache removes a repo so reopening takes the loading path', async () => {
+      const el = await renderCanvas();
+      await switchRepo(el, '/other/repo');
+
+      evictGraphCache(REPO_PATH);
+      clearHistory();
+
+      // Switching back is NOT served from cache: the loading path runs
+      el.repositoryPath = REPO_PATH;
+      await el.updateComplete;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).isLoading).to.be.true;
+
+      await new Promise((r) => setTimeout(r, 200));
+      expect(findCommands('get_commit_history').length).to.equal(1);
     });
 
     it('background revalidation updates the graph when the repo changed', async () => {

--- a/src/components/graph/__tests__/lv-graph-canvas.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas.test.ts
@@ -799,6 +799,22 @@ describe('lv-graph-canvas', () => {
       expect(findCommands('get_commit_history').length).to.equal(2);
     });
 
+    it('switching repos mid-stats-fetch does not leave the stats spinner stuck on', async () => {
+      // Regression: fetchCommitStats' finally only cleared isLoadingStats
+      // when still on the same repo, so switching away mid-fetch (esp. to an
+      // empty repo that runs no stats fetch of its own) left the spinner on.
+      const el = await renderCanvas();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).isLoadingStats = true; // simulate an in-flight stats fetch
+
+      // Switch to a different repo (uncached) — willUpdate must reset it
+      el.repositoryPath = '/other/repo';
+      await el.updateComplete;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).isLoadingStats).to.be.false;
+    });
+
     it('a superseded load must not clear isLoading while the newest load is still running', async () => {
       // Regression: loadCommits' finally cleared isLoading unconditionally,
       // so double-switching between two uncached repos let the first

--- a/src/components/graph/__tests__/lv-graph-canvas.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas.test.ts
@@ -32,6 +32,7 @@ import type { Commit, RefsByCommit } from '../../../types/git.types.ts';
 // Import the actual component — registers <lv-graph-canvas> custom element
 import '../lv-graph-canvas.ts';
 import type { LvGraphCanvas } from '../lv-graph-canvas.ts';
+import { clearGraphCacheForTests } from '../lv-graph-canvas.ts';
 
 // ── Test data ──────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
@@ -703,6 +704,79 @@ describe('lv-graph-canvas', () => {
       expect(result).to.be.true;
       expect(selectedEvent).to.not.be.null;
       expect(selectedEvent!.detail.commit.oid).to.equal(commit2.oid);
+    });
+  });
+
+  // ── Per-repo graph cache ─────────────────────────────────────────────
+  describe('per-repo graph cache', () => {
+    beforeEach(() => {
+      clearGraphCacheForTests();
+    });
+
+    async function switchRepo(el: LvGraphCanvas, path: string): Promise<void> {
+      el.repositoryPath = path;
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 200));
+      await el.updateComplete;
+    }
+
+    it('renders a previously-visited repo from cache without the loading state', async () => {
+      const el = await renderCanvas();
+      await switchRepo(el, '/other/repo');
+      clearHistory();
+
+      // Switch back — cached page must be applied synchronously
+      el.repositoryPath = REPO_PATH;
+      await el.updateComplete;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).isLoading).to.be.false;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).commits.length).to.equal(defaultCommits.length);
+    });
+
+    it('still revalidates a cached repo in the background', async () => {
+      const el = await renderCanvas();
+      await switchRepo(el, '/other/repo');
+      clearHistory();
+
+      await switchRepo(el, REPO_PATH);
+
+      // The cached render is instant, but a background reload still hits the
+      // backend so external changes are picked up
+      expect(findCommands('get_commit_history').length).to.equal(1);
+    });
+
+    it('a repo seen for the first time takes the normal loading path', async () => {
+      const el = await renderCanvas();
+      clearHistory();
+
+      await switchRepo(el, '/never/seen');
+
+      expect(findCommands('get_commit_history').length).to.equal(1);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).commits.length).to.equal(defaultCommits.length);
+    });
+
+    it('background revalidation updates the graph when the repo changed', async () => {
+      const el = await renderCanvas();
+      await switchRepo(el, '/other/repo');
+
+      // The repo gains a commit while its tab is in the background
+      const newCommit = makeCommit({
+        oid: 'ddd4444444444444444444444444444444444444444',
+        shortId: 'ddd4444',
+        summary: 'New commit',
+        message: 'New commit',
+        timestamp: 1700003000,
+        parentIds: [commit3.oid],
+      });
+      setupDefaultMocks({ commits: [newCommit, ...defaultCommits] });
+
+      await switchRepo(el, REPO_PATH);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).commits.length).to.equal(defaultCommits.length + 1);
     });
   });
 });

--- a/src/components/graph/__tests__/lv-graph-canvas.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas.test.ts
@@ -799,6 +799,47 @@ describe('lv-graph-canvas', () => {
       expect(findCommands('get_commit_history').length).to.equal(2);
     });
 
+    it('a superseded load must not clear isLoading while the newest load is still running', async () => {
+      // Regression: loadCommits' finally cleared isLoading unconditionally,
+      // so double-switching between two uncached repos let the first
+      // (superseded) load drop the spinner while the second was still in
+      // flight — flashing a stale graph with no loading indicator.
+      const el = await renderCanvas();
+
+      // Gate get_commit_history so we control when each load resolves
+      const gates: Array<() => void> = [];
+      mockInvoke = async (command: string) => {
+        if (command === 'get_commit_history') {
+          await new Promise<void>((resolve) => gates.push(resolve));
+          return defaultCommits;
+        }
+        if (command === 'get_refs_by_commit') return defaultRefs;
+        return null;
+      };
+
+      // Switch to A (load v+1, gated), then B (load v+2, gated) before A resolves
+      el.repositoryPath = '/repo/a';
+      await el.updateComplete;
+      el.repositoryPath = '/repo/b';
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 10));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).isLoading).to.be.true;
+
+      // Resolve A's (superseded) load first — it must NOT clear isLoading
+      gates[0]?.();
+      await new Promise((r) => setTimeout(r, 10));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).isLoading, 'superseded load must not drop the spinner').to.be.true;
+
+      // Resolve B's (newest) load — now the spinner clears
+      gates[1]?.();
+      await new Promise((r) => setTimeout(r, 10));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).isLoading).to.be.false;
+    });
+
     it('a failed background revalidation does not paint an error over the cached graph', async () => {
       const el = await renderCanvas();
       await switchRepo(el, '/other/repo');

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -506,6 +506,7 @@ export class LvGraphCanvas extends LitElement {
   private loadVersion = 0; // Incremented on each load to cancel stale requests
   private statsDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastLoadedRepoPath: string | null = null; // Track the last repo that completed loading
+  private inFlightLoadPath: string | null = null; // Repo whose loadCommits is currently in flight
   private pullRequestsByCommit: Record<string, GraphPullRequest[]> = {};
   private githubRepo: { owner: string; repo: string } | null = null;
   private renderer: CanvasRenderer | null = null;
@@ -735,6 +736,7 @@ export class LvGraphCanvas extends LitElement {
     this.loadVersion++;
     const currentVersion = this.loadVersion;
     const repoPath = this.repositoryPath;
+    this.inFlightLoadPath = repoPath;
 
     // A background revalidation keeps showing the (cached) graph instead of
     // flashing the loading state
@@ -878,6 +880,10 @@ export class LvGraphCanvas extends LitElement {
       this.loadError = err instanceof Error ? err.message : 'Unknown error loading commits';
     } finally {
       this.isLoading = false;
+      // Only the newest load owns the in-flight marker
+      if (this.loadVersion === currentVersion) {
+        this.inFlightLoadPath = null;
+      }
     }
   }
 
@@ -1830,6 +1836,10 @@ export class LvGraphCanvas extends LitElement {
    * Refresh the commit graph
    */
   public refresh(): void {
+    // A load for this repo is already in flight (e.g. the cache
+    // revalidation kicked off by a tab switch) — starting another would
+    // just cancel it and repeat the same backend walk with a spinner.
+    if (this.inFlightLoadPath === this.repositoryPath) return;
     this.loadCommits();
   }
 

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -913,9 +913,12 @@ export class LvGraphCanvas extends LitElement {
         this.loadError = err instanceof Error ? err.message : 'Unknown error loading commits';
       }
     } finally {
-      this.isLoading = false;
-      // Only the newest load owns the in-flight marker
+      // Only the NEWEST load owns the shared state. A superseded load (the
+      // user switched tabs again before this one resolved) must not clear
+      // isLoading — that would drop the spinner while the newest load is
+      // still running, flashing a stale/empty graph under the new tab.
       if (this.loadVersion === currentVersion) {
+        this.isLoading = false;
         this.inFlightLoadPath = null;
         if (this.reloadQueued) {
           // A refresh was requested mid-load. reloadQueued is only ever set

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -573,6 +573,10 @@ export class LvGraphCanvas extends LitElement {
 
       // A reload queued for the PREVIOUS repo must not leak into this one
       this.reloadQueued = false;
+      // Clear any stats spinner owned by the previous repo — the new repo's
+      // fetch (if any) will set it again; a repo with no stats to fetch must
+      // not inherit the old spinner
+      this.isLoadingStats = false;
 
       // Render instantly from the per-repo cache when switching back to a
       // visited tab, then revalidate in the background (no spinner). A repo
@@ -1189,13 +1193,19 @@ export class LvGraphCanvas extends LitElement {
         log.debug(`fetchCommitStats: discarding stats for ${repoPath}, now on ${this.repositoryPath}`);
       }
     } finally {
-      // Only clear loading state if we're still on the same repo
+      // Enforce the minimum-visible delay only while still on the same repo.
       if (this.repositoryPath === repoPath) {
-        // Ensure loading indicator is visible for minimum time
         const elapsed = Date.now() - startTime;
         if (elapsed < MIN_LOADING_DISPLAY_MS) {
           await new Promise(resolve => setTimeout(resolve, MIN_LOADING_DISPLAY_MS - elapsed));
         }
+      }
+      // Clear the stats spinner only for the CURRENT load. A superseded
+      // fetch (the user switched repos while it ran) must not clear a newer
+      // repo's spinner; the repo switch itself resets the flag (willUpdate)
+      // and the new repo's own fetch manages it from there — so switching
+      // away mid-fetch never leaves the spinner stuck on.
+      if (this.loadVersion === version) {
         this.isLoadingStats = false;
       }
     }

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -61,6 +61,15 @@ function cacheGraphPage(path: string, entry: GraphCacheEntry): void {
   }
 }
 
+/**
+ * Evict a repo's cached graph page — called when its tab closes so a
+ * different repository later opened at the same path can't flash the old
+ * repo's graph before revalidation.
+ */
+export function evictGraphCache(path: string): void {
+  graphCache.delete(path);
+}
+
 /** Test hook: clear the module-level graph cache */
 export function clearGraphCacheForTests(): void {
   graphCache.clear();
@@ -746,11 +755,13 @@ export class LvGraphCanvas extends LitElement {
     this.inFlightLoadPath = repoPath;
 
     // A background revalidation keeps showing the (cached) graph instead of
-    // flashing the loading state
+    // flashing the loading state — and its failure must not paint an error
+    // banner over a perfectly good cached graph, so loadError is only
+    // touched by foreground loads.
     if (!options.background) {
       this.isLoading = true;
+      this.loadError = null;
     }
-    this.loadError = null;
     const startTime = performance.now();
 
     try {
@@ -784,7 +795,11 @@ export class LvGraphCanvas extends LitElement {
       }
 
       if (!commitsResult.success || !commitsResult.data) {
-        this.loadError = commitsResult.error?.message ?? 'Failed to load commits';
+        if (options.background) {
+          log.warn('Background graph revalidation failed:', commitsResult.error?.message);
+        } else {
+          this.loadError = commitsResult.error?.message ?? 'Failed to load commits';
+        }
         this.isLoading = false;
         return;
       }
@@ -884,7 +899,11 @@ export class LvGraphCanvas extends LitElement {
       const searchInfo = hasSearch ? ` (${this.matchedCommitOids.size} matches highlighted)` : '';
       log.debug(`Loaded ${this.commits.length} commits${searchInfo} in ${(performance.now() - startTime).toFixed(2)}ms`);
     } catch (err) {
-      this.loadError = err instanceof Error ? err.message : 'Unknown error loading commits';
+      if (options.background) {
+        log.warn('Background graph revalidation failed:', err);
+      } else {
+        this.loadError = err instanceof Error ? err.message : 'Unknown error loading commits';
+      }
     } finally {
       this.isLoading = false;
       // Only the newest load owns the in-flight marker

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -918,10 +918,15 @@ export class LvGraphCanvas extends LitElement {
       if (this.loadVersion === currentVersion) {
         this.inFlightLoadPath = null;
         if (this.reloadQueued) {
-          // A refresh was requested mid-load; run it now (background — the
-          // graph is already showing data, no spinner flash needed)
+          // A refresh was requested mid-load. reloadQueued is only ever set
+          // by refresh() — i.e. a user/mutation-triggered reload (commit,
+          // pull, merge, watcher refs-changed) — so run it in the FOREGROUND
+          // so its failures surface (a silent background reload would hide
+          // errors the user expects to see after acting). Tab-switch cache
+          // revalidation uses a separate direct background load, not this
+          // queue.
           this.reloadQueued = false;
-          this.loadCommits({ background: true });
+          this.loadCommits();
         }
       }
     }

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -33,6 +33,39 @@ import type { GraphPullRequest } from '../../graph/virtual-scroll.ts';
 import { searchIndexService } from '../../services/search-index.service.ts';
 import { embeddingIndexService } from '../../services/embedding-index.service.ts';
 
+/**
+ * Per-repository cache of the last loaded commit page. Switching back to an
+ * already-visited tab renders instantly from this cache while a background
+ * reload revalidates it — without it every tab switch pays a full backend
+ * history walk. Bounded LRU so many open repos can't grow memory unbounded.
+ */
+interface GraphCacheEntry {
+  commits: Commit[];
+  refsByCommit: RefsByCommit;
+  hasMore: boolean;
+}
+
+const GRAPH_CACHE_MAX_REPOS = 8;
+// Map iteration order is insertion order; re-inserting on write keeps the
+// oldest entry first for LRU eviction.
+const graphCache = new Map<string, GraphCacheEntry>();
+
+function cacheGraphPage(path: string, entry: GraphCacheEntry): void {
+  graphCache.delete(path);
+  graphCache.set(path, entry);
+  if (graphCache.size > GRAPH_CACHE_MAX_REPOS) {
+    const oldest = graphCache.keys().next().value;
+    if (oldest !== undefined) {
+      graphCache.delete(oldest);
+    }
+  }
+}
+
+/** Test hook: clear the module-level graph cache */
+export function clearGraphCacheForTests(): void {
+  graphCache.clear();
+}
+
 export interface CommitSelectedEvent {
   commit: Commit | null;
   commits: Commit[]; // All selected commits for multi-select
@@ -524,8 +557,16 @@ export class LvGraphCanvas extends LitElement {
       // Reload hidden branches for the new repository
       this.loadHiddenBranches();
 
-      // Reload commits for the new repository
-      this.loadCommits();
+      // Render instantly from the per-repo cache when switching back to a
+      // visited tab, then revalidate in the background (no spinner). A repo
+      // seen for the first time takes the normal loading path.
+      const cached = graphCache.get(this.repositoryPath);
+      if (cached) {
+        this.applyCachedGraph(cached);
+        this.loadCommits({ background: true });
+      } else {
+        this.loadCommits();
+      }
     }
 
     // Reload when search filter changes
@@ -669,7 +710,22 @@ export class LvGraphCanvas extends LitElement {
     );
   }
 
-  private async loadCommits(): Promise<void> {
+  /** Populate the graph synchronously from a cached page (no spinner) */
+  private applyCachedGraph(cached: GraphCacheEntry): void {
+    this.realCommits.clear();
+    for (const commit of cached.commits) {
+      this.realCommits.set(commit.oid, commit);
+    }
+    this.refsByCommit = cached.refsByCommit;
+    this.commits = cached.commits.map(commitToGraphCommit);
+    this.totalLoadedCommits = cached.commits.length;
+    this.hasMoreCommits = cached.hasMore;
+    this.isLoading = false;
+    this.loadError = null;
+    this.processLayout();
+  }
+
+  private async loadCommits(options: { background?: boolean } = {}): Promise<void> {
     if (!this.repositoryPath) {
       this.loadError = 'No repository path specified';
       return;
@@ -680,7 +736,11 @@ export class LvGraphCanvas extends LitElement {
     const currentVersion = this.loadVersion;
     const repoPath = this.repositoryPath;
 
-    this.isLoading = true;
+    // A background revalidation keeps showing the (cached) graph instead of
+    // flashing the loading state
+    if (!options.background) {
+      this.isLoading = true;
+    }
     this.loadError = null;
     const startTime = performance.now();
 
@@ -805,6 +865,12 @@ export class LvGraphCanvas extends LitElement {
       this.commits = commitsResult.data.map(commitToGraphCommit);
       this.totalLoadedCommits = commitsResult.data.length;
       this.hasMoreCommits = commitsResult.data.length >= this.commitCount;
+      // Cache this page so switching back to the tab renders instantly
+      cacheGraphPage(repoPath, {
+        commits: commitsResult.data,
+        refsByCommit: this.refsByCommit,
+        hasMore: this.hasMoreCommits,
+      });
       this.processLayout();
       const searchInfo = hasSearch ? ` (${this.matchedCommitOids.size} matches highlighted)` : '';
       log.debug(`Loaded ${this.commits.length} commits${searchInfo} in ${(performance.now() - startTime).toFixed(2)}ms`);

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -507,6 +507,10 @@ export class LvGraphCanvas extends LitElement {
   private statsDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastLoadedRepoPath: string | null = null; // Track the last repo that completed loading
   private inFlightLoadPath: string | null = null; // Repo whose loadCommits is currently in flight
+  // A refresh arrived while a load was in flight; that load's snapshot may
+  // predate the mutation the refresh was for, so one follow-up load runs
+  // when it finishes
+  private reloadQueued = false;
   private pullRequestsByCommit: Record<string, GraphPullRequest[]> = {};
   private githubRepo: { owner: string; repo: string } | null = null;
   private renderer: CanvasRenderer | null = null;
@@ -557,6 +561,9 @@ export class LvGraphCanvas extends LitElement {
 
       // Reload hidden branches for the new repository
       this.loadHiddenBranches();
+
+      // A reload queued for the PREVIOUS repo must not leak into this one
+      this.reloadQueued = false;
 
       // Render instantly from the per-repo cache when switching back to a
       // visited tab, then revalidate in the background (no spinner). A repo
@@ -883,6 +890,12 @@ export class LvGraphCanvas extends LitElement {
       // Only the newest load owns the in-flight marker
       if (this.loadVersion === currentVersion) {
         this.inFlightLoadPath = null;
+        if (this.reloadQueued) {
+          // A refresh was requested mid-load; run it now (background — the
+          // graph is already showing data, no spinner flash needed)
+          this.reloadQueued = false;
+          this.loadCommits({ background: true });
+        }
       }
     }
   }
@@ -1837,9 +1850,15 @@ export class LvGraphCanvas extends LitElement {
    */
   public refresh(): void {
     // A load for this repo is already in flight (e.g. the cache
-    // revalidation kicked off by a tab switch) — starting another would
-    // just cancel it and repeat the same backend walk with a spinner.
-    if (this.inFlightLoadPath === this.repositoryPath) return;
+    // revalidation kicked off by a tab switch) — starting another now would
+    // just cancel it and repeat the same backend walk with a spinner. But
+    // the in-flight snapshot may predate whatever this refresh is about
+    // (a commit, a pull), so queue exactly one follow-up load instead of
+    // dropping the request.
+    if (this.inFlightLoadPath === this.repositoryPath) {
+      this.reloadQueued = true;
+      return;
+    }
     this.loadCommits();
   }
 

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -586,8 +586,12 @@ export class LvGraphCanvas extends LitElement {
       }
     }
 
-    // Reload when search filter changes
-    if (changedProperties.has('searchFilter')) {
+    // Reload when search filter changes. Skip when the repository changed in
+    // the same update (app-shell clears the filter on tab switch): the
+    // repositoryPath branch above already started the right load, and a
+    // second FOREGROUND load here would cancel the instant cached render
+    // with a spinner.
+    if (changedProperties.has('searchFilter') && !changedProperties.has('repositoryPath')) {
       this.loadCommits();
     }
   }
@@ -895,6 +899,10 @@ export class LvGraphCanvas extends LitElement {
         refsByCommit: this.refsByCommit,
         hasMore: this.hasMoreCommits,
       });
+      // Any successful load clears a previous failure — including a queued
+      // background reload succeeding after a failed foreground load, which
+      // would otherwise leave the error panel painted over a healthy graph
+      this.loadError = null;
       this.processLayout();
       const searchInfo = hasSearch ? ` (${this.matchedCommitOids.size} matches highlighted)` : '';
       log.debug(`Loaded ${this.commits.length} commits${searchInfo} in ${(performance.now() - startTime).toFixed(2)}ms`);

--- a/src/components/sidebar/__tests__/lv-right-panel-shortcuts.test.ts
+++ b/src/components/sidebar/__tests__/lv-right-panel-shortcuts.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the right panel's tab-switching shortcuts.
+ *
+ * The panel uses Ctrl+Shift+1/2/3 — plain Ctrl+digit belongs to the GLOBAL
+ * repository-tab shortcuts, so the panel must not react to it (one chord,
+ * one meaning).
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: () => Promise.resolve(null),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { LvRightPanel } from '../lv-right-panel.ts';
+import '../lv-right-panel.ts';
+import { repositoryStore } from '../../../stores/index.ts';
+import type { Repository } from '../../../types/git.types.ts';
+
+function mockRepo(path: string): Repository {
+  return {
+    path,
+    name: 'test-repo',
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+function pressKey(el: LvRightPanel, init: KeyboardEventInit): void {
+  el.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+}
+
+describe('lv-right-panel tab shortcuts', () => {
+  beforeEach(() => {
+    repositoryStore.getState().reset();
+    repositoryStore.getState().addRepository(mockRepo('/test/repo'));
+  });
+
+  it('Ctrl+Shift+2 switches to the Details tab', async () => {
+    const el = await fixture<LvRightPanel>(html`<lv-right-panel></lv-right-panel>`);
+
+    pressKey(el, { code: 'Digit2', key: '@', ctrlKey: true, shiftKey: true });
+    await el.updateComplete;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).activeTab).to.equal('details');
+  });
+
+  it('Ctrl+Shift+3 switches to Analytics, Ctrl+Shift+1 back to Changes', async () => {
+    const el = await fixture<LvRightPanel>(html`<lv-right-panel></lv-right-panel>`);
+
+    pressKey(el, { code: 'Digit3', key: '#', ctrlKey: true, shiftKey: true });
+    await el.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).activeTab).to.equal('analytics');
+
+    pressKey(el, { code: 'Digit1', key: '!', ctrlKey: true, shiftKey: true });
+    await el.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).activeTab).to.equal('changes');
+  });
+
+  it('plain Ctrl+digit is ignored (reserved for repository tabs)', async () => {
+    const el = await fixture<LvRightPanel>(html`<lv-right-panel></lv-right-panel>`);
+
+    pressKey(el, { code: 'Digit2', key: '2', ctrlKey: true });
+    await el.updateComplete;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).activeTab).to.equal('changes');
+  });
+
+  it('advertises the shifted chord in its tooltips', async () => {
+    const el = await fixture<LvRightPanel>(html`<lv-right-panel></lv-right-panel>`);
+
+    const tabs = Array.from(el.shadowRoot!.querySelectorAll('.tab-bar .tab'));
+    expect(tabs.map((t) => t.getAttribute('title'))).to.deep.equal([
+      'Working Changes (Ctrl+Shift+1)',
+      'Commit Details (Ctrl+Shift+2)',
+      'Repository Analytics (Ctrl+Shift+3)',
+    ]);
+  });
+});

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -699,8 +699,17 @@ export class LvBranchList extends LitElement {
         gitService.getRemotes(loadedPath),
       ]);
 
+      // The tab may have switched while the fetch was in flight. The store
+      // write below is path-keyed and always safe; the component's OWN
+      // render state belongs to the now-active repo and must not be
+      // overwritten with a stale result (showing repo A's branches under
+      // repo B's tab would run checkout/delete against the wrong names).
+      const isCurrent = this.repositoryPath === loadedPath;
+
       if (!branchesResult.success) {
-        this.error = branchesResult.error?.message ?? 'Failed to load branches';
+        if (isCurrent) {
+          this.error = branchesResult.error?.message ?? 'Failed to load branches';
+        }
         return;
       }
 
@@ -712,6 +721,8 @@ export class LvBranchList extends LitElement {
         branches,
         currentBranch: branches.find((b) => b.isHead) ?? null,
       });
+
+      if (!isCurrent) return;
 
       // Separate local and remote branches
       const localBranches = branches.filter((b) => !b.isRemote);
@@ -820,9 +831,15 @@ export class LvBranchList extends LitElement {
       });
 
     } catch (err) {
-      this.error = err instanceof Error ? err.message : 'Unknown error';
+      if (this.repositoryPath === loadedPath) {
+        this.error = err instanceof Error ? err.message : 'Unknown error';
+      }
     } finally {
-      this.loading = false;
+      // A stale load must not stomp the loading state of the load that the
+      // now-active repo owns
+      if (this.repositoryPath === loadedPath) {
+        this.loading = false;
+      }
     }
   }
 

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -684,11 +684,18 @@ export class LvBranchList extends LitElement {
     await this.loadBranches();
   }
 
+  // Monotonic sequence per repo path: a load only applies its result if no
+  // NEWER load for the same path started meanwhile (path equality alone
+  // can't catch A -> B -> A switches reordering two loads for A)
+  private branchesLoadSeq = new Map<string, number>();
+
   private async loadBranches(): Promise<void> {
     if (!this.repositoryPath) return;
     // Captured before the await so a mid-flight tab switch still writes the
     // result to the repo it was loaded FROM
     const loadedPath = this.repositoryPath;
+    const seq = (this.branchesLoadSeq.get(loadedPath) ?? 0) + 1;
+    this.branchesLoadSeq.set(loadedPath, seq);
 
     this.loading = true;
     this.error = null;
@@ -699,6 +706,10 @@ export class LvBranchList extends LitElement {
         gitService.getRemotes(loadedPath),
       ]);
 
+      // A newer load for the SAME path supersedes this one entirely (its
+      // result is fresher for both the store and the panel).
+      const isLatestForPath = this.branchesLoadSeq.get(loadedPath) === seq;
+      if (!isLatestForPath) return;
       // The tab may have switched while the fetch was in flight. The store
       // write below is path-keyed and always safe; the component's OWN
       // render state belongs to the now-active repo and must not be

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -6,6 +6,7 @@ import { showConfirm, showPrompt } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import { dragDropService, type DragItem } from '../../services/drag-drop.service.ts';
 import { settingsStore } from '../../stores/settings.store.ts';
+import { repositoryStore } from '../../stores/repository.store.ts';
 import { fuzzyScore } from '../../utils/fuzzy-search.ts';
 import '../dialogs/lv-create-branch-dialog.ts';
 import type { LvCreateBranchDialog } from '../dialogs/lv-create-branch-dialog.ts';
@@ -685,14 +686,17 @@ export class LvBranchList extends LitElement {
 
   private async loadBranches(): Promise<void> {
     if (!this.repositoryPath) return;
+    // Captured before the await so a mid-flight tab switch still writes the
+    // result to the repo it was loaded FROM
+    const loadedPath = this.repositoryPath;
 
     this.loading = true;
     this.error = null;
 
     try {
       const [branchesResult] = await Promise.all([
-        gitService.getBranches(this.repositoryPath),
-        gitService.getRemotes(this.repositoryPath),
+        gitService.getBranches(loadedPath),
+        gitService.getRemotes(loadedPath),
       ]);
 
       if (!branchesResult.success) {
@@ -701,6 +705,13 @@ export class LvBranchList extends LitElement {
       }
 
       const branches = branchesResult.data!;
+
+      // Mirror branches into the repository store so path-keyed consumers
+      // (e.g. the tab bar's ahead/behind badge) stay in sync
+      repositoryStore.getState().updateRepoData(loadedPath, {
+        branches,
+        currentBranch: branches.find((b) => b.isHead) ?? null,
+      });
 
       // Separate local and remote branches
       const localBranches = branches.filter((b) => !b.isRemote);

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -8,6 +8,7 @@ import { showToast } from "../../services/notification.service.ts";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
 import { join } from "@tauri-apps/api/path";
 import type { StatusEntry, FileStatus } from "../../types/git.types.ts";
+import { repositoryStore } from "../../stores/repository.store.ts";
 
 interface FileContextMenuState {
   visible: boolean;
@@ -738,15 +739,7 @@ export class LvFileStatus extends LitElement {
     // Subscribe to file change events with debouncing
     // Note: refs-changed is handled globally by app-shell to ensure it works
     // even when the right panel (and this component) is hidden
-    this.unsubscribeWatcher = watcherService.onFileChange((event) => {
-      // Refresh status on workdir or index changes
-      if (
-        event.eventType === "workdir-changed" ||
-        event.eventType === "index-changed"
-      ) {
-        this.debouncedLoadStatus();
-      }
-    });
+    this.unsubscribeWatcher = watcherService.onFileChange(this.handleWatcherEvent);
 
     // Listen for global stage-all, unstage-all, and refresh events
     this.boundHandleStageAllEvent = () => this.handleStageAll();
@@ -965,6 +958,23 @@ export class LvFileStatus extends LitElement {
   }
 
   /**
+   * Route file-watcher events. Every open repo is watched — only THIS
+   * panel's repo may trigger a status reload here; background repos are
+   * routed to staleness by app-shell and refresh when their tab activates.
+   * (refs-changed stays global in app-shell so it works while this panel is
+   * hidden.)
+   */
+  private handleWatcherEvent = (event: watcherService.FileChangeEvent): void => {
+    if (event.repoPath !== this.repositoryPath) return;
+    if (
+      event.eventType === "workdir-changed" ||
+      event.eventType === "index-changed"
+    ) {
+      this.debouncedLoadStatus();
+    }
+  };
+
+  /**
    * Debounced version of loadStatus to prevent excessive refreshes
    * when multiple file changes occur in rapid succession.
    */
@@ -994,6 +1004,9 @@ export class LvFileStatus extends LitElement {
 
   async loadStatus(): Promise<void> {
     if (!this.repositoryPath) return;
+    // Captured before the await so a mid-flight tab switch still writes the
+    // result to the repo it was loaded FROM
+    const loadedPath = this.repositoryPath;
 
     // Only show loading indicator on the very first load
     if (!this.hasInitiallyLoaded) {
@@ -1002,7 +1015,7 @@ export class LvFileStatus extends LitElement {
     this.error = null;
 
     try {
-      const result = await gitService.getStatus(this.repositoryPath);
+      const result = await gitService.getStatus(loadedPath);
 
       if (!result.success) {
         this.error = result.error?.message ?? "Failed to load status";
@@ -1029,6 +1042,14 @@ export class LvFileStatus extends LitElement {
       if (unstagedChanged) {
         this.unstagedFiles = newUnstagedFiles;
       }
+
+      // Mirror the loaded status into the repository store so path-keyed
+      // consumers (e.g. the tab bar's dirty indicator) stay in sync
+      repositoryStore.getState().updateRepoData(loadedPath, {
+        status: entries,
+        stagedFiles: newStagedFiles,
+        unstagedFiles: newUnstagedFiles,
+      });
 
       // Emit status changed event only if something changed
       if (stagedChanged || unstagedChanged) {

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -1016,15 +1016,33 @@ export class LvFileStatus extends LitElement {
 
     try {
       const result = await gitService.getStatus(loadedPath);
+      // The tab may have switched while the fetch was in flight. The store
+      // write below is path-keyed and always safe; the component's OWN
+      // render state belongs to the now-active repo and must not be
+      // overwritten with a stale result (showing repo A's files under repo
+      // B's tab risks destructive actions on files the user never saw).
+      const isCurrent = this.repositoryPath === loadedPath;
 
       if (!result.success) {
-        this.error = result.error?.message ?? "Failed to load status";
+        if (isCurrent) {
+          this.error = result.error?.message ?? "Failed to load status";
+        }
         return;
       }
 
       const entries = result.data!;
       const newStagedFiles = entries.filter((e) => e.isStaged);
       const newUnstagedFiles = entries.filter((e) => !e.isStaged);
+
+      // Mirror the loaded status into the repository store so path-keyed
+      // consumers (e.g. the tab bar's dirty indicator) stay in sync
+      repositoryStore.getState().updateRepoData(loadedPath, {
+        status: entries,
+        stagedFiles: newStagedFiles,
+        unstagedFiles: newUnstagedFiles,
+      });
+
+      if (!isCurrent) return;
 
       // Only update if there are actual changes (delta update)
       const stagedChanged = !this.areStatusEntriesEqual(
@@ -1043,14 +1061,6 @@ export class LvFileStatus extends LitElement {
         this.unstagedFiles = newUnstagedFiles;
       }
 
-      // Mirror the loaded status into the repository store so path-keyed
-      // consumers (e.g. the tab bar's dirty indicator) stay in sync
-      repositoryStore.getState().updateRepoData(loadedPath, {
-        status: entries,
-        stagedFiles: newStagedFiles,
-        unstagedFiles: newUnstagedFiles,
-      });
-
       // Emit status changed event only if something changed
       if (stagedChanged || unstagedChanged) {
         this.dispatchEvent(
@@ -1065,10 +1075,16 @@ export class LvFileStatus extends LitElement {
         );
       }
     } catch (err) {
-      this.error = err instanceof Error ? err.message : "Unknown error";
+      if (this.repositoryPath === loadedPath) {
+        this.error = err instanceof Error ? err.message : "Unknown error";
+      }
     } finally {
-      this.loading = false;
-      this.hasInitiallyLoaded = true;
+      // A stale load must not stomp the loading state of the load that the
+      // now-active repo owns
+      if (this.repositoryPath === loadedPath) {
+        this.loading = false;
+        this.hasInitiallyLoaded = true;
+      }
     }
   }
 

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -1002,11 +1002,18 @@ export class LvFileStatus extends LitElement {
     }
   }
 
+  // Monotonic sequence per repo path: a load only applies its result if no
+  // NEWER load for the same path started meanwhile (path equality alone
+  // can't catch A -> B -> A switches reordering two loads for A)
+  private statusLoadSeq = new Map<string, number>();
+
   async loadStatus(): Promise<void> {
     if (!this.repositoryPath) return;
     // Captured before the await so a mid-flight tab switch still writes the
     // result to the repo it was loaded FROM
     const loadedPath = this.repositoryPath;
+    const seq = (this.statusLoadSeq.get(loadedPath) ?? 0) + 1;
+    this.statusLoadSeq.set(loadedPath, seq);
 
     // Only show loading indicator on the very first load
     if (!this.hasInitiallyLoaded) {
@@ -1016,6 +1023,10 @@ export class LvFileStatus extends LitElement {
 
     try {
       const result = await gitService.getStatus(loadedPath);
+      // A newer load for the SAME path supersedes this one entirely (its
+      // result is fresher for both the store and the panel).
+      const isLatestForPath = this.statusLoadSeq.get(loadedPath) === seq;
+      if (!isLatestForPath) return;
       // The tab may have switched while the fetch was in flight. The store
       // write below is path-keyed and always safe; the component's OWN
       // render state belongs to the now-active repo and must not be

--- a/src/components/sidebar/lv-right-panel.ts
+++ b/src/components/sidebar/lv-right-panel.ts
@@ -247,14 +247,18 @@ export class LvRightPanel extends LitElement {
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
-    // Tab switching shortcuts
-    if (e.key === '1' && (e.ctrlKey || e.metaKey)) {
+    // Tab switching shortcuts. Ctrl+SHIFT+digit: plain Ctrl+digit belongs to
+    // the global repository-tab shortcuts (browser convention), so the panel
+    // takes the shifted chord. Matched on e.code because Shift changes e.key
+    // ('1' -> '!') on most layouts.
+    if (!e.shiftKey || !(e.ctrlKey || e.metaKey)) return;
+    if (e.code === 'Digit1') {
       e.preventDefault();
       this.switchTab('changes');
-    } else if (e.key === '2' && (e.ctrlKey || e.metaKey)) {
+    } else if (e.code === 'Digit2') {
       e.preventDefault();
       this.switchTab('details');
-    } else if (e.key === '3' && (e.ctrlKey || e.metaKey)) {
+    } else if (e.code === 'Digit3') {
       e.preventDefault();
       this.switchTab('analytics');
     }
@@ -297,7 +301,7 @@ export class LvRightPanel extends LitElement {
         <button
           class="tab ${this.activeTab === 'changes' ? 'active' : ''}"
           @click=${() => this.switchTab('changes')}
-          title="Working Changes (Ctrl+1)"
+          title="Working Changes (Ctrl+Shift+1)"
         >
           <span>Changes</span>
           ${this.changesCount > 0 ? html`<span class="badge">${this.changesCount}</span>` : nothing}
@@ -306,7 +310,7 @@ export class LvRightPanel extends LitElement {
         <button
           class="tab ${this.activeTab === 'details' ? 'active' : ''}"
           @click=${() => this.switchTab('details')}
-          title="Commit Details (Ctrl+2)"
+          title="Commit Details (Ctrl+Shift+2)"
         >
           <span>Details</span>
           ${this.commit ? html`<span class="badge">${this.commit.oid.slice(0, 7)}</span>` : nothing}
@@ -314,7 +318,7 @@ export class LvRightPanel extends LitElement {
         <button
           class="tab ${this.activeTab === 'analytics' ? 'active' : ''}"
           @click=${() => this.switchTab('analytics')}
-          title="Repository Analytics (Ctrl+3)"
+          title="Repository Analytics (Ctrl+Shift+3)"
         >
           <span>Analytics</span>
         </button>

--- a/src/components/toolbar/__tests__/lv-toolbar.test.ts
+++ b/src/components/toolbar/__tests__/lv-toolbar.test.ts
@@ -68,6 +68,16 @@ describe('lv-toolbar repository tabs', () => {
       expect(tabs(el)[0].title).to.equal('/work/api');
     });
 
+    it('disambiguates duplicate repo names on Windows-style paths', async () => {
+      repositoryStore.getState().addRepository(mockRepo('C:\\work\\client-a\\api', 'api'));
+      repositoryStore.getState().addRepository(mockRepo('C:\\work\\client-b\\api', 'api'));
+      const el = await createToolbar();
+
+      const hints = tabs(el).map((t) => t.querySelector('.tab-hint')?.textContent?.trim() ?? null);
+      expect(hints[0]).to.equal('client-a');
+      expect(hints[1]).to.equal('client-b');
+    });
+
     it('disambiguates duplicate repo names with the parent directory', async () => {
       repositoryStore.getState().addRepository(mockRepo('/client-a/api', 'api'));
       repositoryStore.getState().addRepository(mockRepo('/client-b/api', 'api'));
@@ -263,6 +273,29 @@ describe('lv-toolbar repository tabs', () => {
       const menu = await openContextMenu(el, 2);
 
       expect(menuItem(menu, 'Close Tabs to the Right').disabled).to.be.true;
+    });
+
+    it('closes on Escape without touching any tab', async () => {
+      const el = await createToolbar();
+      await openContextMenu(el, 0);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.querySelector('.tab-context-menu')).to.not.exist;
+      expect(repositoryStore.getState().openRepositories.length).to.equal(3);
+    });
+
+    it('the all-repositories dropdown also closes on Escape', async () => {
+      const el = await createToolbar();
+      (el.shadowRoot!.querySelector('.tab-list-btn') as HTMLButtonElement).click();
+      await el.updateComplete;
+      expect(el.shadowRoot!.querySelector('.tab-list-menu')).to.exist;
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.querySelector('.tab-list-menu')).to.not.exist;
     });
 
     it('closes via the backdrop without touching any tab', async () => {

--- a/src/components/toolbar/__tests__/lv-toolbar.test.ts
+++ b/src/components/toolbar/__tests__/lv-toolbar.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for the repository tab bar: labels/tooltips, duplicate-name
+ * disambiguation, active styling, status badges, the all-repos dropdown,
+ * middle-click close, and the tab context menu.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: () => Promise.resolve(null),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { LvToolbar } from '../lv-toolbar.ts';
+import '../lv-toolbar.ts';
+import { repositoryStore } from '../../../stores/index.ts';
+import type { Repository, Branch, StatusEntry } from '../../../types/git.types.ts';
+
+function mockRepo(path: string, name: string): Repository {
+  return {
+    path,
+    name,
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+function mockBranch(aheadBehind?: { ahead: number; behind: number }): Branch {
+  return {
+    name: 'main',
+    shorthand: 'main',
+    isHead: true,
+    isRemote: false,
+    upstream: 'origin/main',
+    targetOid: 'abc123',
+    aheadBehind,
+    isStale: false,
+  };
+}
+
+const dirtyEntry = { path: 'a.txt', status: 'modified', isStaged: false } as unknown as StatusEntry;
+
+async function createToolbar(): Promise<LvToolbar> {
+  return fixture<LvToolbar>(html`<lv-toolbar></lv-toolbar>`);
+}
+
+function tabs(el: LvToolbar): HTMLButtonElement[] {
+  return Array.from(el.shadowRoot!.querySelectorAll('.tab'));
+}
+
+describe('lv-toolbar repository tabs', () => {
+  beforeEach(() => {
+    repositoryStore.getState().reset();
+  });
+
+  describe('tab rendering', () => {
+    it('shows the full path as a tooltip on every tab', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/work/api', 'api'));
+      const el = await createToolbar();
+
+      expect(tabs(el)[0].title).to.equal('/work/api');
+    });
+
+    it('disambiguates duplicate repo names with the parent directory', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/client-a/api', 'api'));
+      repositoryStore.getState().addRepository(mockRepo('/client-b/api', 'api'));
+      repositoryStore.getState().addRepository(mockRepo('/work/web', 'web'));
+      const el = await createToolbar();
+
+      const hints = tabs(el).map((t) => t.querySelector('.tab-hint')?.textContent?.trim() ?? null);
+      expect(hints[0]).to.equal('client-a');
+      expect(hints[1]).to.equal('client-b');
+      expect(hints[2]).to.equal(null, 'unique names need no hint');
+    });
+
+    it('marks the active tab with class, aria-selected and an accent', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+      const el = await createToolbar();
+
+      const [first, second] = tabs(el);
+      expect(second.classList.contains('active')).to.be.true;
+      expect(second.getAttribute('aria-selected')).to.equal('true');
+      expect(first.classList.contains('active')).to.be.false;
+      expect(first.getAttribute('aria-selected')).to.equal('false');
+    });
+  });
+
+  describe('tab badges', () => {
+    it('shows a dirty dot when the repo has uncommitted changes', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      repositoryStore.getState().updateRepoData('/repo/one', { status: [dirtyEntry] });
+      const el = await createToolbar();
+
+      expect(tabs(el)[0].querySelector('.tab-dirty')).to.exist;
+    });
+
+    it('shows no dirty dot for a clean repo', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      const el = await createToolbar();
+
+      expect(tabs(el)[0].querySelector('.tab-dirty')).to.not.exist;
+    });
+
+    it('shows ahead/behind counts when the branch diverges from upstream', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      repositoryStore.getState().updateRepoData('/repo/one', {
+        currentBranch: mockBranch({ ahead: 2, behind: 1 }),
+      });
+      const el = await createToolbar();
+
+      const badge = tabs(el)[0].querySelector('.tab-ahead-behind');
+      expect(badge).to.exist;
+      expect(badge!.textContent).to.contain('↑2');
+      expect(badge!.textContent).to.contain('↓1');
+    });
+
+    it('shows no ahead/behind badge when in sync', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      repositoryStore.getState().updateRepoData('/repo/one', {
+        currentBranch: mockBranch({ ahead: 0, behind: 0 }),
+      });
+      const el = await createToolbar();
+
+      expect(tabs(el)[0].querySelector('.tab-ahead-behind')).to.not.exist;
+    });
+  });
+
+  describe('all-repositories dropdown', () => {
+    it('lists every open repo with its path and activates on click', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+      const el = await createToolbar();
+
+      (el.shadowRoot!.querySelector('.tab-list-btn') as HTMLButtonElement).click();
+      await el.updateComplete;
+
+      const items = Array.from(el.shadowRoot!.querySelectorAll('.tab-list-item'));
+      expect(items.length).to.equal(2);
+      expect(items[0].textContent).to.contain('one');
+      expect(items[0].querySelector('.item-path')!.textContent).to.contain('/repo/one');
+      // Active repo (two) carries the check mark
+      expect(items[1].querySelector('.check svg')).to.exist;
+      expect(items[0].querySelector('.check svg')).to.not.exist;
+
+      (items[0] as HTMLButtonElement).click();
+      await el.updateComplete;
+
+      expect(repositoryStore.getState().activeIndex).to.equal(0);
+      expect(el.shadowRoot!.querySelector('.tab-list-menu')).to.not.exist;
+    });
+
+    it('is hidden when no repositories are open', async () => {
+      const el = await createToolbar();
+      expect(el.shadowRoot!.querySelector('.tab-list-btn')).to.not.exist;
+    });
+  });
+
+  describe('middle-click close', () => {
+    it('closes the tab on middle click', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+      const el = await createToolbar();
+
+      tabs(el)[0].dispatchEvent(new MouseEvent('auxclick', { button: 1, bubbles: true }));
+      await el.updateComplete;
+
+      const state = repositoryStore.getState();
+      expect(state.openRepositories.length).to.equal(1);
+      expect(state.openRepositories[0].repository.path).to.equal('/repo/two');
+    });
+
+    it('ignores non-middle auxclicks', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      const el = await createToolbar();
+
+      tabs(el)[0].dispatchEvent(new MouseEvent('auxclick', { button: 2, bubbles: true }));
+      await el.updateComplete;
+
+      expect(repositoryStore.getState().openRepositories.length).to.equal(1);
+    });
+  });
+
+  describe('tab context menu', () => {
+    async function openContextMenu(el: LvToolbar, tabIndex: number): Promise<HTMLElement> {
+      tabs(el)[tabIndex].dispatchEvent(
+        new MouseEvent('contextmenu', { clientX: 50, clientY: 50, bubbles: true, cancelable: true })
+      );
+      await el.updateComplete;
+      const menu = el.shadowRoot!.querySelector('.tab-context-menu');
+      expect(menu).to.exist;
+      return menu as HTMLElement;
+    }
+
+    function menuItem(menu: HTMLElement, label: string): HTMLButtonElement {
+      const item = Array.from(menu.querySelectorAll('.context-menu-item')).find((b) =>
+        b.textContent!.includes(label)
+      );
+      expect(item, `menu item "${label}"`).to.exist;
+      return item as HTMLButtonElement;
+    }
+
+    beforeEach(() => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
+      repositoryStore.getState().addRepository(mockRepo('/repo/three', 'three'));
+    });
+
+    it('Close closes only that tab', async () => {
+      const el = await createToolbar();
+      const menu = await openContextMenu(el, 1);
+
+      menuItem(menu, 'Close').click();
+      await el.updateComplete;
+
+      const paths = repositoryStore.getState().openRepositories.map((r) => r.repository.path);
+      expect(paths).to.deep.equal(['/repo/one', '/repo/three']);
+    });
+
+    it('Close Others keeps only the clicked tab', async () => {
+      const el = await createToolbar();
+      const menu = await openContextMenu(el, 1);
+
+      menuItem(menu, 'Close Others').click();
+      await el.updateComplete;
+
+      const paths = repositoryStore.getState().openRepositories.map((r) => r.repository.path);
+      expect(paths).to.deep.equal(['/repo/two']);
+      expect(repositoryStore.getState().activeIndex).to.equal(0);
+    });
+
+    it('Close Tabs to the Right closes everything after the clicked tab', async () => {
+      const el = await createToolbar();
+      const menu = await openContextMenu(el, 0);
+
+      menuItem(menu, 'Close Tabs to the Right').click();
+      await el.updateComplete;
+
+      const paths = repositoryStore.getState().openRepositories.map((r) => r.repository.path);
+      expect(paths).to.deep.equal(['/repo/one']);
+    });
+
+    it('Close All closes every tab', async () => {
+      const el = await createToolbar();
+      const menu = await openContextMenu(el, 0);
+
+      menuItem(menu, 'Close All').click();
+      await el.updateComplete;
+
+      expect(repositoryStore.getState().openRepositories.length).to.equal(0);
+      expect(repositoryStore.getState().activeIndex).to.equal(-1);
+    });
+
+    it('disables Close Tabs to the Right on the last tab', async () => {
+      const el = await createToolbar();
+      const menu = await openContextMenu(el, 2);
+
+      expect(menuItem(menu, 'Close Tabs to the Right').disabled).to.be.true;
+    });
+
+    it('closes via the backdrop without touching any tab', async () => {
+      const el = await createToolbar();
+      await openContextMenu(el, 0);
+
+      (el.shadowRoot!.querySelector('.menu-backdrop') as HTMLElement).click();
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.querySelector('.tab-context-menu')).to.not.exist;
+      expect(repositoryStore.getState().openRepositories.length).to.equal(3);
+    });
+  });
+});

--- a/src/components/toolbar/lv-toolbar.ts
+++ b/src/components/toolbar/lv-toolbar.ts
@@ -407,6 +407,10 @@ export class LvToolbar extends LitElement {
     super.disconnectedCallback();
     this.unsubscribe?.();
     this._resizeObserver?.disconnect();
+    if (this.menuEscapeListenerAttached) {
+      document.removeEventListener('keydown', this.handleMenuEscape, { capture: true });
+      this.menuEscapeListenerAttached = false;
+    }
   }
 
   private async handleOpenRepo(): Promise<void> {
@@ -546,7 +550,8 @@ export class LvToolbar extends LitElement {
     const name = repo.repository.name;
     const sameName = this.openRepositories.filter((r) => r.repository.name === name);
     if (sameName.length < 2) return null;
-    const parts = repo.repository.path.split('/').filter(Boolean);
+    // Split on both separators — Windows paths use backslashes
+    const parts = repo.repository.path.split(/[\\/]/).filter(Boolean);
     return parts.length >= 2 ? parts[parts.length - 2] : null;
   }
 
@@ -690,8 +695,32 @@ export class LvToolbar extends LitElement {
     this.updateScrollButtons();
   }
 
+  // Close the tab menus on Escape, matching the other context menus in the
+  // app (e.g. lv-file-status). Registered only while a menu is open.
+  private handleMenuEscape = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      this.tabListAnchor = null;
+      this.tabContextMenu = null;
+    }
+  };
+
+  private menuEscapeListenerAttached = false;
+
+  private syncMenuEscapeListener(): void {
+    const menuOpen = this.tabListAnchor !== null || this.tabContextMenu !== null;
+    if (menuOpen && !this.menuEscapeListenerAttached) {
+      document.addEventListener('keydown', this.handleMenuEscape, { capture: true });
+      this.menuEscapeListenerAttached = true;
+    } else if (!menuOpen && this.menuEscapeListenerAttached) {
+      document.removeEventListener('keydown', this.handleMenuEscape, { capture: true });
+      this.menuEscapeListenerAttached = false;
+    }
+  }
+
   protected updated(changedProperties: Map<string, unknown>): void {
     super.updated(changedProperties);
+    this.syncMenuEscapeListener();
     if (changedProperties.has('openRepositories')) {
       this.updateComplete.then(() => this.updateScrollButtons());
     }

--- a/src/components/toolbar/lv-toolbar.ts
+++ b/src/components/toolbar/lv-toolbar.ts
@@ -3,7 +3,7 @@
  * Contains menu buttons and repository tabs
  */
 
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state, query } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import { repositoryStore, type OpenRepository } from '../../stores/index.ts';
@@ -86,10 +86,18 @@ export class LvToolbar extends LitElement {
       .tabs {
         display: flex;
         flex: 1;
-        overflow-x: hidden;
+        min-width: 0;
+        overflow-x: auto;
         padding: 0 var(--spacing-xs);
         gap: var(--spacing-xs);
         scroll-behavior: smooth;
+        /* Scrolling happens via wheel/trackpad and the arrow buttons; a
+           scrollbar in a 32px-high strip is just noise */
+        scrollbar-width: none;
+      }
+
+      .tabs::-webkit-scrollbar {
+        display: none;
       }
 
       .scroll-btn {
@@ -138,7 +146,10 @@ export class LvToolbar extends LitElement {
         cursor: pointer;
         transition: all var(--transition-fast);
         white-space: nowrap;
-        flex-shrink: 0;
+        /* Tabs shrink (with ellipsis) before the strip overflows */
+        flex: 0 1 auto;
+        min-width: 90px;
+        max-width: 200px;
       }
 
       .tab:hover {
@@ -149,10 +160,41 @@ export class LvToolbar extends LitElement {
       .tab.active {
         background: var(--color-bg-tertiary);
         color: var(--color-text-primary);
+        font-weight: 600;
+        box-shadow: inset 0 -2px 0 var(--color-accent, var(--color-primary));
       }
 
       .tab-name {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
         white-space: nowrap;
+        text-align: left;
+      }
+
+      .tab-hint {
+        color: var(--color-text-muted);
+        font-size: var(--font-size-xs);
+        font-weight: normal;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 70px;
+      }
+
+      .tab-dirty {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--color-warning, #e5a50a);
+        flex-shrink: 0;
+      }
+
+      .tab-ahead-behind {
+        color: var(--color-text-muted);
+        font-size: var(--font-size-xs);
+        font-weight: normal;
+        flex-shrink: 0;
       }
 
       .provider-icon {
@@ -209,6 +251,101 @@ export class LvToolbar extends LitElement {
         font-size: var(--font-size-sm);
         font-style: italic;
       }
+
+      .menu-backdrop {
+        position: fixed;
+        inset: 0;
+        z-index: 999;
+      }
+
+      .tab-list-menu,
+      .tab-context-menu {
+        position: fixed;
+        z-index: 1000;
+        min-width: 220px;
+        max-width: 360px;
+        max-height: 60vh;
+        overflow-y: auto;
+        padding: var(--spacing-xs);
+        background: var(--color-bg-secondary);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+      }
+
+      .tab-list-item {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-sm);
+        width: 100%;
+        padding: var(--spacing-xs) var(--spacing-sm);
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--color-text-primary);
+        font-size: var(--font-size-sm);
+        cursor: pointer;
+        text-align: left;
+      }
+
+      .tab-list-item:hover {
+        background: var(--color-bg-hover);
+      }
+
+      .tab-list-item .check {
+        width: 14px;
+        flex-shrink: 0;
+        color: var(--color-accent, var(--color-primary));
+      }
+
+      .tab-list-item .item-texts {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .tab-list-item .item-path {
+        color: var(--color-text-muted);
+        font-size: var(--font-size-xs);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        direction: rtl;
+        text-align: left;
+      }
+
+      .context-menu-item {
+        display: block;
+        width: 100%;
+        padding: var(--spacing-xs) var(--spacing-sm);
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--color-text-primary);
+        font-size: var(--font-size-sm);
+        cursor: pointer;
+        text-align: left;
+      }
+
+      .context-menu-item:hover {
+        background: var(--color-bg-hover);
+      }
+
+      .context-menu-item:disabled {
+        color: var(--color-text-muted);
+        cursor: default;
+      }
+
+      .context-menu-item:disabled:hover {
+        background: transparent;
+      }
+
+      .context-menu-separator {
+        height: 1px;
+        margin: var(--spacing-xs) 0;
+        background: var(--color-border);
+      }
     `,
   ];
 
@@ -225,12 +362,22 @@ export class LvToolbar extends LitElement {
   @state() private semanticAvailable = false;
   @state() private canScrollLeft = false;
   @state() private canScrollRight = false;
+  // Anchor for the "all open repositories" dropdown (null = closed)
+  @state() private tabListAnchor: { x: number; y: number } | null = null;
+  // Right-click context menu on a tab (null = closed)
+  @state() private tabContextMenu: { x: number; y: number; index: number } | null = null;
 
   private unsubscribe?: () => void;
   private _resizeObserver?: ResizeObserver;
 
   connectedCallback(): void {
     super.connectedCallback();
+    // Seed from current store state — repos may already be open if the
+    // toolbar (re)mounts after startup restore
+    const initial = repositoryStore.getState();
+    this.openRepositories = initial.openRepositories;
+    this.activeIndex = initial.activeIndex;
+    this.isLoading = initial.isLoading;
     // Subscribe to store changes
     this.unsubscribe = repositoryStore.subscribe((state) => {
       this.openRepositories = state.openRepositories;
@@ -313,6 +460,94 @@ export class LvToolbar extends LitElement {
   private handleTabClose(e: Event, path: string): void {
     e.stopPropagation();
     repositoryStore.getState().removeRepository(path);
+  }
+
+  // Middle-click closes a tab (browser-tab convention)
+  private handleTabAuxClick(e: MouseEvent, path: string): void {
+    if (e.button === 1) {
+      e.preventDefault();
+      repositoryStore.getState().removeRepository(path);
+    }
+  }
+
+  private handleTabContextMenu(e: MouseEvent, index: number): void {
+    e.preventDefault();
+    e.stopPropagation();
+    this.tabListAnchor = null;
+    this.tabContextMenu = { x: e.clientX, y: e.clientY, index };
+  }
+
+  private handleCloseOtherTabs(index: number): void {
+    const keep = repositoryStore.getState().openRepositories[index]?.repository.path;
+    this.tabContextMenu = null;
+    if (!keep) return;
+    const others = repositoryStore
+      .getState()
+      .openRepositories.filter((r) => r.repository.path !== keep)
+      .map((r) => r.repository.path);
+    for (const path of others) {
+      repositoryStore.getState().removeRepository(path);
+    }
+  }
+
+  private handleCloseTabsToRight(index: number): void {
+    this.tabContextMenu = null;
+    const toClose = repositoryStore
+      .getState()
+      .openRepositories.slice(index + 1)
+      .map((r) => r.repository.path);
+    for (const path of toClose) {
+      repositoryStore.getState().removeRepository(path);
+    }
+  }
+
+  private handleCloseAllTabs(): void {
+    this.tabContextMenu = null;
+    const toClose = repositoryStore
+      .getState()
+      .openRepositories.map((r) => r.repository.path);
+    for (const path of toClose) {
+      repositoryStore.getState().removeRepository(path);
+    }
+  }
+
+  private async handleCopyTabPath(index: number): Promise<void> {
+    const path = repositoryStore.getState().openRepositories[index]?.repository.path;
+    this.tabContextMenu = null;
+    if (!path) return;
+    try {
+      await navigator.clipboard.writeText(path);
+      showToast('Repository path copied', 'success');
+    } catch {
+      showToast('Failed to copy path', 'error');
+    }
+  }
+
+  private handleToggleTabList(e: MouseEvent): void {
+    if (this.tabListAnchor) {
+      this.tabListAnchor = null;
+      return;
+    }
+    this.tabContextMenu = null;
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    this.tabListAnchor = { x: rect.right, y: rect.bottom + 4 };
+  }
+
+  private handleTabListSelect(index: number): void {
+    this.tabListAnchor = null;
+    repositoryStore.getState().setActiveIndex(index);
+  }
+
+  /**
+   * When several open repos share a name (two clones of "api"), the bare
+   * name can't identify a tab — disambiguate with the parent directory.
+   */
+  private getTabHint(repo: OpenRepository): string | null {
+    const name = repo.repository.name;
+    const sameName = this.openRepositories.filter((r) => r.repository.name === name);
+    if (sameName.length < 2) return null;
+    const parts = repo.repository.path.split('/').filter(Boolean);
+    return parts.length >= 2 ? parts[parts.length - 2] : null;
   }
 
   private handleTabCloseKeydown(e: KeyboardEvent, path: string): void {
@@ -460,6 +695,120 @@ export class LvToolbar extends LitElement {
     if (changedProperties.has('openRepositories')) {
       this.updateComplete.then(() => this.updateScrollButtons());
     }
+    // Keep the active tab visible when activated from anywhere (keyboard
+    // shortcut, command palette, dropdown) — not just direct clicks.
+    if (changedProperties.has('activeIndex') && this.activeIndex >= 0) {
+      this.updateComplete.then(() => {
+        this.tabsContainer
+          ?.querySelector('.tab.active')
+          ?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      });
+    }
+  }
+
+  private renderTabBadges(repo: OpenRepository) {
+    const dirty = repo.status.length > 0;
+    const ab = repo.currentBranch?.aheadBehind;
+    const showAheadBehind = ab && (ab.ahead > 0 || ab.behind > 0);
+    return html`
+      ${showAheadBehind
+        ? html`<span
+            class="tab-ahead-behind"
+            title="${ab.ahead} ahead, ${ab.behind} behind upstream"
+            >${ab.ahead > 0 ? `↑${ab.ahead}` : ''}${ab.behind > 0 ? `↓${ab.behind}` : ''}</span
+          >`
+        : nothing}
+      ${dirty
+        ? html`<span class="tab-dirty" title="Uncommitted changes" aria-label="Uncommitted changes"></span>`
+        : nothing}
+    `;
+  }
+
+  private renderTabListMenu() {
+    if (!this.tabListAnchor) return nothing;
+    return html`
+      <div class="menu-backdrop" @click=${() => (this.tabListAnchor = null)}></div>
+      <div
+        class="tab-list-menu"
+        role="menu"
+        aria-label="Open repositories"
+        style="top: ${this.tabListAnchor.y}px; left: ${this.tabListAnchor.x}px; transform: translateX(-100%);"
+      >
+        ${this.openRepositories.map(
+          (repo, index) => html`
+            <button
+              class="tab-list-item"
+              role="menuitem"
+              @click=${() => this.handleTabListSelect(index)}
+            >
+              <span class="check">
+                ${index === this.activeIndex
+                  ? html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                      <polyline points="20 6 9 17 4 12"></polyline>
+                    </svg>`
+                  : nothing}
+              </span>
+              <span class="item-texts">
+                <span>${repo.repository.name}</span>
+                <span class="item-path">${repo.repository.path}</span>
+              </span>
+            </button>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  private renderTabContextMenu() {
+    if (!this.tabContextMenu) return nothing;
+    const { x, y, index } = this.tabContextMenu;
+    const repo = this.openRepositories[index];
+    if (!repo) return nothing;
+    const isLast = index === this.openRepositories.length - 1;
+    const isOnly = this.openRepositories.length === 1;
+    return html`
+      <div class="menu-backdrop" @click=${() => (this.tabContextMenu = null)}></div>
+      <div
+        class="tab-context-menu"
+        role="menu"
+        aria-label="Tab actions for ${repo.repository.name}"
+        style="top: ${y}px; left: ${x}px;"
+      >
+        <button
+          class="context-menu-item"
+          role="menuitem"
+          @click=${() => {
+            this.tabContextMenu = null;
+            repositoryStore.getState().removeRepository(repo.repository.path);
+          }}
+        >
+          Close
+        </button>
+        <button
+          class="context-menu-item"
+          role="menuitem"
+          ?disabled=${isOnly}
+          @click=${() => this.handleCloseOtherTabs(index)}
+        >
+          Close Others
+        </button>
+        <button
+          class="context-menu-item"
+          role="menuitem"
+          ?disabled=${isLast}
+          @click=${() => this.handleCloseTabsToRight(index)}
+        >
+          Close Tabs to the Right
+        </button>
+        <button class="context-menu-item" role="menuitem" @click=${() => this.handleCloseAllTabs()}>
+          Close All
+        </button>
+        <div class="context-menu-separator"></div>
+        <button class="context-menu-item" role="menuitem" @click=${() => this.handleCopyTabPath(index)}>
+          Copy Path
+        </button>
+      </div>
+    `;
   }
 
   protected firstUpdated(): void {
@@ -547,10 +896,17 @@ export class LvToolbar extends LitElement {
                     role="tab"
                     aria-selected=${index === this.activeIndex}
                     aria-label="${repo.repository.name}"
+                    title="${repo.repository.path}"
                     @click=${() => this.handleTabClick(index)}
+                    @auxclick=${(e: MouseEvent) => this.handleTabAuxClick(e, repo.repository.path)}
+                    @contextmenu=${(e: MouseEvent) => this.handleTabContextMenu(e, index)}
                   >
                     ${this.renderProviderIcon(repo)}
                     <span class="tab-name">${repo.repository.name}</span>
+                    ${this.getTabHint(repo)
+                      ? html`<span class="tab-hint">${this.getTabHint(repo)}</span>`
+                      : nothing}
+                    ${this.renderTabBadges(repo)}
                     <span
                       class="tab-close"
                       role="button"
@@ -578,7 +934,24 @@ export class LvToolbar extends LitElement {
             <polyline points="9 18 15 12 9 6"></polyline>
           </svg>
         </button>
+        ${this.openRepositories.length > 0
+          ? html`
+              <button
+                class="menu-btn tab-list-btn"
+                title="All open repositories"
+                aria-label="List all open repositories"
+                aria-expanded=${this.tabListAnchor !== null}
+                @click=${this.handleToggleTabList}
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <polyline points="6 9 12 15 18 9"></polyline>
+                </svg>
+              </button>
+            `
+          : nothing}
       </div>
+
+      ${this.renderTabListMenu()} ${this.renderTabContextMenu()}
 
       <div class="toolbar-section">
         ${this.activeRepo ? html`

--- a/src/components/welcome/__tests__/lv-welcome-workspace.test.ts
+++ b/src/components/welcome/__tests__/lv-welcome-workspace.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the welcome screen's workspace-open flow: batch open without
+ * per-repo activation, and user-visible feedback when repos fail to open.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
+const mockResponses: Record<string, (args: Record<string, unknown>) => unknown> = {};
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCallArgs.push({ command, args: args || {} });
+    const handler = mockResponses[command];
+    try {
+      return Promise.resolve(handler ? handler(args || {}) : null);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect } from '@open-wc/testing';
+import '../lv-welcome.ts';
+import { repositoryStore, uiStore } from '../../../stores/index.ts';
+
+function mockRepoPayload(path: string) {
+  return {
+    path,
+    name: path.split('/').pop(),
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+function makeWorkspace(paths: string[]) {
+  return {
+    id: 'ws-1',
+    name: 'client-a',
+    repositories: paths.map((path) => ({ path, name: path.split('/').pop() ?? path })),
+  };
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('lv-welcome workspace open', () => {
+  beforeEach(() => {
+    invokeCallArgs.length = 0;
+    for (const key of Object.keys(mockResponses)) {
+      delete mockResponses[key];
+    }
+    uiStore.setState({ toasts: [] });
+    repositoryStore.getState().reset();
+  });
+
+  it('opens every repo, activates the last one, and toasts success', async () => {
+    mockResponses['open_repository'] = (args) => mockRepoPayload(args.path as string);
+    const el = document.createElement('lv-welcome') as HTMLElement;
+
+    await (el as any).handleWorkspaceClick(makeWorkspace(['/ws/one', '/ws/two', '/ws/three']));
+
+    const state = repositoryStore.getState();
+    expect(state.openRepositories.length).to.equal(3);
+    expect(state.openRepositories[state.activeIndex].repository.path).to.equal('/ws/three');
+
+    const toasts = uiStore.getState().toasts;
+    expect(toasts.length).to.equal(1);
+    expect(toasts[0].type).to.equal('success');
+  });
+
+  it('reports partially failed workspace opens instead of toasting plain success', async () => {
+    mockResponses['open_repository'] = (args) => {
+      if (args.path === '/ws/gone') {
+        throw new Error('repository not found');
+      }
+      return mockRepoPayload(args.path as string);
+    };
+    const el = document.createElement('lv-welcome') as HTMLElement;
+
+    await (el as any).handleWorkspaceClick(makeWorkspace(['/ws/one', '/ws/gone']));
+
+    expect(repositoryStore.getState().openRepositories.length).to.equal(1);
+    const toasts = uiStore.getState().toasts;
+    expect(toasts.length).to.equal(1);
+    expect(toasts[0].type).to.equal('warning');
+    expect(toasts[0].message).to.contain('1 of 2');
+  });
+
+  it('toasts an error when NO repository in the workspace could be opened', async () => {
+    mockResponses['open_repository'] = () => {
+      throw new Error('repository not found');
+    };
+    const el = document.createElement('lv-welcome') as HTMLElement;
+
+    await (el as any).handleWorkspaceClick(makeWorkspace(['/ws/gone-1', '/ws/gone-2']));
+
+    expect(repositoryStore.getState().openRepositories.length).to.equal(0);
+    const toasts = uiStore.getState().toasts;
+    expect(toasts.length).to.equal(1);
+    expect(toasts[0].type).to.equal('error');
+  });
+});

--- a/src/components/welcome/lv-welcome.ts
+++ b/src/components/welcome/lv-welcome.ts
@@ -418,7 +418,11 @@ export class LvWelcome extends LitElement {
       const result = await openRepository({ path: repo.path });
       if (result.success && result.data) {
         store.addRepository(result.data);
-        searchIndexService.buildIndex(repo.path);
+        // Index builds are deliberately NOT started here: opening a
+        // workspace with many repos would kick off that many concurrent
+        // history walks at once. The repo that ends up active gets its
+        // indexes from app-shell's activation hook; the rest build lazily
+        // when their tab is first activated.
       }
     }
 

--- a/src/components/welcome/lv-welcome.ts
+++ b/src/components/welcome/lv-welcome.ts
@@ -414,16 +414,21 @@ export class LvWelcome extends LitElement {
   private async handleWorkspaceClick(workspace: Workspace): Promise<void> {
     const store = repositoryStore.getState();
 
+    // Open WITHOUT activating each repo: addRepository's default activation
+    // would fire the per-activation side effects (index builds, integration
+    // checks) once per repo — a 10-repo workspace would still kick off 10
+    // concurrent history walks. Activate only the final repo; the rest get
+    // their indexes lazily when their tab is first activated.
+    let lastOpenedPath: string | null = null;
     for (const repo of workspace.repositories) {
       const result = await openRepository({ path: repo.path });
       if (result.success && result.data) {
-        store.addRepository(result.data);
-        // Index builds are deliberately NOT started here: opening a
-        // workspace with many repos would kick off that many concurrent
-        // history walks at once. The repo that ends up active gets its
-        // indexes from app-shell's activation hook; the rest build lazily
-        // when their tab is first activated.
+        store.addRepository(result.data, { activate: false });
+        lastOpenedPath = result.data.path;
       }
+    }
+    if (lastOpenedPath) {
+      store.setActiveByPath(lastOpenedPath);
     }
 
     workspaceStore.getState().setActiveWorkspaceId(workspace.id);

--- a/src/components/welcome/lv-welcome.ts
+++ b/src/components/welcome/lv-welcome.ts
@@ -420,11 +420,14 @@ export class LvWelcome extends LitElement {
     // concurrent history walks. Activate only the final repo; the rest get
     // their indexes lazily when their tab is first activated.
     let lastOpenedPath: string | null = null;
+    let failedCount = 0;
     for (const repo of workspace.repositories) {
       const result = await openRepository({ path: repo.path });
       if (result.success && result.data) {
         store.addRepository(result.data, { activate: false });
         lastOpenedPath = result.data.path;
+      } else {
+        failedCount++;
       }
     }
     if (lastOpenedPath) {
@@ -433,7 +436,18 @@ export class LvWelcome extends LitElement {
 
     workspaceStore.getState().setActiveWorkspaceId(workspace.id);
     await workspaceService.updateWorkspaceLastOpened(workspace.id);
-    showToast(`Opened workspace: ${workspace.name}`, 'success');
+    // A repo that failed to open (moved, deleted) must not hide behind a
+    // green success toast
+    if (failedCount === 0) {
+      showToast(`Opened workspace: ${workspace.name}`, 'success');
+    } else if (lastOpenedPath) {
+      showToast(
+        `Opened workspace: ${workspace.name} (${failedCount} of ${workspace.repositories.length} repositories failed to open)`,
+        'warning',
+      );
+    } else {
+      showToast(`Could not open workspace: ${workspace.name} — no repository could be opened`, 'error');
+    }
   }
 
   private handleManageWorkspaces(): void {

--- a/src/services/__tests__/embedding-index.service.test.ts
+++ b/src/services/__tests__/embedding-index.service.test.ts
@@ -119,6 +119,41 @@ describe('EmbeddingIndexService', () => {
     expect((cancelCall!.args as Record<string, unknown>).path).to.equal('/repo/a');
   });
 
+  it("a cancelled build's late completion must not clear a reopen build's marker", async () => {
+    // Regression: buildingRepos was a plain Set with no epoch, so a
+    // cancelled build's finally could delete the reopen build's in-flight
+    // marker, letting a third activation start a redundant concurrent build.
+    const path = '/repo/cancel-race';
+    let releaseFirst!: () => void;
+    pendingBuildGate = new Promise((resolve) => {
+      releaseFirst = resolve;
+    });
+    const build1 = embeddingIndexService.buildIndex(path); // in flight (epoch 0)
+    await embeddingIndexService.cancelBuild(path); // tab closed → epoch 1
+
+    // Reopen: a fresh build (epoch 1) starts and stays in flight
+    let releaseSecond!: () => void;
+    pendingBuildGate = new Promise((resolve) => {
+      releaseSecond = resolve;
+    });
+    const build2 = embeddingIndexService.buildIndex(path);
+
+    // The original cancelled build now finishes and runs its finally — it
+    // must NOT clear build2's (epoch-1) marker
+    releaseFirst();
+    await build1;
+
+    // A further activation must still be deduped against build2 — no third
+    // concurrent build
+    const build3 = embeddingIndexService.buildIndex(path);
+    const buildCalls = invokedCommands.filter((c) => c.command === 'build_embedding_index');
+    expect(buildCalls.length).to.equal(2);
+
+    // Cleanup: let build2 finish so no promise dangles into other tests
+    releaseSecond();
+    await Promise.all([build2, build3]);
+  });
+
   it('allows rebuilding a repo after its previous build finished', async () => {
     await embeddingIndexService.buildIndex('/repo/a');
     await embeddingIndexService.buildIndex('/repo/a');

--- a/src/services/__tests__/embedding-index.service.test.ts
+++ b/src/services/__tests__/embedding-index.service.test.ts
@@ -9,11 +9,16 @@ const invokedCommands: Array<{ command: string; args?: unknown }> = [];
 
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
 
+// When set, build_embedding_index waits on this before resolving — lets
+// tests overlap builds for different repos
+let pendingBuildGate: Promise<void> | null = null;
+
 const mockInvoke: MockInvoke = async (command: string, args?: unknown) => {
   invokedCommands.push({ command, args });
 
   switch (command) {
     case 'build_embedding_index':
+      if (pendingBuildGate) await pendingBuildGate;
       return 42;
     case 'refresh_embedding_index':
       return 5;
@@ -54,6 +59,50 @@ import { embeddingIndexService } from '../embedding-index.service.ts';
 describe('EmbeddingIndexService', () => {
   beforeEach(() => {
     invokedCommands.length = 0;
+    pendingBuildGate = null;
+  });
+
+  it('builds indexes for DIFFERENT repos concurrently without dropping any', async () => {
+    // Regression: a single global "building" flag silently skipped repo B's
+    // build while repo A's (slow ONNX) build was in flight, so activating a
+    // second tab never got a semantic index.
+    let releaseBuilds!: () => void;
+    pendingBuildGate = new Promise((resolve) => {
+      releaseBuilds = resolve;
+    });
+
+    const buildA = embeddingIndexService.buildIndex('/repo/a');
+    const buildB = embeddingIndexService.buildIndex('/repo/b');
+    releaseBuilds();
+    await Promise.all([buildA, buildB]);
+
+    const buildPaths = invokedCommands
+      .filter((c) => c.command === 'build_embedding_index')
+      .map((c) => (c.args as Record<string, unknown>).path);
+    expect(buildPaths).to.have.members(['/repo/a', '/repo/b']);
+  });
+
+  it('deduplicates concurrent builds for the SAME repo', async () => {
+    let releaseBuilds!: () => void;
+    pendingBuildGate = new Promise((resolve) => {
+      releaseBuilds = resolve;
+    });
+
+    const first = embeddingIndexService.buildIndex('/repo/a');
+    const second = embeddingIndexService.buildIndex('/repo/a');
+    releaseBuilds();
+    await Promise.all([first, second]);
+
+    const buildCalls = invokedCommands.filter((c) => c.command === 'build_embedding_index');
+    expect(buildCalls.length).to.equal(1);
+  });
+
+  it('allows rebuilding a repo after its previous build finished', async () => {
+    await embeddingIndexService.buildIndex('/repo/a');
+    await embeddingIndexService.buildIndex('/repo/a');
+
+    const buildCalls = invokedCommands.filter((c) => c.command === 'build_embedding_index');
+    expect(buildCalls.length).to.equal(2);
   });
 
   it('buildIndex invokes build_embedding_index command', async () => {

--- a/src/services/__tests__/embedding-index.service.test.ts
+++ b/src/services/__tests__/embedding-index.service.test.ts
@@ -97,6 +97,28 @@ describe('EmbeddingIndexService', () => {
     expect(buildCalls.length).to.equal(1);
   });
 
+  it('cancelBuild clears the in-flight marker so a reopened tab can rebuild immediately', async () => {
+    // Regression: close-tab cancels the build but the dedup marker stayed
+    // until the cancelled invoke unwound — a quick reopen was deduped
+    // against the cancelled build and never got an index.
+    let releaseOldBuild!: () => void;
+    pendingBuildGate = new Promise((resolve) => {
+      releaseOldBuild = resolve;
+    });
+    const cancelledBuild = embeddingIndexService.buildIndex('/repo/a');
+    await embeddingIndexService.cancelBuild('/repo/a'); // tab closed
+
+    pendingBuildGate = null;
+    const reopenBuild = embeddingIndexService.buildIndex('/repo/a'); // tab reopened
+    releaseOldBuild();
+    await Promise.all([cancelledBuild, reopenBuild]);
+
+    const buildCalls = invokedCommands.filter((c) => c.command === 'build_embedding_index');
+    expect(buildCalls.length).to.equal(2);
+    const cancelCall = invokedCommands.find((c) => c.command === 'cancel_embedding_build');
+    expect((cancelCall!.args as Record<string, unknown>).path).to.equal('/repo/a');
+  });
+
   it('allows rebuilding a repo after its previous build finished', async () => {
     await embeddingIndexService.buildIndex('/repo/a');
     await embeddingIndexService.buildIndex('/repo/a');

--- a/src/services/__tests__/search-index.service.test.ts
+++ b/src/services/__tests__/search-index.service.test.ts
@@ -196,7 +196,9 @@ describe('SearchIndexService', () => {
     it('a build finishing AFTER its repo was dropped must not resurrect readiness', async () => {
       // Regression: open repo -> slow build starts -> user closes the tab
       // (drop) -> build completes. Without an epoch guard the completed
-      // build re-marked the closed repo ready and leaked the backend index.
+      // build re-marked the closed repo ready. (The backend discards the
+      // stale build via its own generation guard, so the frontend no longer
+      // issues a compensating drop.)
       let releaseBuild!: () => void;
       pendingBuildGate = new Promise((resolve) => {
         releaseBuild = resolve;
@@ -210,10 +212,9 @@ describe('SearchIndexService', () => {
       await building;
 
       expect(searchIndexService.isReady('/repo/one')).to.be.false;
-      // The backend index inserted by the late build is freed again
-      const dropCall = invokeCallArgs.find((c) => c.command === 'drop_search_index');
-      expect(dropCall).to.not.be.undefined;
-      expect(dropCall!.args.path).to.equal('/repo/one');
+      // The backend generation guard owns cleanup — the frontend must NOT
+      // issue a redundant drop that could clobber a reopened tab's index
+      expect(invokeCallArgs.find((c) => c.command === 'drop_search_index')).to.be.undefined;
     });
 
     it('reopening a repo during an in-flight pre-drop build starts a fresh build', async () => {
@@ -279,10 +280,11 @@ describe('SearchIndexService', () => {
       expect(searchIndexService.isReady('/repo/one')).to.be.true;
     });
 
-    it('a refresh finishing AFTER its repo was dropped frees the resurrected backend index', async () => {
+    it('a refresh finishing AFTER its repo was dropped must not resurrect readiness', async () => {
       // Regression: handleRefresh fires refresh_search_index; if the tab is
-      // closed while it runs, the backend refresh re-inserts an index for a
-      // closed repo (or falls back to a full rebuild) — leaking it.
+      // closed while it runs, readiness must not come back. (The backend
+      // generation guard discards the stale reinsert, so the frontend no
+      // longer issues a compensating drop.)
       await searchIndexService.buildIndex('/repo/one');
       let releaseRefresh!: () => void;
       pendingRefreshGate = new Promise((resolve) => {
@@ -296,9 +298,7 @@ describe('SearchIndexService', () => {
       releaseRefresh();
       await refreshing;
 
-      const dropCall = invokeCallArgs.find((c) => c.command === 'drop_search_index');
-      expect(dropCall).to.not.be.undefined;
-      expect(dropCall!.args.path).to.equal('/repo/one');
+      expect(invokeCallArgs.find((c) => c.command === 'drop_search_index')).to.be.undefined;
       expect(searchIndexService.isReady('/repo/one')).to.be.false;
     });
 

--- a/src/services/__tests__/search-index.service.test.ts
+++ b/src/services/__tests__/search-index.service.test.ts
@@ -238,6 +238,47 @@ describe('SearchIndexService', () => {
       expect(searchIndexService.isReady('/repo/one')).to.be.true;
     });
 
+    it('a LATE pre-drop build must not delete the index a reopen build created', async () => {
+      // Regression: pre-drop build (epoch 0) resolves AFTER the reopen build
+      // (epoch 1) already inserted a fresh index — its compensating drop
+      // used to delete that fresh index while isReady stayed true.
+      let releaseOldBuild!: () => void;
+      pendingBuildGate = new Promise((resolve) => {
+        releaseOldBuild = resolve;
+      });
+      const oldBuild = searchIndexService.buildIndex('/repo/one'); // epoch 0, slow
+      await searchIndexService.drop('/repo/one'); // tab closed
+      pendingBuildGate = null;
+      await searchIndexService.buildIndex('/repo/one'); // reopen build, completes first
+      expect(searchIndexService.isReady('/repo/one')).to.be.true;
+      invokeCallArgs.length = 0;
+
+      releaseOldBuild();
+      await oldBuild;
+
+      expect(invokeCallArgs.find((c) => c.command === 'drop_search_index')).to.be.undefined;
+      expect(searchIndexService.isReady('/repo/one')).to.be.true;
+    });
+
+    it("a LATE pre-drop refresh must not delete the reopened repo's index", async () => {
+      await searchIndexService.buildIndex('/repo/one');
+      let releaseRefresh!: () => void;
+      pendingRefreshGate = new Promise((resolve) => {
+        releaseRefresh = resolve;
+      });
+      const staleRefresh = searchIndexService.refresh('/repo/one'); // slow
+      await searchIndexService.drop('/repo/one'); // tab closed
+      await searchIndexService.buildIndex('/repo/one'); // reopened + rebuilt
+      expect(searchIndexService.isReady('/repo/one')).to.be.true;
+      invokeCallArgs.length = 0;
+
+      releaseRefresh();
+      await staleRefresh;
+
+      expect(invokeCallArgs.find((c) => c.command === 'drop_search_index')).to.be.undefined;
+      expect(searchIndexService.isReady('/repo/one')).to.be.true;
+    });
+
     it('a refresh finishing AFTER its repo was dropped frees the resurrected backend index', async () => {
       // Regression: handleRefresh fires refresh_search_index; if the tab is
       // closed while it runs, the backend refresh re-inserts an index for a

--- a/src/services/__tests__/search-index.service.test.ts
+++ b/src/services/__tests__/search-index.service.test.ts
@@ -3,12 +3,17 @@ import { expect } from '@open-wc/testing';
 // Track mock calls
 const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
 
+// When set, build_search_index waits on this before resolving — lets tests
+// interleave a drop() with an in-flight build
+let pendingBuildGate: Promise<void> | null = null;
+
 // Mock Tauri API before importing any modules that use it
-const mockInvoke = (command: string, args?: Record<string, unknown>): Promise<unknown> => {
+const mockInvoke = async (command: string, args?: Record<string, unknown>): Promise<unknown> => {
   invokeCallArgs.push({ command, args: args || {} });
 
   switch (command) {
     case 'build_search_index':
+      if (pendingBuildGate) await pendingBuildGate;
       return Promise.resolve(500);
     case 'search_index':
       return Promise.resolve([
@@ -41,6 +46,7 @@ import { searchIndexService } from '../search-index.service.ts';
 describe('SearchIndexService', () => {
   beforeEach(() => {
     invokeCallArgs.length = 0;
+    pendingBuildGate = null;
     searchIndexService.invalidate();
   });
 
@@ -184,6 +190,29 @@ describe('SearchIndexService', () => {
   });
 
   describe('drop', () => {
+    it('a build finishing AFTER its repo was dropped must not resurrect readiness', async () => {
+      // Regression: open repo -> slow build starts -> user closes the tab
+      // (drop) -> build completes. Without an epoch guard the completed
+      // build re-marked the closed repo ready and leaked the backend index.
+      let releaseBuild!: () => void;
+      pendingBuildGate = new Promise((resolve) => {
+        releaseBuild = resolve;
+      });
+
+      const building = searchIndexService.buildIndex('/repo/one');
+      await searchIndexService.drop('/repo/one');
+      invokeCallArgs.length = 0;
+
+      releaseBuild();
+      await building;
+
+      expect(searchIndexService.isReady('/repo/one')).to.be.false;
+      // The backend index inserted by the late build is freed again
+      const dropCall = invokeCallArgs.find((c) => c.command === 'drop_search_index');
+      expect(dropCall).to.not.be.undefined;
+      expect(dropCall!.args.path).to.equal('/repo/one');
+    });
+
     it('should call drop_search_index and clear readiness for that repo only', async () => {
       await searchIndexService.buildIndex('/repo/one');
       await searchIndexService.buildIndex('/repo/two');

--- a/src/services/__tests__/search-index.service.test.ts
+++ b/src/services/__tests__/search-index.service.test.ts
@@ -162,6 +162,39 @@ describe('SearchIndexService', () => {
     });
   });
 
+  describe('refresh dedup', () => {
+    it('dedupes overlapping refreshes for the same repo (no redundant rebuild)', async () => {
+      // Regression: the backend refresh takes the index out first, so a
+      // second concurrent refresh would fall through to a full rebuild.
+      await searchIndexService.buildIndex('/repo/one');
+      invokeCallArgs.length = 0;
+
+      let releaseRefresh!: () => void;
+      pendingRefreshGate = new Promise((resolve) => {
+        releaseRefresh = resolve;
+      });
+
+      const first = searchIndexService.refresh('/repo/one');
+      const second = searchIndexService.refresh('/repo/one'); // overlaps — must no-op
+      releaseRefresh();
+      await Promise.all([first, second]);
+
+      const refreshCalls = invokeCallArgs.filter((c) => c.command === 'refresh_search_index');
+      expect(refreshCalls.length).to.equal(1);
+    });
+
+    it('allows a fresh refresh after the previous one settled', async () => {
+      await searchIndexService.buildIndex('/repo/one');
+      invokeCallArgs.length = 0;
+
+      await searchIndexService.refresh('/repo/one');
+      await searchIndexService.refresh('/repo/one');
+
+      const refreshCalls = invokeCallArgs.filter((c) => c.command === 'refresh_search_index');
+      expect(refreshCalls.length).to.equal(2);
+    });
+  });
+
   describe('refresh failure', () => {
     it('clears readiness on a genuine refresh failure so the next activation rebuilds', async () => {
       // Regression: the backend takes the index out before the incremental

--- a/src/services/__tests__/search-index.service.test.ts
+++ b/src/services/__tests__/search-index.service.test.ts
@@ -6,6 +6,7 @@ const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> 
 // When set, build_search_index waits on this before resolving — lets tests
 // interleave a drop() with an in-flight build
 let pendingBuildGate: Promise<void> | null = null;
+let pendingRefreshGate: Promise<void> | null = null;
 
 // Mock Tauri API before importing any modules that use it
 const mockInvoke = async (command: string, args?: Record<string, unknown>): Promise<unknown> => {
@@ -15,6 +16,9 @@ const mockInvoke = async (command: string, args?: Record<string, unknown>): Prom
     case 'build_search_index':
       if (pendingBuildGate) await pendingBuildGate;
       return Promise.resolve(500);
+    case 'refresh_search_index':
+      if (pendingRefreshGate) await pendingRefreshGate;
+      return Promise.resolve(502);
     case 'search_index':
       return Promise.resolve([
         {
@@ -28,8 +32,6 @@ const mockInvoke = async (command: string, args?: Record<string, unknown>): Prom
           parentCount: 1,
         },
       ]);
-    case 'refresh_search_index':
-      return Promise.resolve(502);
     default:
       return Promise.resolve(null);
   }
@@ -47,6 +49,7 @@ describe('SearchIndexService', () => {
   beforeEach(() => {
     invokeCallArgs.length = 0;
     pendingBuildGate = null;
+    pendingRefreshGate = null;
     searchIndexService.invalidate();
   });
 
@@ -211,6 +214,29 @@ describe('SearchIndexService', () => {
       const dropCall = invokeCallArgs.find((c) => c.command === 'drop_search_index');
       expect(dropCall).to.not.be.undefined;
       expect(dropCall!.args.path).to.equal('/repo/one');
+    });
+
+    it('a refresh finishing AFTER its repo was dropped frees the resurrected backend index', async () => {
+      // Regression: handleRefresh fires refresh_search_index; if the tab is
+      // closed while it runs, the backend refresh re-inserts an index for a
+      // closed repo (or falls back to a full rebuild) — leaking it.
+      await searchIndexService.buildIndex('/repo/one');
+      let releaseRefresh!: () => void;
+      pendingRefreshGate = new Promise((resolve) => {
+        releaseRefresh = resolve;
+      });
+
+      const refreshing = searchIndexService.refresh('/repo/one');
+      await searchIndexService.drop('/repo/one');
+      invokeCallArgs.length = 0;
+
+      releaseRefresh();
+      await refreshing;
+
+      const dropCall = invokeCallArgs.find((c) => c.command === 'drop_search_index');
+      expect(dropCall).to.not.be.undefined;
+      expect(dropCall!.args.path).to.equal('/repo/one');
+      expect(searchIndexService.isReady('/repo/one')).to.be.false;
     });
 
     it('should call drop_search_index and clear readiness for that repo only', async () => {

--- a/src/services/__tests__/search-index.service.test.ts
+++ b/src/services/__tests__/search-index.service.test.ts
@@ -216,6 +216,28 @@ describe('SearchIndexService', () => {
       expect(dropCall!.args.path).to.equal('/repo/one');
     });
 
+    it('reopening a repo during an in-flight pre-drop build starts a fresh build', async () => {
+      // Regression: buildIndex deduped purely on "a build is in flight", so
+      // close-then-reopen during a slow build left the reopened tab with no
+      // index at all (the old build self-dropped, nothing rebuilt).
+      let releaseBuilds!: () => void;
+      pendingBuildGate = new Promise((resolve) => {
+        releaseBuilds = resolve;
+      });
+
+      const preDropBuild = searchIndexService.buildIndex('/repo/one');
+      await searchIndexService.drop('/repo/one'); // tab closed mid-build
+      const reopenBuild = searchIndexService.buildIndex('/repo/one'); // tab reopened
+
+      releaseBuilds();
+      await Promise.all([preDropBuild, reopenBuild]);
+
+      const buildCalls = invokeCallArgs.filter((c) => c.command === 'build_search_index');
+      expect(buildCalls.length).to.equal(2);
+      // The reopened tab ends up READY (the post-drop build won)
+      expect(searchIndexService.isReady('/repo/one')).to.be.true;
+    });
+
     it('a refresh finishing AFTER its repo was dropped frees the resurrected backend index', async () => {
       // Regression: handleRefresh fires refresh_search_index; if the tab is
       // closed while it runs, the backend refresh re-inserts an index for a

--- a/src/services/__tests__/search-index.service.test.ts
+++ b/src/services/__tests__/search-index.service.test.ts
@@ -7,6 +7,9 @@ const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> 
 // interleave a drop() with an in-flight build
 let pendingBuildGate: Promise<void> | null = null;
 let pendingRefreshGate: Promise<void> | null = null;
+// When true, refresh_search_index rejects (simulating a genuine backend
+// failure — corrupt/locked repo mid-session)
+let refreshShouldFail = false;
 
 // Mock Tauri API before importing any modules that use it
 const mockInvoke = async (command: string, args?: Record<string, unknown>): Promise<unknown> => {
@@ -18,6 +21,7 @@ const mockInvoke = async (command: string, args?: Record<string, unknown>): Prom
       return Promise.resolve(500);
     case 'refresh_search_index':
       if (pendingRefreshGate) await pendingRefreshGate;
+      if (refreshShouldFail) return Promise.reject(new Error('corrupt repo'));
       return Promise.resolve(502);
     case 'search_index':
       return Promise.resolve([
@@ -50,6 +54,7 @@ describe('SearchIndexService', () => {
     invokeCallArgs.length = 0;
     pendingBuildGate = null;
     pendingRefreshGate = null;
+    refreshShouldFail = false;
     searchIndexService.invalidate();
   });
 
@@ -154,6 +159,21 @@ describe('SearchIndexService', () => {
       await searchIndexService.search('/path/to/repo', { query: 'test' });
       const secondCallCount = invokeCallArgs.filter((c) => c.command === 'search_index').length;
       expect(secondCallCount).to.equal(1); // Should not increase
+    });
+  });
+
+  describe('refresh failure', () => {
+    it('clears readiness on a genuine refresh failure so the next activation rebuilds', async () => {
+      // Regression: the backend takes the index out before the incremental
+      // walk; a genuine failure leaves no index, but readiness stayed true —
+      // the repo was stuck searchable-but-empty for the session.
+      await searchIndexService.buildIndex('/repo/one');
+      expect(searchIndexService.isReady('/repo/one')).to.be.true;
+
+      refreshShouldFail = true;
+      await searchIndexService.refresh('/repo/one');
+
+      expect(searchIndexService.isReady('/repo/one')).to.be.false;
     });
   });
 

--- a/src/services/__tests__/search-index.service.test.ts
+++ b/src/services/__tests__/search-index.service.test.ts
@@ -53,6 +53,34 @@ describe('SearchIndexService', () => {
       expect(buildCall!.args.path).to.equal('/path/to/repo');
     });
 
+    it('should build indexes for multiple repos concurrently without dropping any', async () => {
+      // Regression: a global "building" flag used to silently skip every
+      // build after the first when several repos were restored at startup.
+      await Promise.all([
+        searchIndexService.buildIndex('/repo/one'),
+        searchIndexService.buildIndex('/repo/two'),
+        searchIndexService.buildIndex('/repo/three'),
+      ]);
+
+      const buildPaths = invokeCallArgs
+        .filter((c) => c.command === 'build_search_index')
+        .map((c) => c.args.path);
+      expect(buildPaths).to.have.members(['/repo/one', '/repo/two', '/repo/three']);
+      expect(searchIndexService.isReady('/repo/one')).to.be.true;
+      expect(searchIndexService.isReady('/repo/two')).to.be.true;
+      expect(searchIndexService.isReady('/repo/three')).to.be.true;
+    });
+
+    it('should deduplicate concurrent builds for the SAME repo', async () => {
+      await Promise.all([
+        searchIndexService.buildIndex('/repo/one'),
+        searchIndexService.buildIndex('/repo/one'),
+      ]);
+
+      const buildCalls = invokeCallArgs.filter((c) => c.command === 'build_search_index');
+      expect(buildCalls.length).to.equal(1);
+    });
+
     it('should set index as ready after building', async () => {
       expect(searchIndexService.isReady()).to.be.false;
       await searchIndexService.buildIndex('/path/to/repo');
@@ -83,6 +111,25 @@ describe('SearchIndexService', () => {
 
       const searchCall = invokeCallArgs.find((c) => c.command === 'search_index');
       expect(searchCall).to.not.be.undefined;
+    });
+
+    it('should pass the repo path to the backend so results come from the right repo', async () => {
+      await searchIndexService.buildIndex('/path/to/repo');
+      invokeCallArgs.length = 0;
+
+      await searchIndexService.search('/path/to/repo', { query: 'test' });
+
+      const searchCall = invokeCallArgs.find((c) => c.command === 'search_index');
+      expect(searchCall!.args.path).to.equal('/path/to/repo');
+    });
+
+    it('should return null for a repo whose index is not built, even when another repo is ready', async () => {
+      // Regression: with a single global index, searching repo B used to
+      // return repo A's commits.
+      await searchIndexService.buildIndex('/repo/one');
+
+      const result = await searchIndexService.search('/repo/two', { query: 'test' });
+      expect(result).to.be.null;
     });
 
     it('should cache search results', async () => {
@@ -121,6 +168,34 @@ describe('SearchIndexService', () => {
       // After invalidate, search should return null (not from cache)
       const result = await searchIndexService.search('/path/to/repo', { query: 'test' });
       expect(result).to.be.null;
+    });
+  });
+
+  describe('invalidate with a path', () => {
+    it('should only invalidate the given repo', async () => {
+      await searchIndexService.buildIndex('/repo/one');
+      await searchIndexService.buildIndex('/repo/two');
+
+      searchIndexService.invalidate('/repo/one');
+
+      expect(searchIndexService.isReady('/repo/one')).to.be.false;
+      expect(searchIndexService.isReady('/repo/two')).to.be.true;
+    });
+  });
+
+  describe('drop', () => {
+    it('should call drop_search_index and clear readiness for that repo only', async () => {
+      await searchIndexService.buildIndex('/repo/one');
+      await searchIndexService.buildIndex('/repo/two');
+      invokeCallArgs.length = 0;
+
+      await searchIndexService.drop('/repo/one');
+
+      const dropCall = invokeCallArgs.find((c) => c.command === 'drop_search_index');
+      expect(dropCall).to.not.be.undefined;
+      expect(dropCall!.args.path).to.equal('/repo/one');
+      expect(searchIndexService.isReady('/repo/one')).to.be.false;
+      expect(searchIndexService.isReady('/repo/two')).to.be.true;
     });
   });
 

--- a/src/services/__tests__/watcher.service.test.ts
+++ b/src/services/__tests__/watcher.service.test.ts
@@ -49,6 +49,41 @@ describe('watcher.service', () => {
     // Don't clean up here to avoid double-invoke issues in tests
   });
 
+  // NOTE: this block must run FIRST — the module registers its (single)
+  // Tauri listener on the first successful startWatching, so listener-count
+  // assertions are only meaningful before other tests trigger it.
+  describe('shared listener registration', () => {
+    function listenRegistrations(): number {
+      return invokeCallArgs.filter(
+        (c) => c.command === 'plugin:event|listen' && c.args.event === 'file-change'
+      ).length;
+    }
+
+    it('registers exactly ONE file-change listener across concurrent startWatching calls', async () => {
+      // Regression: startup restore watches N repos back-to-back; a
+      // non-atomic `if (!unlisten)` check let every call register its own
+      // listener, leaking N-1 of them and dispatching every event N times.
+      await Promise.all([
+        startWatching('/repo/one'),
+        startWatching('/repo/two'),
+        startWatching('/repo/three'),
+      ]);
+
+      expect(listenRegistrations()).to.equal(1);
+
+      // Each repo still gets its own backend watcher
+      const watched = invokeCallArgs
+        .filter((c) => c.command === 'start_watching')
+        .map((c) => c.args.path);
+      expect(watched).to.have.members(['/repo/one', '/repo/two', '/repo/three']);
+    });
+
+    it('does not register another listener on later startWatching calls', async () => {
+      await startWatching('/repo/four');
+      expect(listenRegistrations()).to.equal(0); // registered in the previous test
+    });
+  });
+
   describe('startWatching', () => {
     it('should invoke start_watching with the path', async () => {
       await startWatching('/path/to/repo');
@@ -77,6 +112,20 @@ describe('watcher.service', () => {
 
       const call = invokeCallArgs.find((c) => c.command === 'stop_watching');
       expect(call).to.not.be.undefined;
+    });
+
+    it('should pass the specific path when given one', async () => {
+      await stopWatching('/repo/one');
+
+      const call = invokeCallArgs.find((c) => c.command === 'stop_watching');
+      expect(call!.args.path).to.equal('/repo/one');
+    });
+
+    it('should pass null (stop all) when called without a path', async () => {
+      await stopWatching();
+
+      const call = invokeCallArgs.find((c) => c.command === 'stop_watching');
+      expect(call!.args.path).to.equal(null);
     });
 
     it('should throw on backend error', async () => {

--- a/src/services/embedding-index.service.ts
+++ b/src/services/embedding-index.service.ts
@@ -29,19 +29,27 @@ export interface EmbeddingIndexProgress {
 }
 
 class EmbeddingIndexService {
-  // Builds are tracked per repo: concurrent builds for DIFFERENT repos must
-  // both run (a global flag silently dropped every build after the first
-  // when several tabs were opened), only a build for the same repo is
-  // deduplicated.
-  private buildingRepos = new Set<string>();
+  // Builds are tracked per repo, keyed by the cancel epoch they started
+  // under. Concurrent builds for DIFFERENT repos must both run (a global
+  // flag silently dropped every build after the first). Dedup is
+  // epoch-aware (mirroring searchIndexService): after a cancel (tab close)
+  // bumps the epoch, a reopen's build is a new epoch, and the cancelled
+  // build's late completion must not clear the reopen build's marker.
+  private buildingRepos = new Map<string, number>();
+  // Bumped by cancelBuild() so a build cancelled mid-flight doesn't dedupe
+  // away or clobber a subsequent reopen build.
+  private cancelEpochs = new Map<string, number>();
 
   /**
    * Build the embedding index for a repository.
    * Non-blocking - meant to be called fire-and-forget.
    */
   async buildIndex(repoPath: string): Promise<void> {
-    if (this.buildingRepos.has(repoPath)) return;
-    this.buildingRepos.add(repoPath);
+    const epoch = this.cancelEpochs.get(repoPath) ?? 0;
+    // Dedupe only builds from the SAME epoch: a cancelled pre-close build
+    // still unwinding must not block the rebuild for a reopened tab.
+    if (this.buildingRepos.get(repoPath) === epoch) return;
+    this.buildingRepos.set(repoPath, epoch);
 
     try {
       const count = await invoke<number>('build_embedding_index', { path: repoPath });
@@ -49,7 +57,11 @@ class EmbeddingIndexService {
     } catch (err) {
       console.warn('[EmbeddingIndex] Failed to build index:', err);
     } finally {
-      this.buildingRepos.delete(repoPath);
+      // Only clear the marker if it still belongs to THIS build — a newer
+      // (post-cancel) build may have replaced it
+      if (this.buildingRepos.get(repoPath) === epoch) {
+        this.buildingRepos.delete(repoPath);
+      }
     }
   }
 
@@ -91,10 +103,12 @@ class EmbeddingIndexService {
 
   /**
    * Cancel an in-progress embedding build (e.g. the tab was closed).
-   * Clears the in-flight marker immediately so a reopened tab can start a
-   * fresh build instead of being deduped against the cancelled one.
+   * Bumps the epoch and clears the in-flight marker so a reopened tab can
+   * start a fresh build, and the cancelled build's late completion can't
+   * clear the reopen build's marker.
    */
   async cancelBuild(repoPath: string): Promise<void> {
+    this.cancelEpochs.set(repoPath, (this.cancelEpochs.get(repoPath) ?? 0) + 1);
     this.buildingRepos.delete(repoPath);
     await invoke<void>('cancel_embedding_build', { path: repoPath });
   }

--- a/src/services/embedding-index.service.ts
+++ b/src/services/embedding-index.service.ts
@@ -90,9 +90,12 @@ class EmbeddingIndexService {
   }
 
   /**
-   * Cancel an in-progress embedding build
+   * Cancel an in-progress embedding build (e.g. the tab was closed).
+   * Clears the in-flight marker immediately so a reopened tab can start a
+   * fresh build instead of being deduped against the cancelled one.
    */
   async cancelBuild(repoPath: string): Promise<void> {
+    this.buildingRepos.delete(repoPath);
     await invoke<void>('cancel_embedding_build', { path: repoPath });
   }
 

--- a/src/services/embedding-index.service.ts
+++ b/src/services/embedding-index.service.ts
@@ -29,25 +29,27 @@ export interface EmbeddingIndexProgress {
 }
 
 class EmbeddingIndexService {
-  private building = false;
-  private currentRepoPath: string | null = null;
+  // Builds are tracked per repo: concurrent builds for DIFFERENT repos must
+  // both run (a global flag silently dropped every build after the first
+  // when several tabs were opened), only a build for the same repo is
+  // deduplicated.
+  private buildingRepos = new Set<string>();
 
   /**
    * Build the embedding index for a repository.
    * Non-blocking - meant to be called fire-and-forget.
    */
   async buildIndex(repoPath: string): Promise<void> {
-    if (this.building) return;
-    this.building = true;
+    if (this.buildingRepos.has(repoPath)) return;
+    this.buildingRepos.add(repoPath);
 
     try {
       const count = await invoke<number>('build_embedding_index', { path: repoPath });
-      this.currentRepoPath = repoPath;
-      console.log(`[EmbeddingIndex] Built index with ${count} commits`);
+      console.log(`[EmbeddingIndex] Built index for ${repoPath} with ${count} commits`);
     } catch (err) {
       console.warn('[EmbeddingIndex] Failed to build index:', err);
     } finally {
-      this.building = false;
+      this.buildingRepos.delete(repoPath);
     }
   }
 
@@ -119,12 +121,6 @@ class EmbeddingIndexService {
     });
   }
 
-  /**
-   * Invalidate the index (e.g., when switching repos)
-   */
-  invalidate(): void {
-    this.currentRepoPath = null;
-  }
 }
 
 export const embeddingIndexService = new EmbeddingIndexService();

--- a/src/services/keyboard.service.ts
+++ b/src/services/keyboard.service.ts
@@ -648,6 +648,9 @@ export function registerDefaultShortcuts(actions: {
   createBranch?: () => void;
   createStash?: () => void;
   closeDiff?: () => void;
+  nextTab?: () => void;
+  previousTab?: () => void;
+  selectTab?: (index: number) => void;
 }): void {
   // Set vim actions
   keyboardService.setVimActions({
@@ -860,5 +863,40 @@ export function registerDefaultShortcuts(actions: {
       description: 'Close diff/panel',
       category: 'View',
     });
+  }
+
+  // Repository tabs
+  if (actions.nextTab) {
+    keyboardService.register('next-tab', {
+      key: 'Tab',
+      ctrl: true,
+      action: actions.nextTab,
+      description: 'Next repository tab',
+      category: 'View',
+    });
+  }
+
+  if (actions.previousTab) {
+    keyboardService.register('previous-tab', {
+      key: 'Tab',
+      ctrl: true,
+      shift: true,
+      action: actions.previousTab,
+      description: 'Previous repository tab',
+      category: 'View',
+    });
+  }
+
+  if (actions.selectTab) {
+    const selectTab = actions.selectTab;
+    for (let n = 1; n <= 9; n++) {
+      keyboardService.register(`select-tab-${n}`, {
+        key: String(n),
+        ctrl: true,
+        action: () => selectTab(n - 1),
+        description: `Go to repository tab ${n}`,
+        category: 'View',
+      });
+    }
   }
 }

--- a/src/services/search-index.service.ts
+++ b/src/services/search-index.service.ts
@@ -1,6 +1,8 @@
 /**
  * Search Index Service
- * Provides fast commit searching via a Rust-side background index
+ * Provides fast commit searching via a Rust-side background index.
+ * Indexes are per-repository: every open repo can have its own index at the
+ * same time, and searching one repo never returns another repo's commits.
  */
 
 import { invokeCommand } from './tauri-api.ts';
@@ -26,32 +28,35 @@ export interface SearchOptions {
 }
 
 class SearchIndexService {
-  private indexReady = false;
-  private building = false;
-  private currentRepoPath: string | null = null;
+  private readyRepos = new Set<string>();
+  private buildingRepos = new Set<string>();
 
   /**
    * Build the search index for a repository.
    * Non-blocking - meant to be called fire-and-forget.
+   * Builds for different repositories can run concurrently; only a build for
+   * the SAME repository is deduplicated.
    */
   async buildIndex(repoPath: string): Promise<void> {
-    if (this.building) return;
-    this.building = true;
+    if (this.buildingRepos.has(repoPath)) return;
+    this.buildingRepos.add(repoPath);
 
-    const result = await invokeCommand<number>('build_search_index', { path: repoPath });
-    if (result.success) {
-      this.indexReady = true;
-      this.currentRepoPath = repoPath;
-      console.log(`[SearchIndex] Built index with ${result.data} commits`);
-    } else {
-      console.warn('[SearchIndex] Failed to build index:', result.error?.message);
-      this.indexReady = false;
+    try {
+      const result = await invokeCommand<number>('build_search_index', { path: repoPath });
+      if (result.success) {
+        this.readyRepos.add(repoPath);
+        console.log(`[SearchIndex] Built index for ${repoPath} with ${result.data} commits`);
+      } else {
+        this.readyRepos.delete(repoPath);
+        console.warn('[SearchIndex] Failed to build index:', result.error?.message);
+      }
+    } finally {
+      this.buildingRepos.delete(repoPath);
     }
-    this.building = false;
   }
 
   /**
-   * Search commits using the index if available, otherwise return null
+   * Search commits using the repo's index if available, otherwise return null
    * to signal the caller should use the fallback.
    */
   async search(repoPath: string, options: SearchOptions): Promise<IndexedCommit[] | null> {
@@ -60,9 +65,10 @@ class SearchIndexService {
     const cached = searchResultCache.get(cacheKey) as IndexedCommit[] | undefined;
     if (cached) return cached;
 
-    if (!this.indexReady) return null;
+    if (!this.readyRepos.has(repoPath)) return null;
 
     const result = await invokeCommand<IndexedCommit[]>('search_index', {
+      path: repoPath,
       query: options.query || null,
       author: options.author || null,
       dateFrom: options.dateFrom || null,
@@ -78,10 +84,10 @@ class SearchIndexService {
   }
 
   /**
-   * Refresh the index incrementally after repo-mutating operations
+   * Refresh a repo's index incrementally after repo-mutating operations
    */
   async refresh(repoPath: string): Promise<void> {
-    if (!this.indexReady) return;
+    if (!this.readyRepos.has(repoPath)) return;
 
     const result = await invokeCommand<number>('refresh_search_index', { path: repoPath });
     if (result.success) {
@@ -93,21 +99,39 @@ class SearchIndexService {
   }
 
   /**
-   * Invalidate the index (e.g., when switching repos)
+   * Drop a repo's index entirely (e.g., when its tab is closed) so the
+   * backend releases the memory.
    */
-  invalidate(): void {
-    this.indexReady = false;
-    this.currentRepoPath = null;
+  async drop(repoPath: string): Promise<void> {
+    this.readyRepos.delete(repoPath);
+    searchResultCache.clear();
+    const result = await invokeCommand<void>('drop_search_index', { path: repoPath });
+    if (!result.success) {
+      console.warn('[SearchIndex] Failed to drop index:', result.error?.message);
+    }
+  }
+
+  /**
+   * Invalidate readiness state — for one repo if a path is given, for all
+   * repos otherwise. The backend index is kept; a later search simply won't
+   * use it until buildIndex marks it ready again.
+   */
+  invalidate(repoPath?: string): void {
+    if (repoPath) {
+      this.readyRepos.delete(repoPath);
+    } else {
+      this.readyRepos.clear();
+    }
     searchResultCache.clear();
   }
 
   /**
-   * Check if the index is ready for the given repo
+   * Check if the index is ready — for a specific repo if a path is given,
+   * for any repo otherwise.
    */
   isReady(repoPath?: string): boolean {
-    if (!this.indexReady) return false;
-    if (repoPath && this.currentRepoPath !== repoPath) return false;
-    return true;
+    if (repoPath) return this.readyRepos.has(repoPath);
+    return this.readyRepos.size > 0;
   }
 }
 

--- a/src/services/search-index.service.ts
+++ b/src/services/search-index.service.ts
@@ -55,15 +55,10 @@ class SearchIndexService {
     try {
       const result = await invokeCommand<number>('build_search_index', { path: repoPath });
       if ((this.dropEpochs.get(repoPath) ?? 0) !== epoch) {
-        // The repo was closed while this build ran. Free the index the
-        // backend just (re)inserted — UNLESS the repo was reopened and a
-        // newer build owns the path now (dropping would delete the index
-        // that newer build created while the frontend still reports ready).
-        const newerBuild =
-          this.buildingRepos.has(repoPath) && this.buildingRepos.get(repoPath) !== epoch;
-        if (!newerBuild && !this.readyRepos.has(repoPath)) {
-          invokeCommand<void>('drop_search_index', { path: repoPath });
-        }
+        // The repo was closed while this build ran. The BACKEND guards its
+        // own insert by generation, so it already discarded this stale
+        // build (and a reopen build's fresh index is untouched) — nothing to
+        // clean up here; just don't mark this closed epoch as ready.
         return;
       }
       if (result.success) {
@@ -119,13 +114,9 @@ class SearchIndexService {
 
     const result = await invokeCommand<number>('refresh_search_index', { path: repoPath });
     if ((this.dropEpochs.get(repoPath) ?? 0) !== epoch) {
-      // The repo was closed while the refresh ran — the backend refresh
-      // (or its build-from-scratch fallback) just re-inserted an index for
-      // a closed tab; free it again. Skip when the repo was reopened and is
-      // ready (or rebuilding) — the index belongs to the reopened tab then.
-      if (!this.readyRepos.has(repoPath) && !this.buildingRepos.has(repoPath)) {
-        invokeCommand<void>('drop_search_index', { path: repoPath });
-      }
+      // The repo was closed while the refresh ran. The backend guards its
+      // reinsert by generation (and discards the stale result), so there is
+      // nothing to clean up here.
       return;
     }
     if (result.success) {

--- a/src/services/search-index.service.ts
+++ b/src/services/search-index.service.ts
@@ -123,6 +123,11 @@ class SearchIndexService {
       // Invalidate search cache since results may have changed
       searchResultCache.clear();
     } else {
+      // A genuine refresh failure (e.g. corrupt/locked repo) means the
+      // backend took the index out and never reinserted it — the path is no
+      // longer searchable. Clear readiness so the next activation rebuilds
+      // from scratch instead of leaving the repo "ready" with no index.
+      this.readyRepos.delete(repoPath);
       console.warn('[SearchIndex] Failed to refresh index:', result.error?.message);
     }
   }

--- a/src/services/search-index.service.ts
+++ b/src/services/search-index.service.ts
@@ -37,6 +37,10 @@ class SearchIndexService {
   // dropped must not resurrect readiness (or leak the backend index) for a
   // closed tab
   private dropEpochs = new Map<string, number>();
+  // Paths with an in-flight refresh, to dedupe overlapping refreshes (the
+  // backend takes the index out first, so a concurrent refresh would trigger
+  // a redundant full rebuild)
+  private refreshingRepos = new Set<string>();
 
   /**
    * Build the search index for a repository.
@@ -110,25 +114,35 @@ class SearchIndexService {
    */
   async refresh(repoPath: string): Promise<void> {
     if (!this.readyRepos.has(repoPath)) return;
+    // Dedupe overlapping refreshes for the same repo: the backend's refresh
+    // takes the index out before its incremental walk, so a second
+    // concurrent refresh would find nothing and fall through to a full
+    // (up to 100k-commit) rebuild running alongside the first.
+    if (this.refreshingRepos.has(repoPath)) return;
+    this.refreshingRepos.add(repoPath);
     const epoch = this.dropEpochs.get(repoPath) ?? 0;
 
-    const result = await invokeCommand<number>('refresh_search_index', { path: repoPath });
-    if ((this.dropEpochs.get(repoPath) ?? 0) !== epoch) {
-      // The repo was closed while the refresh ran. The backend guards its
-      // reinsert by generation (and discards the stale result), so there is
-      // nothing to clean up here.
-      return;
-    }
-    if (result.success) {
-      // Invalidate search cache since results may have changed
-      searchResultCache.clear();
-    } else {
-      // A genuine refresh failure (e.g. corrupt/locked repo) means the
-      // backend took the index out and never reinserted it — the path is no
-      // longer searchable. Clear readiness so the next activation rebuilds
-      // from scratch instead of leaving the repo "ready" with no index.
-      this.readyRepos.delete(repoPath);
-      console.warn('[SearchIndex] Failed to refresh index:', result.error?.message);
+    try {
+      const result = await invokeCommand<number>('refresh_search_index', { path: repoPath });
+      if ((this.dropEpochs.get(repoPath) ?? 0) !== epoch) {
+        // The repo was closed while the refresh ran. The backend guards its
+        // reinsert by generation (and discards the stale result), so there is
+        // nothing to clean up here.
+        return;
+      }
+      if (result.success) {
+        // Invalidate search cache since results may have changed
+        searchResultCache.clear();
+      } else {
+        // A genuine refresh failure (e.g. corrupt/locked repo) means the
+        // backend took the index out and never reinserted it — the path is no
+        // longer searchable. Clear readiness so the next activation rebuilds
+        // from scratch instead of leaving the repo "ready" with no index.
+        this.readyRepos.delete(repoPath);
+        console.warn('[SearchIndex] Failed to refresh index:', result.error?.message);
+      }
+    } finally {
+      this.refreshingRepos.delete(repoPath);
     }
   }
 

--- a/src/services/search-index.service.ts
+++ b/src/services/search-index.service.ts
@@ -55,9 +55,15 @@ class SearchIndexService {
     try {
       const result = await invokeCommand<number>('build_search_index', { path: repoPath });
       if ((this.dropEpochs.get(repoPath) ?? 0) !== epoch) {
-        // The repo was closed while this build ran — the backend just
-        // (re)inserted an index for a closed tab; free it and stay not-ready
-        invokeCommand<void>('drop_search_index', { path: repoPath });
+        // The repo was closed while this build ran. Free the index the
+        // backend just (re)inserted — UNLESS the repo was reopened and a
+        // newer build owns the path now (dropping would delete the index
+        // that newer build created while the frontend still reports ready).
+        const newerBuild =
+          this.buildingRepos.has(repoPath) && this.buildingRepos.get(repoPath) !== epoch;
+        if (!newerBuild && !this.readyRepos.has(repoPath)) {
+          invokeCommand<void>('drop_search_index', { path: repoPath });
+        }
         return;
       }
       if (result.success) {
@@ -115,8 +121,11 @@ class SearchIndexService {
     if ((this.dropEpochs.get(repoPath) ?? 0) !== epoch) {
       // The repo was closed while the refresh ran — the backend refresh
       // (or its build-from-scratch fallback) just re-inserted an index for
-      // a closed tab; free it again
-      invokeCommand<void>('drop_search_index', { path: repoPath });
+      // a closed tab; free it again. Skip when the repo was reopened and is
+      // ready (or rebuilding) — the index belongs to the reopened tab then.
+      if (!this.readyRepos.has(repoPath) && !this.buildingRepos.has(repoPath)) {
+        invokeCommand<void>('drop_search_index', { path: repoPath });
+      }
       return;
     }
     if (result.success) {

--- a/src/services/search-index.service.ts
+++ b/src/services/search-index.service.ts
@@ -29,9 +29,13 @@ export interface SearchOptions {
 
 class SearchIndexService {
   private readyRepos = new Set<string>();
-  private buildingRepos = new Set<string>();
-  // Bumped by drop(); a build that finishes after its repo was dropped must
-  // not resurrect readiness (or leak the backend index) for a closed tab
+  // In-flight builds, keyed by path, storing the drop epoch each build
+  // started under. Deduplication is epoch-aware: a build started BEFORE the
+  // repo was dropped must not block a rebuild after the repo is reopened.
+  private buildingRepos = new Map<string, number>();
+  // Bumped by drop(); a build/refresh that finishes after its repo was
+  // dropped must not resurrect readiness (or leak the backend index) for a
+  // closed tab
   private dropEpochs = new Map<string, number>();
 
   /**
@@ -41,9 +45,12 @@ class SearchIndexService {
    * the SAME repository is deduplicated.
    */
   async buildIndex(repoPath: string): Promise<void> {
-    if (this.buildingRepos.has(repoPath)) return;
-    this.buildingRepos.add(repoPath);
     const epoch = this.dropEpochs.get(repoPath) ?? 0;
+    // Dedupe only builds from the SAME epoch: a pre-drop build still in
+    // flight must not block the rebuild for a reopened tab (it will discard
+    // itself on completion via the epoch check below).
+    if (this.buildingRepos.get(repoPath) === epoch) return;
+    this.buildingRepos.set(repoPath, epoch);
 
     try {
       const result = await invokeCommand<number>('build_search_index', { path: repoPath });
@@ -61,7 +68,11 @@ class SearchIndexService {
         console.warn('[SearchIndex] Failed to build index:', result.error?.message);
       }
     } finally {
-      this.buildingRepos.delete(repoPath);
+      // Only remove the marker if it still belongs to THIS build — a newer
+      // (post-drop) build may have replaced it
+      if (this.buildingRepos.get(repoPath) === epoch) {
+        this.buildingRepos.delete(repoPath);
+      }
     }
   }
 

--- a/src/services/search-index.service.ts
+++ b/src/services/search-index.service.ts
@@ -30,6 +30,9 @@ export interface SearchOptions {
 class SearchIndexService {
   private readyRepos = new Set<string>();
   private buildingRepos = new Set<string>();
+  // Bumped by drop(); a build that finishes after its repo was dropped must
+  // not resurrect readiness (or leak the backend index) for a closed tab
+  private dropEpochs = new Map<string, number>();
 
   /**
    * Build the search index for a repository.
@@ -40,9 +43,16 @@ class SearchIndexService {
   async buildIndex(repoPath: string): Promise<void> {
     if (this.buildingRepos.has(repoPath)) return;
     this.buildingRepos.add(repoPath);
+    const epoch = this.dropEpochs.get(repoPath) ?? 0;
 
     try {
       const result = await invokeCommand<number>('build_search_index', { path: repoPath });
+      if ((this.dropEpochs.get(repoPath) ?? 0) !== epoch) {
+        // The repo was closed while this build ran — the backend just
+        // (re)inserted an index for a closed tab; free it and stay not-ready
+        invokeCommand<void>('drop_search_index', { path: repoPath });
+        return;
+      }
       if (result.success) {
         this.readyRepos.add(repoPath);
         console.log(`[SearchIndex] Built index for ${repoPath} with ${result.data} commits`);
@@ -103,6 +113,7 @@ class SearchIndexService {
    * backend releases the memory.
    */
   async drop(repoPath: string): Promise<void> {
+    this.dropEpochs.set(repoPath, (this.dropEpochs.get(repoPath) ?? 0) + 1);
     this.readyRepos.delete(repoPath);
     searchResultCache.clear();
     const result = await invokeCommand<void>('drop_search_index', { path: repoPath });

--- a/src/services/search-index.service.ts
+++ b/src/services/search-index.service.ts
@@ -98,8 +98,16 @@ class SearchIndexService {
    */
   async refresh(repoPath: string): Promise<void> {
     if (!this.readyRepos.has(repoPath)) return;
+    const epoch = this.dropEpochs.get(repoPath) ?? 0;
 
     const result = await invokeCommand<number>('refresh_search_index', { path: repoPath });
+    if ((this.dropEpochs.get(repoPath) ?? 0) !== epoch) {
+      // The repo was closed while the refresh ran — the backend refresh
+      // (or its build-from-scratch fallback) just re-inserted an index for
+      // a closed tab; free it again
+      invokeCommand<void>('drop_search_index', { path: repoPath });
+      return;
+    }
     if (result.success) {
       // Invalidate search cache since results may have changed
       searchResultCache.clear();

--- a/src/services/watcher.service.ts
+++ b/src/services/watcher.service.ts
@@ -16,6 +16,11 @@ export interface FileChangeEvent {
 export type FileChangeHandler = (event: FileChangeEvent) => void;
 
 let unlisten: UnlistenFn | null = null;
+// In-flight listener registration. Concurrent startWatching calls (e.g. the
+// startup restore watching N repos at once) must share ONE registration —
+// checking `unlisten` alone is not atomic across the await and used to leak
+// N-1 duplicate listeners that each dispatched every event again.
+let listenerSetup: Promise<void> | null = null;
 const handlers: Set<FileChangeHandler> = new Set();
 
 /**
@@ -23,9 +28,9 @@ const handlers: Set<FileChangeHandler> = new Set();
  * being watched are unaffected.
  */
 export async function startWatching(path: string): Promise<void> {
-  // Set up event listener if not already done
-  if (!unlisten) {
-    unlisten = await listen<FileChangeEvent>('file-change', (event) => {
+  // Set up the (single) event listener if not already done
+  if (!listenerSetup) {
+    listenerSetup = listen<FileChangeEvent>('file-change', (event) => {
       // Notify all registered handlers
       for (const handler of handlers) {
         try {
@@ -34,8 +39,18 @@ export async function startWatching(path: string): Promise<void> {
           console.error('Error in file change handler:', err);
         }
       }
-    });
+    }).then(
+      (fn) => {
+        unlisten = fn;
+      },
+      (err) => {
+        // Don't cache a failed registration — the next call retries
+        listenerSetup = null;
+        throw err;
+      }
+    );
   }
+  await listenerSetup;
 
   // Start watching on the backend
   const result = await invokeCommand<void>('start_watching', { path });
@@ -73,6 +88,7 @@ export async function cleanup(): Promise<void> {
     unlisten();
     unlisten = null;
   }
+  listenerSetup = null;
   handlers.clear();
   await stopWatching();
 }

--- a/src/services/watcher.service.ts
+++ b/src/services/watcher.service.ts
@@ -1,12 +1,14 @@
 /**
  * File Watcher Service
- * Watches for file system changes in the repository and emits events
+ * Watches for file system changes across all open repositories and emits
+ * events tagged with the repository they came from.
  */
 
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { invokeCommand } from './tauri-api.ts';
 
 export interface FileChangeEvent {
+  repoPath: string;
   eventType: 'workdir-changed' | 'index-changed' | 'refs-changed' | 'config-changed';
   paths: string[];
 }
@@ -17,7 +19,8 @@ let unlisten: UnlistenFn | null = null;
 const handlers: Set<FileChangeHandler> = new Set();
 
 /**
- * Start watching a repository for file changes
+ * Start watching a repository for file changes. Other repositories already
+ * being watched are unaffected.
  */
 export async function startWatching(path: string): Promise<void> {
   // Set up event listener if not already done
@@ -42,10 +45,10 @@ export async function startWatching(path: string): Promise<void> {
 }
 
 /**
- * Stop watching the current repository
+ * Stop watching a repository. With no path, stop watching all repositories.
  */
-export async function stopWatching(): Promise<void> {
-  const result = await invokeCommand<void>('stop_watching');
+export async function stopWatching(path?: string): Promise<void> {
+  const result = await invokeCommand<void>('stop_watching', { path: path ?? null });
   if (!result.success) {
     throw new Error(result.error?.message ?? 'Failed to stop watching');
   }

--- a/src/stores/__tests__/repository.store.test.ts
+++ b/src/stores/__tests__/repository.store.test.ts
@@ -72,6 +72,34 @@ describe('repository.store', () => {
     });
   });
 
+  describe('addRepository with activate: false', () => {
+    it('adds the repo without changing the active tab', () => {
+      repositoryStore.getState().addRepository(createMockRepo('/repo/active'));
+      repositoryStore.getState().addRepository(createMockRepo('/repo/bg'), { activate: false });
+
+      const state = repositoryStore.getState();
+      expect(state.openRepositories.length).to.equal(2);
+      expect(state.activeIndex).to.equal(0);
+    });
+
+    it('does not steal focus for an already-open repo either', () => {
+      repositoryStore.getState().addRepository(createMockRepo('/repo/one'));
+      repositoryStore.getState().addRepository(createMockRepo('/repo/two'));
+
+      repositoryStore.getState().addRepository(createMockRepo('/repo/one'), { activate: false });
+
+      expect(repositoryStore.getState().activeIndex).to.equal(1);
+    });
+
+    it('keeps activeIndex -1 when batch-adding into an empty store', () => {
+      repositoryStore.getState().addRepository(createMockRepo('/repo/one'), { activate: false });
+      expect(repositoryStore.getState().activeIndex).to.equal(-1);
+
+      repositoryStore.getState().setActiveByPath('/repo/one');
+      expect(repositoryStore.getState().activeIndex).to.equal(0);
+    });
+  });
+
   describe('updateRepoData', () => {
     const branch = {
       name: 'feature/x',

--- a/src/stores/__tests__/repository.store.test.ts
+++ b/src/stores/__tests__/repository.store.test.ts
@@ -130,6 +130,19 @@ describe('repository.store', () => {
     });
   });
 
+  describe('prunePersistedRepo', () => {
+    it('removes a repo from the persisted list without touching open repos', () => {
+      repositoryStore.getState().addRepository(createMockRepo('/repo/one'));
+      repositoryStore.getState().addRepository(createMockRepo('/repo/two'));
+
+      repositoryStore.getState().prunePersistedRepo('/repo/one');
+
+      const state = repositoryStore.getState();
+      expect(state.persistedOpenRepos.map((r) => r.path)).to.deep.equal(['/repo/two']);
+      expect(state.openRepositories.length).to.equal(2);
+    });
+  });
+
   describe('removeRepository', () => {
     it('removes a repository from open repositories', () => {
       const repo = createMockRepo('/test/path');

--- a/src/stores/__tests__/repository.store.test.ts
+++ b/src/stores/__tests__/repository.store.test.ts
@@ -72,6 +72,64 @@ describe('repository.store', () => {
     });
   });
 
+  describe('updateRepoData', () => {
+    const branch = {
+      name: 'feature/x',
+      shorthand: 'feature/x',
+      isHead: false,
+      isRemote: false,
+      upstream: null,
+      targetOid: 'abc123',
+      isStale: false,
+    };
+
+    it('updates a BACKGROUND repo without touching activeIndex', () => {
+      repositoryStore.getState().addRepository(createMockRepo('/repo/one'));
+      repositoryStore.getState().addRepository(createMockRepo('/repo/two'));
+      // repo two is active; update repo one by path
+      expect(repositoryStore.getState().activeIndex).to.equal(1);
+
+      repositoryStore.getState().updateRepoData('/repo/one', { branches: [branch] });
+
+      const state = repositoryStore.getState();
+      expect(state.activeIndex).to.equal(1);
+      expect(state.openRepositories[0].branches).to.deep.equal([branch]);
+      expect(state.openRepositories[1].branches).to.deep.equal([]);
+    });
+
+    it('is a no-op for a path that is not open', () => {
+      repositoryStore.getState().addRepository(createMockRepo('/repo/one'));
+      const before = repositoryStore.getState().openRepositories;
+
+      repositoryStore.getState().updateRepoData('/not/open', { branches: [branch] });
+
+      expect(repositoryStore.getState().openRepositories).to.deep.equal(before);
+    });
+
+    it('active-repo setters delegate to the active repo only', () => {
+      repositoryStore.getState().addRepository(createMockRepo('/repo/one'));
+      repositoryStore.getState().addRepository(createMockRepo('/repo/two'));
+
+      repositoryStore.getState().setBranches([branch]);
+
+      const state = repositoryStore.getState();
+      expect(state.openRepositories[1].branches).to.deep.equal([branch]);
+      expect(state.openRepositories[0].branches).to.deep.equal([]);
+    });
+
+    it('setStatus computes staged/unstaged for the active repo', () => {
+      repositoryStore.getState().addRepository(createMockRepo('/repo/one'));
+      const staged = { path: 'a.txt', status: 'modified', isStaged: true } as never;
+      const unstaged = { path: 'b.txt', status: 'modified', isStaged: false } as never;
+
+      repositoryStore.getState().setStatus([staged, unstaged]);
+
+      const repo = repositoryStore.getState().openRepositories[0];
+      expect(repo.stagedFiles).to.deep.equal([staged]);
+      expect(repo.unstagedFiles).to.deep.equal([unstaged]);
+    });
+  });
+
   describe('removeRepository', () => {
     it('removes a repository from open repositories', () => {
       const repo = createMockRepo('/test/path');

--- a/src/stores/repository.store.ts
+++ b/src/stores/repository.store.ts
@@ -47,9 +47,12 @@ export interface RepositoryState {
   setActiveIndex: (index: number) => void;
   setActiveByPath: (path: string) => void;
 
-  // Actions - Update active repo data
+  // Actions - Update repo data
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
+  /** Update any open repo's data by path — works for background tabs too */
+  updateRepoData: (path: string, data: Partial<Omit<OpenRepository, 'repository'>>) => void;
+  // Convenience setters for the ACTIVE repo
   setBranches: (branches: Branch[]) => void;
   setCurrentBranch: (branch: Branch | null) => void;
   setRemotes: (remotes: Remote[]) => void;
@@ -191,79 +194,55 @@ export const repositoryStore = createStore<RepositoryState>()(
 
       setError: (error) => set({ error, isLoading: false }),
 
-      // Update active repo data
-      setBranches: (branches) => {
+      // Update repo data. All setters funnel through updateRepoData so any
+      // open repo (active or background) can be updated by path without
+      // touching activeIndex.
+      updateRepoData: (path, data) => {
         set((state) => {
-          if (!isActiveIndexValid(state)) return state;
+          const index = state.openRepositories.findIndex(
+            (r) => r.repository.path === path
+          );
+          if (index < 0) return state;
           const newRepos = [...state.openRepositories];
-          newRepos[state.activeIndex] = {
-            ...newRepos[state.activeIndex],
-            branches,
-          };
+          newRepos[index] = { ...newRepos[index], ...data };
           return { openRepositories: newRepos };
         });
+      },
+
+      setBranches: (branches) => {
+        const path = get().getActiveRepository()?.repository.path;
+        if (path) get().updateRepoData(path, { branches });
       },
 
       setCurrentBranch: (currentBranch) => {
-        set((state) => {
-          if (!isActiveIndexValid(state)) return state;
-          const newRepos = [...state.openRepositories];
-          newRepos[state.activeIndex] = {
-            ...newRepos[state.activeIndex],
-            currentBranch,
-          };
-          return { openRepositories: newRepos };
-        });
+        const path = get().getActiveRepository()?.repository.path;
+        if (path) get().updateRepoData(path, { currentBranch });
       },
 
       setRemotes: (remotes) => {
-        set((state) => {
-          if (!isActiveIndexValid(state)) return state;
-          const newRepos = [...state.openRepositories];
-          newRepos[state.activeIndex] = {
-            ...newRepos[state.activeIndex],
-            remotes,
-          };
-          return { openRepositories: newRepos };
-        });
+        const path = get().getActiveRepository()?.repository.path;
+        if (path) get().updateRepoData(path, { remotes });
       },
 
       setTags: (tags) => {
-        set((state) => {
-          if (!isActiveIndexValid(state)) return state;
-          const newRepos = [...state.openRepositories];
-          newRepos[state.activeIndex] = {
-            ...newRepos[state.activeIndex],
-            tags,
-          };
-          return { openRepositories: newRepos };
-        });
+        const path = get().getActiveRepository()?.repository.path;
+        if (path) get().updateRepoData(path, { tags });
       },
 
       setStashes: (stashes) => {
-        set((state) => {
-          if (!isActiveIndexValid(state)) return state;
-          const newRepos = [...state.openRepositories];
-          newRepos[state.activeIndex] = {
-            ...newRepos[state.activeIndex],
-            stashes,
-          };
-          return { openRepositories: newRepos };
-        });
+        const path = get().getActiveRepository()?.repository.path;
+        if (path) get().updateRepoData(path, { stashes });
       },
 
       setStatus: (status) => {
-        set((state) => {
-          if (!isActiveIndexValid(state)) return state;
-          const newRepos = [...state.openRepositories];
-          newRepos[state.activeIndex] = {
-            ...newRepos[state.activeIndex],
+        const path = get().getActiveRepository()?.repository.path;
+        if (path) {
+          get().updateRepoData(path, {
             status,
             stagedFiles: status.filter((s) => s.isStaged),
             unstagedFiles: status.filter((s) => !s.isStaged),
-          };
-          return { openRepositories: newRepos };
-        });
+          });
+        }
       },
 
       updateActiveRepository: (repo) => {

--- a/src/stores/repository.store.ts
+++ b/src/stores/repository.store.ts
@@ -33,6 +33,9 @@ export interface RepositoryState {
 
   // Persisted open repos (restored on startup)
   persistedOpenRepos: PersistedOpenRepo[];
+  // Path of the tab that was active when the app last persisted — restored
+  // by restorePersistedRepositories so a restart lands on the same tab
+  persistedActivePath: string | null;
 
   // Loading state
   isLoading: boolean;
@@ -44,6 +47,8 @@ export interface RepositoryState {
   // Actions - Repository management
   addRepository: (repo: Repository) => void;
   removeRepository: (path: string) => void;
+  /** Remove a repo from the persisted list only (e.g. it failed to restore) */
+  prunePersistedRepo: (path: string) => void;
   setActiveIndex: (index: number) => void;
   setActiveByPath: (path: string) => void;
 
@@ -78,6 +83,7 @@ const initialState = {
   openRepositories: [] as OpenRepository[],
   activeIndex: -1,
   persistedOpenRepos: [] as PersistedOpenRepo[],
+  persistedActivePath: null as string | null,
   isLoading: false,
   error: null,
   recentRepositories: [] as RecentRepository[],
@@ -168,6 +174,12 @@ export const repositoryStore = createStore<RepositoryState>()(
             activeIndex: newActiveIndex,
           };
         });
+      },
+
+      prunePersistedRepo: (path) => {
+        set((state) => ({
+          persistedOpenRepos: state.persistedOpenRepos.filter((r) => r.path !== path),
+        }));
       },
 
       setActiveIndex: (index) => {
@@ -303,6 +315,13 @@ export const repositoryStore = createStore<RepositoryState>()(
         recentRepositories: state.recentRepositories,
         persistedOpenRepos: state.persistedOpenRepos,
         activeIndex: state.activeIndex,
+        // Derive the active PATH at persist time: activeIndex alone can't be
+        // restored (openRepositories is rebuilt async at startup, so the
+        // rehydrate hook clamps the index). Keep the previous value while no
+        // repo is active (e.g. during the startup window before restore).
+        persistedActivePath:
+          state.openRepositories[state.activeIndex]?.repository.path ??
+          state.persistedActivePath,
       }),
       onRehydrateStorage: () => (state) => {
         // Clamp activeIndex to valid range — openRepositories starts empty

--- a/src/stores/repository.store.ts
+++ b/src/stores/repository.store.ts
@@ -45,7 +45,13 @@ export interface RepositoryState {
   recentRepositories: RecentRepository[];
 
   // Actions - Repository management
-  addRepository: (repo: Repository) => void;
+  /**
+   * Open a repo as a tab. By default it becomes the active tab; pass
+   * `{ activate: false }` when opening several repos in a batch (workspace
+   * open) so each add doesn't fire the activation side effects (index
+   * builds, integration checks) — activate the final one explicitly.
+   */
+  addRepository: (repo: Repository, options?: { activate?: boolean }) => void;
   removeRepository: (path: string) => void;
   /** Remove a repo from the persisted list only (e.g. it failed to restore) */
   prunePersistedRepo: (path: string) => void;
@@ -112,8 +118,9 @@ export const repositoryStore = createStore<RepositoryState>()(
       ...initialState,
 
       // Repository management
-      addRepository: (repo) => {
+      addRepository: (repo, options) => {
         const name = repo.name || repo.path.split('/').pop() || repo.path;
+        const activate = options?.activate ?? true;
 
         set((state) => {
           const existingIndex = state.openRepositories.findIndex(
@@ -121,7 +128,7 @@ export const repositoryStore = createStore<RepositoryState>()(
           );
 
           if (existingIndex >= 0) {
-            return { activeIndex: existingIndex };
+            return activate ? { activeIndex: existingIndex } : state;
           }
 
           const newRepos = [...state.openRepositories, createEmptyRepoData(repo)];
@@ -131,7 +138,7 @@ export const repositoryStore = createStore<RepositoryState>()(
 
           return {
             openRepositories: newRepos,
-            activeIndex: newRepos.length - 1,
+            activeIndex: activate ? newRepos.length - 1 : state.activeIndex,
             persistedOpenRepos: newPersistedRepos,
             error: null,
           };


### PR DESCRIPTION
# Summary

With many repositories open, the app previously had a single-repo architecture wearing a tab strip: several backend services were literal singletons that assumed one repository, background work scaled linearly with open tabs, and the tab bar itself became unusable past a handful of repos. This PR makes multi-repo a first-class mode across the stack, in three phases, then hardens it through ten rounds of multi-model adversarial review.

## Phase 1 — Multi-repo correctness

- **Per-repo search index.** The commit search index was one global slot shared by all repos: opening repo B replaced repo A's index, concurrent builds during startup restore were silently dropped, and an incremental refresh against a different repo prepended that repo's *entire history* into the existing index — search in one tab could return another tab's commits. Indexes are now keyed by repository path end-to-end (`build`/`search`/`refresh` take the path; `drop_search_index` frees memory on tab close). A backend per-path **generation counter** (`CommitIndexStore::insert_if_current`, bumped on drop) guarantees a build/refresh that finishes after a close-then-reopen can't overwrite the reopened tab's fresh index, and the frontend mirrors this with epoch-keyed build dedup.
- **Multi-repo file watching + poller thread leak.** `start_watching` used to spawn a new 500 ms polling thread on every tab switch, none of which ever exited. There is now a single poller (spawned on demand, exits with the last watcher, exit flag flipped under the service lock so it's race-free against registration), and every open repo gets its own watcher with events tagged `repoPath`. Background repos are marked stale on events and refreshed once when activated; closed repos release their watcher.
- **Path-keyed store.** Store setters could only write to the active repo, forcing an `activeIndex` flip-flop hack to update background repos. `updateRepoData(path, …)` updates any open repo; the active-repo setters delegate to it. The sidebar panels capture the path before their async loads and use per-path monotonic sequence guards, so a slow load for the previous tab can't overwrite the newly active one (including A→B→A reordering).
- **Scoped auto-fetch feedback.** The toolbar ahead/behind badge took whichever repo auto-fetched last; it now follows only the active repo (and resets on tab switch), while every repo's fetch result updates its own tab badge. Remote-update toasts name the repo.

## Phase 2 — Tab bar UX

- Tabs shrink with ellipsis (90–200 px) instead of clipping invisibly; the strip wheel-scrolls and the active tab auto-scrolls into view however it was activated.
- Unmistakable active tab (accent underline + bold), full-path tooltips, and parent-directory hints to disambiguate duplicate names (`api · client-a` vs `api · client-b`), backslash-aware for Windows paths.
- Per-tab status: dirty dot for uncommitted changes and ahead/behind counts, hydrated for every open tab (including restored, never-activated ones) through a concurrency-capped queue and kept live via debounced background updates.
- All-repositories dropdown listing every open repo with its path; Ctrl+Tab / Ctrl+Shift+Tab cycling; Ctrl+1..9 direct jumps (the right panel's tab shortcuts moved to Ctrl+Shift+1..3 to avoid the collision); middle-click close; right-click context menu (Close / Close Others / Close Tabs to the Right / Close All / Copy Path); Escape closes the menus.

## Phase 3 — Performance with many tabs

- Startup restore opens repos in parallel (order preserved), lands on the tab that was active last session, and reports + prunes repos that fail to restore instead of silently retrying forever.
- Search/embedding index builds are lazy: only the active repo builds at startup or on workspace open; each background tab builds on first activation. Both index services dedupe per repo and cancel/guard in-flight builds on close so a closed tab can't keep burning CPU (ONNX embedding builds) or resurrect an index.
- Per-repo graph cache (LRU, 8 repos): switching back to a visited tab renders instantly while a spinner-free background reload revalidates (evicted on close so a reused path can't flash a prior repo's graph); a refresh requested mid-load queues exactly one foreground follow-up so mutation results still surface.
- Auto-fetch first ticks are staggered per repo (deterministic hash offset) so N repos don't all hit the network at once, and auto-fetch starts/stops with the tab lifecycle.

## Review process

The full change set went through **ten rounds** of three-model adversarial review — three independent frontier-model reviewers per round, each reviewing the entire diff holistically, every finding verified against the code before fixing, with a full test + lint + clippy gate green between rounds. The trajectory:

- **Rounds 1–3 (12 → 8 → 8 findings)** caught the load-bearing defects: cross-repo search-index corruption, the watcher thread leak, tab badges with no data source, and stale-write races in the sidebar panels.
- **Rounds 4–6** narrowed to edge cases and, increasingly, regressions in the fixes themselves (round 6's findings were entirely fallout from round 5's backend generation guard) — the signal that the feature had stabilized.
- **Rounds 7–10** were down to one or two peripheral findings each, with two of the three reviewers returning no issues in rounds 8, 9, and 10. The last substantive fix (round 10) was a pre-existing search-filter-leak gap that this PR's rapid tab switching made routinely reachable — now fixed by binding the graph's filter reactively.

Every finding across all rounds landed as a follow-up commit on this branch with a regression test.

## Test plan

- Rust: **1,779 passing** (`cargo test --lib`), including cross-repo index-corruption regressions, the generation-guard store test, multi-repo watcher tests, and auto-fetch stagger tests.
- Frontend unit: **3,468 passing** (web-test-runner), including new suites for the toolbar tabs, multi-repo app-shell behavior, per-repo index/watcher services and their close-then-reopen races, the sidebar stale-write guards, and the graph cache / load-version guards.
- E2E: **1,125 passing** (Playwright, full suite), including a new `repo-tabs.spec.ts` covering tab rendering, duplicate-name disambiguation, the all-repos dropdown, keyboard switching, middle-click close, and the context-menu actions.
- Gates: `npm run lint`, `npm run typecheck`, `cargo fmt --check`, `cargo clippy -- -D warnings`, and the snake_case IPC check all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCssBH1juoqieKZ1ndhwfZ