### PR TITLE
Full git-correctness audit: fix 113 divergences from canonical git (17 data-loss) across all git features

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src-tauri/src/commands/advanced_search.rs
+++ b/src-tauri/src/commands/advanced_search.rs
@@ -730,7 +730,7 @@ mod tests {
 
     #[test]
     fn test_parse_log_line_valid() {
-        let line = "abc123def456abc123def456abc123def456abc123\0abc123d\0feat: add feature\0John Doe\0john@example.com\01700000000\0John Doe\01700000000\0parent1 parent2";
+        let line = "abc123def456abc123def456abc123def456abc123\x00abc123d\x00feat: add feature\x00John Doe\x00john@example.com\x001700000000\x00John Doe\x001700000000\x00parent1 parent2";
         let commit = parse_log_line(line);
         assert!(commit.is_some());
         let commit = commit.unwrap();
@@ -748,7 +748,7 @@ mod tests {
 
     #[test]
     fn test_parse_log_line_no_parents() {
-        let line = "abc123\0abc1\0initial\0Author\0a@b.com\01000\0Author\01000\0";
+        let line = "abc123\x00abc1\x00initial\x00Author\x00a@b.com\x001000\x00Author\x001000\x00";
         let commit = parse_log_line(line);
         assert!(commit.is_some());
         let commit = commit.unwrap();
@@ -758,7 +758,8 @@ mod tests {
 
     #[test]
     fn test_parse_log_line_single_parent() {
-        let line = "abc123\0abc1\0second\0Author\0a@b.com\01000\0Author\01000\0deadbeef";
+        let line =
+            "abc123\x00abc1\x00second\x00Author\x00a@b.com\x001000\x00Author\x001000\x00deadbeef";
         let commit = parse_log_line(line);
         assert!(commit.is_some());
         let commit = commit.unwrap();
@@ -778,7 +779,7 @@ mod tests {
         // Regression: a commit subject (%s) containing '|' must NOT corrupt any
         // downstream field. With NUL separators the pipe is preserved verbatim in
         // the message and every other field parses correctly.
-        let line = "abc123\0abc1\0feat: support a|b syntax in parser\0Dev One\0dev@example.com\01783335269\0Dev One\01783335269\0p1 p2 p3";
+        let line = "abc123\x00abc1\x00feat: support a|b syntax in parser\x00Dev One\x00dev@example.com\x001783335269\x00Dev One\x001783335269\x00p1 p2 p3";
         let commit = parse_log_line(line);
         assert!(commit.is_some());
         let commit = commit.unwrap();

--- a/src-tauri/src/commands/advanced_search.rs
+++ b/src-tauri/src/commands/advanced_search.rs
@@ -39,10 +39,12 @@ pub struct FilteredCommit {
     pub is_merge: bool,
 }
 
-/// Parse a line of git log output formatted as:
-/// `%H|%h|%s|%an|%ae|%at|%cn|%ct|%P`
+/// Parse a line of git log output formatted as [`LOG_FORMAT`], whose fields are
+/// separated by NUL (`%x00`). NUL is used instead of `|` because a commit subject
+/// (`%s`) or an author/committer name can legitimately contain `|`, which would
+/// otherwise shift every subsequent field into the wrong slot.
 fn parse_log_line(line: &str) -> Option<FilteredCommit> {
-    let parts: Vec<&str> = line.splitn(9, '|').collect();
+    let parts: Vec<&str> = line.splitn(9, '\0').collect();
     if parts.len() < 9 {
         return None;
     }
@@ -97,7 +99,7 @@ fn execute_git_log(cmd: &mut Command) -> Result<Vec<FilteredCommit>> {
     Ok(commits)
 }
 
-const LOG_FORMAT: &str = "%H|%h|%s|%an|%ae|%at|%cn|%ct|%P";
+const LOG_FORMAT: &str = "%H%x00%h%x00%s%x00%an%x00%ae%x00%at%x00%cn%x00%ct%x00%P";
 
 /// Filter commits using a rich set of criteria
 ///
@@ -128,7 +130,16 @@ pub async fn filter_commits(
 
     if let Some(ref message) = filter.message {
         cmd.arg(format!("--grep={}", message));
-        cmd.arg("-i");
+        // Match the message literally (like `git log --grep=… -F`); without -F
+        // the query is a regex, so "v1.2" would spuriously match "v1x2".
+        cmd.arg("--fixed-strings");
+        // NOTE: -i is deliberately NOT added here. Canonical git applies -i
+        // globally to ALL header-matching patterns (--grep, --author, --committer)
+        // and defaults to case-sensitive. Adding -i only when a message filter is
+        // present silently made --author/--committer case-insensitive whenever a
+        // message was also supplied, so an unrelated field changed the author
+        // result set. Matching canonical git's default keeps every field
+        // case-sensitive regardless of which other filters are set.
     }
 
     if let Some(ref after_date) = filter.after_date {
@@ -333,6 +344,126 @@ mod tests {
         let commits = result.unwrap();
         assert_eq!(commits.len(), 1);
         assert!(commits[0].message.contains("unique_search_xyz"));
+    }
+
+    #[tokio::test]
+    async fn test_filter_commits_subject_with_pipe() {
+        // Regression (finding 105): a commit subject containing '|' must not shift
+        // author/committer/date fields. Canonical git emits pipes verbatim; the
+        // NUL-separated format parses every field unambiguously.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit(
+            "feat: support a|b syntax in parser",
+            &[("parser.txt", "content")],
+        );
+
+        let filter = CommitFilter {
+            author: None,
+            committer: None,
+            message: None,
+            after_date: None,
+            before_date: None,
+            path: None,
+            branch: None,
+            min_parents: None,
+            max_parents: None,
+            no_merges: None,
+            first_parent: None,
+        };
+
+        let result = filter_commits(repo.path_str(), filter, Some(1)).await;
+        assert!(result.is_ok());
+        let commits = result.unwrap();
+        assert_eq!(commits.len(), 1);
+        let commit = &commits[0];
+        assert_eq!(commit.message, "feat: support a|b syntax in parser");
+        assert_eq!(commit.author_name, "Test User");
+        assert_eq!(commit.author_email, "test@example.com");
+        assert!(commit.author_date > 0);
+        assert_eq!(commit.committer_name, "Test User");
+        assert!(commit.committer_date > 0);
+        assert_eq!(commit.parent_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_filter_commits_author_case_sensitive_regardless_of_message() {
+        // Regression (finding 110): --author is case-sensitive in canonical git,
+        // and -i is global to all header patterns. The author result set must not
+        // change depending on whether an unrelated message filter is also present.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Second commit", &[("file2.txt", "content")]);
+
+        // Author-only, lowercase: must match nothing (author is "Test User").
+        let author_only = CommitFilter {
+            author: Some("test user".to_string()),
+            committer: None,
+            message: None,
+            after_date: None,
+            before_date: None,
+            path: None,
+            branch: None,
+            min_parents: None,
+            max_parents: None,
+            no_merges: None,
+            first_parent: None,
+        };
+        let r1 = filter_commits(repo.path_str(), author_only, Some(100)).await;
+        assert!(r1.is_ok());
+        assert!(
+            r1.unwrap().is_empty(),
+            "lowercase author must be case-sensitive (0 matches)"
+        );
+
+        // Same lowercase author, now WITH a message filter: adding an unrelated
+        // message filter must not flip the author match to case-insensitive.
+        let author_and_message = CommitFilter {
+            author: Some("test user".to_string()),
+            committer: None,
+            message: Some("Second".to_string()),
+            after_date: None,
+            before_date: None,
+            path: None,
+            branch: None,
+            min_parents: None,
+            max_parents: None,
+            no_merges: None,
+            first_parent: None,
+        };
+        let r2 = filter_commits(repo.path_str(), author_and_message, Some(100)).await;
+        assert!(r2.is_ok());
+        assert!(
+            r2.unwrap().is_empty(),
+            "author case-sensitivity must not depend on the message filter"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_filter_commits_message_literal_not_regex() {
+        // Regression (finding 108): the message filter must match literally, so
+        // "v1.2" must NOT match a commit whose message is "release v1x2".
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("release v1x2", &[("rel.txt", "content")]);
+
+        let filter = CommitFilter {
+            author: None,
+            committer: None,
+            message: Some("v1.2".to_string()),
+            after_date: None,
+            before_date: None,
+            path: None,
+            branch: None,
+            min_parents: None,
+            max_parents: None,
+            no_merges: None,
+            first_parent: None,
+        };
+
+        let result = filter_commits(repo.path_str(), filter, Some(100)).await;
+        assert!(result.is_ok());
+        assert!(
+            result.unwrap().is_empty(),
+            "literal 'v1.2' must not match 'v1x2'"
+        );
     }
 
     #[tokio::test]
@@ -599,7 +730,7 @@ mod tests {
 
     #[test]
     fn test_parse_log_line_valid() {
-        let line = "abc123def456abc123def456abc123def456abc123|abc123d|feat: add feature|John Doe|john@example.com|1700000000|John Doe|1700000000|parent1 parent2";
+        let line = "abc123def456abc123def456abc123def456abc123\0abc123d\0feat: add feature\0John Doe\0john@example.com\01700000000\0John Doe\01700000000\0parent1 parent2";
         let commit = parse_log_line(line);
         assert!(commit.is_some());
         let commit = commit.unwrap();
@@ -617,7 +748,7 @@ mod tests {
 
     #[test]
     fn test_parse_log_line_no_parents() {
-        let line = "abc123|abc1|initial|Author|a@b.com|1000|Author|1000|";
+        let line = "abc123\0abc1\0initial\0Author\0a@b.com\01000\0Author\01000\0";
         let commit = parse_log_line(line);
         assert!(commit.is_some());
         let commit = commit.unwrap();
@@ -627,7 +758,7 @@ mod tests {
 
     #[test]
     fn test_parse_log_line_single_parent() {
-        let line = "abc123|abc1|second|Author|a@b.com|1000|Author|1000|deadbeef";
+        let line = "abc123\0abc1\0second\0Author\0a@b.com\01000\0Author\01000\0deadbeef";
         let commit = parse_log_line(line);
         assert!(commit.is_some());
         let commit = commit.unwrap();
@@ -644,13 +775,19 @@ mod tests {
 
     #[test]
     fn test_parse_log_line_message_with_pipe() {
-        // The message field is part of splitn(9, '|'), so pipes in parents field
-        // are handled, but the subject (%s) should not contain pipes normally.
-        // This tests that the 9-part split handles it correctly.
-        let line = "abc123|abc1|msg|Author|a@b.com|1000|Committer|1000|p1 p2 p3";
+        // Regression: a commit subject (%s) containing '|' must NOT corrupt any
+        // downstream field. With NUL separators the pipe is preserved verbatim in
+        // the message and every other field parses correctly.
+        let line = "abc123\0abc1\0feat: support a|b syntax in parser\0Dev One\0dev@example.com\01783335269\0Dev One\01783335269\0p1 p2 p3";
         let commit = parse_log_line(line);
         assert!(commit.is_some());
         let commit = commit.unwrap();
+        assert_eq!(commit.message, "feat: support a|b syntax in parser");
+        assert_eq!(commit.author_name, "Dev One");
+        assert_eq!(commit.author_email, "dev@example.com");
+        assert_eq!(commit.author_date, 1783335269);
+        assert_eq!(commit.committer_name, "Dev One");
+        assert_eq!(commit.committer_date, 1783335269);
         assert_eq!(commit.parent_count, 3);
     }
 }

--- a/src-tauri/src/commands/archive.rs
+++ b/src-tauri/src/commands/archive.rs
@@ -1,22 +1,33 @@
 //! Archive command handlers
 //! Export repository snapshots as zip/tar archives
 
-use std::io::Write;
 use std::path::Path;
+use std::process::Command;
 use tauri::command;
 
 use crate::error::{LeviathanError, Result};
+use crate::utils::reject_flag_like;
 
-/// Supported archive formats
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ArchiveFormat {
-    Zip,
-    Tar,
-    TarGz,
+/// Map a user-supplied format string to the value understood by
+/// `git archive --format=<fmt>`. Returns an error for unsupported formats.
+fn resolve_format(format: Option<&str>) -> Result<&'static str> {
+    match format.unwrap_or("zip") {
+        "zip" => Ok("zip"),
+        "tar" => Ok("tar"),
+        "tar.gz" | "tgz" => Ok("tar.gz"),
+        other => Err(LeviathanError::OperationFailed(format!(
+            "Unsupported archive format: {}",
+            other
+        ))),
+    }
 }
 
-/// Create an archive of the repository at a given commit/ref
+/// Create an archive of the repository at a given commit/ref.
+///
+/// This delegates to `git archive`, which correctly preserves executable
+/// file modes, emits committed symlinks as symlink entries, and honours the
+/// `export-ignore` / `export-subst` gitattributes — behaviour a hand-rolled
+/// tree walk does not reproduce.
 #[command]
 pub async fn create_archive(
     path: String,
@@ -25,163 +36,110 @@ pub async fn create_archive(
     format: Option<String>,
     prefix: Option<String>,
 ) -> Result<String> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    let repo_path = Path::new(&path);
+    let repo = git2::Repository::open(repo_path)?;
 
-    // Resolve the reference to a tree
+    // Resolve the reference to a tree so we can surface a clear error for an
+    // invalid ref before shelling out to git.
     let ref_str = tree_ref.as_deref().unwrap_or("HEAD");
     let obj = repo.revparse_single(ref_str)?;
-    let tree = obj.peel_to_tree().map_err(|_| {
+    obj.peel_to_tree().map_err(|_| {
         LeviathanError::OperationFailed(format!("Cannot resolve '{}' to a tree", ref_str))
     })?;
 
-    let format_str = format.as_deref().unwrap_or("zip");
-    let archive_format = match format_str {
-        "zip" => ArchiveFormat::Zip,
-        "tar" => ArchiveFormat::Tar,
-        "tar.gz" | "tgz" => ArchiveFormat::TarGz,
-        _ => {
-            return Err(LeviathanError::OperationFailed(format!(
-                "Unsupported archive format: {}",
-                format_str
-            )))
-        }
-    };
+    let format_arg = resolve_format(format.as_deref())?;
 
+    // Defend every user-controlled value that reaches the CLI.
+    reject_flag_like(&output_path, "Output path")?;
+    reject_flag_like(ref_str, "Reference")?;
     let prefix_str = prefix.unwrap_or_default();
+    if !prefix_str.is_empty() {
+        reject_flag_like(&prefix_str, "Prefix")?;
+    }
 
-    match archive_format {
-        ArchiveFormat::Zip => create_zip_archive(&repo, &tree, &output_path, &prefix_str)?,
-        ArchiveFormat::Tar => create_tar_archive(&repo, &tree, &output_path, &prefix_str, false)?,
-        ArchiveFormat::TarGz => create_tar_archive(&repo, &tree, &output_path, &prefix_str, true)?,
+    let mut cmd = Command::new("git");
+    cmd.current_dir(repo_path)
+        .arg("archive")
+        .arg(format!("--format={}", format_arg))
+        .arg(format!("--output={}", output_path));
+    if !prefix_str.is_empty() {
+        // git archive requires a trailing slash to nest entries under a
+        // directory, matching the previous "<prefix>/<file>" layout.
+        cmd.arg(format!("--prefix={}/", prefix_str));
+    }
+    // `--` terminates options so a ref cannot be reinterpreted as a flag.
+    cmd.arg("--").arg(ref_str);
+
+    let output = cmd.output().map_err(|e| {
+        LeviathanError::OperationFailed(format!("Failed to execute git archive: {}", e))
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(LeviathanError::OperationFailed(format!(
+            "git archive failed: {}",
+            stderr.trim()
+        )));
     }
 
     Ok(output_path)
 }
 
-fn create_zip_archive(
-    repo: &git2::Repository,
-    tree: &git2::Tree,
-    output_path: &str,
-    prefix: &str,
-) -> Result<()> {
-    let file = std::fs::File::create(output_path)?;
-    let mut zip = zip::ZipWriter::new(file);
-
-    let options = zip::write::SimpleFileOptions::default()
-        .compression_method(zip::CompressionMethod::Deflated);
-
-    tree.walk(git2::TreeWalkMode::PreOrder, |dir, entry| {
-        if entry.kind() == Some(git2::ObjectType::Blob) {
-            let file_path = if dir.is_empty() {
-                entry.name().unwrap_or("").to_string()
-            } else {
-                format!("{}{}", dir, entry.name().unwrap_or(""))
-            };
-
-            let archive_path = if prefix.is_empty() {
-                file_path
-            } else {
-                format!("{}/{}", prefix, file_path)
-            };
-
-            if let Ok(blob) = repo.find_blob(entry.id()) {
-                let _ = zip.start_file(&archive_path, options);
-                let _ = zip.write_all(blob.content());
-            }
-        }
-        git2::TreeWalkResult::Ok
-    })?;
-
-    zip.finish()
-        .map_err(|e| LeviathanError::OperationFailed(format!("Failed to finalize zip: {}", e)))?;
-
-    Ok(())
-}
-
-fn create_tar_archive(
-    repo: &git2::Repository,
-    tree: &git2::Tree,
-    output_path: &str,
-    prefix: &str,
-    gzip: bool,
-) -> Result<()> {
-    let file = std::fs::File::create(output_path)?;
-
-    if gzip {
-        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
-        let mut tar = tar::Builder::new(encoder);
-        write_tree_to_tar(repo, tree, &mut tar, prefix)?;
-        let encoder = tar.into_inner()?;
-        encoder.finish()?;
-    } else {
-        let mut tar = tar::Builder::new(file);
-        write_tree_to_tar(repo, tree, &mut tar, prefix)?;
-        tar.finish()?;
-    }
-
-    Ok(())
-}
-
-fn write_tree_to_tar<W: Write>(
-    repo: &git2::Repository,
-    tree: &git2::Tree,
-    tar: &mut tar::Builder<W>,
-    prefix: &str,
-) -> Result<()> {
-    tree.walk(git2::TreeWalkMode::PreOrder, |dir, entry| {
-        if entry.kind() == Some(git2::ObjectType::Blob) {
-            let file_path = if dir.is_empty() {
-                entry.name().unwrap_or("").to_string()
-            } else {
-                format!("{}{}", dir, entry.name().unwrap_or(""))
-            };
-
-            let archive_path = if prefix.is_empty() {
-                file_path
-            } else {
-                format!("{}/{}", prefix, file_path)
-            };
-
-            if let Ok(blob) = repo.find_blob(entry.id()) {
-                let content = blob.content();
-                let mut header = tar::Header::new_gnu();
-                header.set_size(content.len() as u64);
-                header.set_mode(0o644);
-                header.set_cksum();
-
-                let _ = tar.append_data(&mut header, &archive_path, content);
-            }
-        }
-        git2::TreeWalkResult::Ok
-    })?;
-
-    Ok(())
-}
-
-/// Get list of files that would be included in the archive
+/// Get the list of files that would be included in the archive.
+///
+/// The list is produced by asking `git archive` for a tar stream and reading
+/// the entry names, so it reflects the exact set of files the archive will
+/// contain — including the effect of `export-ignore` gitattributes.
 #[command]
 pub async fn get_archive_files(path: String, tree_ref: Option<String>) -> Result<Vec<String>> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    let repo_path = Path::new(&path);
+    let repo = git2::Repository::open(repo_path)?;
 
     let ref_str = tree_ref.as_deref().unwrap_or("HEAD");
     let obj = repo.revparse_single(ref_str)?;
-    let tree = obj.peel_to_tree().map_err(|_| {
+    obj.peel_to_tree().map_err(|_| {
         LeviathanError::OperationFailed(format!("Cannot resolve '{}' to a tree", ref_str))
     })?;
 
-    let mut files = Vec::new();
+    reject_flag_like(ref_str, "Reference")?;
 
-    tree.walk(git2::TreeWalkMode::PreOrder, |dir, entry| {
-        if entry.kind() == Some(git2::ObjectType::Blob) {
-            let file_path = if dir.is_empty() {
-                entry.name().unwrap_or("").to_string()
-            } else {
-                format!("{}{}", dir, entry.name().unwrap_or(""))
-            };
-            files.push(file_path);
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .arg("archive")
+        .arg("--format=tar")
+        .arg("--")
+        .arg(ref_str)
+        .output()
+        .map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to execute git archive: {}", e))
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(LeviathanError::OperationFailed(format!(
+            "git archive failed: {}",
+            stderr.trim()
+        )));
+    }
+
+    let mut files = Vec::new();
+    let mut archive = tar::Archive::new(output.stdout.as_slice());
+    for entry in archive
+        .entries()
+        .map_err(|e| LeviathanError::OperationFailed(format!("Failed to read archive: {}", e)))?
+    {
+        let entry = entry.map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to read archive entry: {}", e))
+        })?;
+        // Skip directory entries; report only files and symlinks.
+        if entry.header().entry_type().is_dir() {
+            continue;
         }
-        git2::TreeWalkResult::Ok
-    })?;
+        let entry_path = entry
+            .path()
+            .map_err(|e| LeviathanError::OperationFailed(format!("Invalid archive path: {}", e)))?;
+        files.push(entry_path.to_string_lossy().to_string());
+    }
 
     Ok(files)
 }
@@ -190,6 +148,29 @@ pub async fn get_archive_files(path: String, tree_ref: Option<String>) -> Result
 mod tests {
     use super::*;
     use crate::test_utils::TestRepo;
+    use std::io::Read;
+
+    /// Read all entries from a tar archive file into (path, header) pairs.
+    fn read_tar_entries(path: &Path) -> Vec<(String, tar::Header, Option<String>)> {
+        let file = std::fs::File::open(path).expect("open tar");
+        let mut archive = tar::Archive::new(file);
+        let mut out = Vec::new();
+        for entry in archive.entries().expect("entries") {
+            let mut entry = entry.expect("entry");
+            let p = entry.path().expect("path").to_string_lossy().to_string();
+            let header = entry.header().clone();
+            let link = entry
+                .link_name()
+                .ok()
+                .flatten()
+                .map(|l| l.to_string_lossy().to_string());
+            // Drain the entry body so the reader advances.
+            let mut buf = Vec::new();
+            let _ = entry.read_to_end(&mut buf);
+            out.push((p, header, link));
+        }
+        out
+    }
 
     #[tokio::test]
     async fn test_create_zip_archive() {
@@ -260,18 +241,26 @@ mod tests {
         let repo = TestRepo::with_initial_commit();
         repo.create_commit("Add file", &[("file.txt", "content")]);
 
-        let output = repo.path.join("prefixed.zip");
+        let output = repo.path.join("prefixed.tar");
         let result = create_archive(
             repo.path_str(),
             output.to_string_lossy().to_string(),
             None,
-            Some("zip".to_string()),
+            Some("tar".to_string()),
             Some("myproject-v1.0".to_string()),
         )
         .await;
 
         assert!(result.is_ok());
         assert!(output.exists());
+        let entries = read_tar_entries(&output);
+        assert!(
+            entries
+                .iter()
+                .any(|(p, _, _)| p == "myproject-v1.0/file.txt"),
+            "entries: {:?}",
+            entries.iter().map(|(p, _, _)| p).collect::<Vec<_>>()
+        );
     }
 
     #[tokio::test]
@@ -306,7 +295,8 @@ mod tests {
         let files = result.unwrap();
         // After with_initial_commit (README.md) + second commit (src/main.rs, README.md),
         // the tree contains README.md and src/main.rs = 2 files
-        assert!(files.len() >= 2);
+        assert!(files.iter().any(|f| f == "README.md"));
+        assert!(files.iter().any(|f| f == "src/main.rs"));
     }
 
     #[tokio::test]
@@ -341,5 +331,144 @@ mod tests {
         .await;
 
         assert!(result.is_err());
+    }
+
+    // Finding 74: git archive preserves executable file mode (100755).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_archive_preserves_executable_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let repo = TestRepo::with_initial_commit();
+        // Write an executable script and stage it so the index records 100755.
+        repo.create_file("run.sh", "#!/bin/sh\necho hi\n");
+        let script = repo.path.join("run.sh");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod run.sh");
+        repo.stage_file("run.sh");
+        // Commit the staged executable.
+        {
+            let git_repo = repo.repo();
+            let mut index = git_repo.index().unwrap();
+            let tree_oid = index.write_tree().unwrap();
+            let tree = git_repo.find_tree(tree_oid).unwrap();
+            let sig = git_repo.signature().unwrap();
+            let parent = git_repo.head().unwrap().peel_to_commit().unwrap();
+            git_repo
+                .commit(Some("HEAD"), &sig, &sig, "add script", &tree, &[&parent])
+                .unwrap();
+        }
+
+        let output = repo.path.join("exec.tar");
+        create_archive(
+            repo.path_str(),
+            output.to_string_lossy().to_string(),
+            None,
+            Some("tar".to_string()),
+            None,
+        )
+        .await
+        .expect("archive");
+
+        let entries = read_tar_entries(&output);
+        let (_, header, _) = entries
+            .iter()
+            .find(|(p, _, _)| p == "run.sh")
+            .expect("run.sh in archive");
+        let mode = header.mode().expect("mode");
+        assert!(
+            mode & 0o111 != 0,
+            "run.sh should be executable, got mode {:o}",
+            mode
+        );
+    }
+
+    // Finding 75: committed symlinks are emitted as symlink entries.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_archive_preserves_symlink() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_file("plain.txt", "hello");
+        repo.stage_file("plain.txt");
+        std::os::unix::fs::symlink("plain.txt", repo.path.join("link.txt")).expect("symlink");
+        repo.stage_file("link.txt");
+        {
+            let git_repo = repo.repo();
+            let mut index = git_repo.index().unwrap();
+            let tree_oid = index.write_tree().unwrap();
+            let tree = git_repo.find_tree(tree_oid).unwrap();
+            let sig = git_repo.signature().unwrap();
+            let parent = git_repo.head().unwrap().peel_to_commit().unwrap();
+            git_repo
+                .commit(Some("HEAD"), &sig, &sig, "add symlink", &tree, &[&parent])
+                .unwrap();
+        }
+
+        let output = repo.path.join("symlink.tar");
+        create_archive(
+            repo.path_str(),
+            output.to_string_lossy().to_string(),
+            None,
+            Some("tar".to_string()),
+            None,
+        )
+        .await
+        .expect("archive");
+
+        let entries = read_tar_entries(&output);
+        let (_, header, link) = entries
+            .iter()
+            .find(|(p, _, _)| p == "link.txt")
+            .expect("link.txt in archive");
+        assert_eq!(
+            header.entry_type(),
+            tar::EntryType::Symlink,
+            "link.txt should be a symlink entry"
+        );
+        assert_eq!(link.as_deref(), Some("plain.txt"));
+    }
+
+    // Finding 76: export-ignore files are excluded from the archive and the
+    // preview file list.
+    #[tokio::test]
+    async fn test_archive_honors_export_ignore() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit(
+            "Add files with export-ignore",
+            &[
+                (".gitattributes", "private.txt export-ignore\n"),
+                ("private.txt", "secret"),
+                ("public.txt", "public"),
+            ],
+        );
+
+        // Creation excludes the export-ignored file.
+        let output = repo.path.join("ignore.tar");
+        create_archive(
+            repo.path_str(),
+            output.to_string_lossy().to_string(),
+            None,
+            Some("tar".to_string()),
+            None,
+        )
+        .await
+        .expect("archive");
+        let entries = read_tar_entries(&output);
+        let names: Vec<&String> = entries.iter().map(|(p, _, _)| p).collect();
+        assert!(
+            !names.iter().any(|p| p.as_str() == "private.txt"),
+            "private.txt must be excluded, got {:?}",
+            names
+        );
+        assert!(names.iter().any(|p| p.as_str() == "public.txt"));
+
+        // The preview list reflects the same exclusion.
+        let files = get_archive_files(repo.path_str(), None).await.unwrap();
+        assert!(
+            !files.iter().any(|f| f == "private.txt"),
+            "preview must exclude private.txt, got {:?}",
+            files
+        );
+        assert!(files.iter().any(|f| f == "public.txt"));
     }
 }

--- a/src-tauri/src/commands/bisect.rs
+++ b/src-tauri/src/commands/bisect.rs
@@ -1,7 +1,7 @@
 //! Bisect command handlers
 //! Binary search through commits to find bug-introducing changes
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tauri::command;
 
 use crate::error::{LeviathanError, Result};
@@ -73,24 +73,89 @@ fn run_git_command(repo_path: &Path, args: &[&str]) -> Result<String> {
     if output.status.success() {
         Ok(stdout.trim().to_string())
     } else {
-        // Some bisect commands return non-zero but aren't errors (like bisect visualize)
-        // Check if stderr contains actual error
-        if stderr.contains("error:") || stderr.contains("fatal:") {
-            Err(LeviathanError::OperationFailed(stderr.trim().to_string()))
-        } else {
+        // A few bisect outcomes exit non-zero yet are legitimate results the UI
+        // must display rather than swallow: skip-exhaustion ("We cannot bisect
+        // more!", exit 2) and, on some git versions, the first-bad-commit summary.
+        // Everything else (e.g. swapped good/bad: "Some good revs are not
+        // ancestors of the bad rev.") is a real failure and must surface as an error.
+        let combined = format!("{}\n{}", stdout, stderr);
+        if combined.contains("We cannot bisect more")
+            || combined.contains("is the first bad commit")
+        {
             Ok(stdout.trim().to_string())
+        } else {
+            let message = if stderr.trim().is_empty() {
+                stdout.trim()
+            } else {
+                stderr.trim()
+            };
+            Err(LeviathanError::OperationFailed(message.to_string()))
         }
     }
 }
 
+/// Resolve the real git directory for `repo_path`. In a linked worktree `.git`
+/// is a plain file, so per-worktree bisect state lives under
+/// `<main>/.git/worktrees/<name>` rather than `<repo>/.git`.
+fn git_dir(repo_path: &Path) -> Option<PathBuf> {
+    run_git_command(repo_path, &["rev-parse", "--absolute-git-dir"])
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Read the recorded bisect terms (term for bad/new, term for good/old) from
+/// BISECT_TERMS. Defaults to ("bad", "good") when the file is absent.
+fn read_bisect_terms(git_dir: &Path) -> (String, String) {
+    let default = || ("bad".to_string(), "good".to_string());
+    match std::fs::read_to_string(git_dir.join("BISECT_TERMS")) {
+        Ok(content) => {
+            let mut lines = content.lines();
+            let bad = lines.next().map(|s| s.trim().to_string());
+            let good = lines.next().map(|s| s.trim().to_string());
+            match (bad, good) {
+                (Some(b), Some(g)) if !b.is_empty() && !g.is_empty() => (b, g),
+                _ => default(),
+            }
+        }
+        Err(_) => default(),
+    }
+}
+
+/// git's estimate for the number of remaining bisection steps (mirrors
+/// `estimate_bisect_steps` in git's bisect.c so the UI shows the same figure).
+fn estimate_bisect_steps(all: u32) -> u32 {
+    if all < 3 {
+        return 0;
+    }
+    let n = 31 - all.leading_zeros(); // floor(log2(all))
+    let e = 1u32 << n;
+    let x = all - e;
+    if e < 3 * x {
+        n
+    } else {
+        n - 1
+    }
+}
+
+/// Strip surrounding quotes that `git bisect log` puts around start arguments.
+fn unquote(s: &str) -> String {
+    s.trim_matches('\'').trim_matches('"').to_string()
+}
+
 /// Check if a bisect session is active
 fn is_bisect_active(repo_path: &Path) -> bool {
-    repo_path.join(".git/BISECT_START").exists()
+    git_dir(repo_path)
+        .map(|d| d.join("BISECT_START").exists())
+        .unwrap_or(false)
 }
 
 /// Parse the bisect log file
 fn parse_bisect_log(repo_path: &Path) -> Vec<BisectLogEntry> {
-    let log_path = repo_path.join(".git/BISECT_LOG");
+    let log_path = match git_dir(repo_path) {
+        Some(d) => d.join("BISECT_LOG"),
+        None => return Vec::new(),
+    };
     if !log_path.exists() {
         return Vec::new();
     }
@@ -104,19 +169,41 @@ fn parse_bisect_log(repo_path: &Path) -> Vec<BisectLogEntry> {
         .lines()
         .filter(|line| !line.starts_with('#') && !line.is_empty())
         .filter_map(|line| {
-            // Format: "git bisect good|bad|skip <commit>"
+            // Format: "git bisect <term|skip> <commit>". Custom terms produce
+            // e.g. "git bisect broken <sha>"; the bookkeeping "git bisect start
+            // '--term-new=broken' ..." line must be skipped, not shown as history.
             let parts: Vec<&str> = line.split_whitespace().collect();
             if parts.len() >= 4 && parts[0] == "git" && parts[1] == "bisect" {
-                Some(BisectLogEntry {
-                    commit_oid: parts[3].to_string(),
-                    action: parts[2].to_string(),
-                    message: None,
-                })
+                let action = unquote(parts[2]);
+                let commit = unquote(parts[3]);
+                if action == "start" || commit.is_empty() || commit.starts_with('-') {
+                    None
+                } else {
+                    Some(BisectLogEntry {
+                        commit_oid: commit,
+                        action,
+                        message: None,
+                    })
+                }
             } else {
                 None
             }
         })
         .collect()
+}
+
+/// The status returned when no bisect session is in progress.
+fn inactive_status() -> BisectStatus {
+    BisectStatus {
+        active: false,
+        current_commit: None,
+        bad_commit: None,
+        good_commit: None,
+        remaining: None,
+        total_steps: None,
+        current_step: None,
+        log: Vec::new(),
+    }
 }
 
 /// Get the current bisect status
@@ -125,54 +212,70 @@ pub async fn get_bisect_status(path: String) -> Result<BisectStatus> {
     let repo_path = Path::new(&path);
 
     if !is_bisect_active(repo_path) {
-        return Ok(BisectStatus {
-            active: false,
-            current_commit: None,
-            bad_commit: None,
-            good_commit: None,
-            remaining: None,
-            total_steps: None,
-            current_step: None,
-            log: Vec::new(),
-        });
+        return Ok(inactive_status());
     }
 
-    // Get current HEAD
+    let gdir = match git_dir(repo_path) {
+        Some(d) => d,
+        None => return Ok(inactive_status()),
+    };
+
+    // Honor custom terms (git bisect start --term-new/--term-old, or new/old).
+    let (term_bad, term_good) = read_bisect_terms(&gdir);
+
+    // Get current HEAD (the commit currently being tested)
     let current_commit = run_git_command(repo_path, &["rev-parse", "HEAD"]).ok();
 
-    // Read bad commit
-    let bad_commit = std::fs::read_to_string(repo_path.join(".git/refs/bisect/bad"))
+    // Read the bad/new ref via git so it resolves in linked worktrees and honors
+    // packed refs (raw .git/refs/bisect/* file reads break in both cases).
+    let bad_ref = format!("refs/bisect/{}", term_bad);
+    let bad_commit = run_git_command(repo_path, &["rev-parse", "--verify", "--quiet", &bad_ref])
         .ok()
-        .map(|s| s.trim().to_string());
+        .filter(|s| !s.is_empty());
 
-    // Find first good commit (there might be multiple)
-    let good_commit = std::fs::read_dir(repo_path.join(".git/refs/bisect"))
-        .ok()
-        .and_then(|entries| {
-            entries
-                .filter_map(|e| e.ok())
-                .find(|e| e.file_name().to_string_lossy().starts_with("good-"))
-                .and_then(|e| std::fs::read_to_string(e.path()).ok())
-                .map(|s| s.trim().to_string())
-        });
+    // Collect all good/old refs (there can be several: <term_good>-<sha>).
+    let good_prefix = format!("refs/bisect/{}-", term_good);
+    let good_refs: Vec<String> = run_git_command(
+        repo_path,
+        &["for-each-ref", "--format=%(refname)", "refs/bisect"],
+    )
+    .map(|out| {
+        out.lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| l.starts_with(&good_prefix))
+            .collect()
+    })
+    .unwrap_or_default();
+
+    let good_commit = good_refs
+        .first()
+        .and_then(|r| run_git_command(repo_path, &["rev-parse", r]).ok())
+        .filter(|s| !s.is_empty());
 
     // Parse the log
     let log = parse_bisect_log(repo_path);
 
-    // Estimate remaining steps
-    let remaining_info = if bad_commit.is_some() && good_commit.is_some() {
-        // Try to get the remaining count from git bisect
-        let output = run_git_command(repo_path, &["bisect", "visualize", "--oneline", "--count"]);
-        if let Ok(count_str) = output {
-            if let Ok(count) = count_str.parse::<u32>() {
-                // Approximate steps = log2(count)
-                let steps = (count as f64).log2().ceil() as u32;
-                Some((count, steps))
-            } else {
-                None
+    // Estimate remaining work exactly as git prints it:
+    //   "Bisecting: N revisions left to test after this (roughly M steps)"
+    // where N = all - reaches - 1 (all = candidate commits in the range,
+    // reaches = commits reachable from the current midpoint) and
+    // M = estimate_bisect_steps(all).
+    let remaining_info = if bad_commit.is_some() && !good_refs.is_empty() {
+        let count = |start: &str| -> Option<u32> {
+            let mut args: Vec<&str> = vec!["rev-list", "--count", start, "--not"];
+            for r in &good_refs {
+                args.push(r.as_str());
             }
-        } else {
-            None
+            run_git_command(repo_path, &args)
+                .ok()
+                .and_then(|s| s.trim().parse::<u32>().ok())
+        };
+        match (count(&bad_ref), count("HEAD")) {
+            (Some(all), Some(reaches)) if all > 0 => {
+                let remaining = all.saturating_sub(reaches).saturating_sub(1);
+                Some((remaining, estimate_bisect_steps(all)))
+            }
+            _ => None,
         }
     } else {
         None
@@ -585,5 +688,156 @@ Date:   Mon Jan 1 12:00:00 2024 +0000
         let output = "abc123def456 is the first bad commit\ncommit abc123def456";
         let culprit = parse_culprit_from_output(output);
         assert!(culprit.is_none());
+    }
+
+    // Finding 94: swapped good/bad must surface an error rather than silently
+    // reporting a started session the user is then stuck in.
+    #[tokio::test]
+    async fn test_bisect_start_rejects_swapped_good_bad() {
+        let repo = TestRepo::with_initial_commit();
+        for i in 2..=6 {
+            repo.create_commit(
+                &format!("Commit {}", i),
+                &[(format!("f{}.txt", i).as_str(), "x")],
+            );
+        }
+        // Mark an ancestor as "bad" and its descendant HEAD as "good" (swapped).
+        let bad_oid = run_git_command(&repo.path, &["rev-parse", "HEAD~4"]).unwrap();
+        let good_oid = repo.head_oid().to_string();
+
+        let result = bisect_start(repo.path_str(), Some(bad_oid), Some(good_oid)).await;
+        assert!(
+            result.is_err(),
+            "swapped good/bad must surface an error, not a silent success"
+        );
+
+        let _ = run_git_command(&repo.path, &["bisect", "reset"]);
+    }
+
+    // Finding 95: remaining / total_steps must be populated (they were always None
+    // because `git bisect visualize --oneline --count` never emits a bare count).
+    #[tokio::test]
+    async fn test_bisect_status_populates_progress() {
+        let repo = TestRepo::with_initial_commit();
+        let good_oid = repo.head_oid().to_string();
+        for i in 2..=9 {
+            repo.create_commit(
+                &format!("Commit {}", i),
+                &[(format!("f{}.txt", i).as_str(), "x")],
+            );
+        }
+        let bad_oid = repo.head_oid().to_string();
+
+        bisect_start(repo.path_str(), Some(bad_oid), Some(good_oid))
+            .await
+            .unwrap();
+
+        let status = get_bisect_status(repo.path_str()).await.unwrap();
+        assert!(status.active);
+        assert!(status.remaining.is_some(), "remaining should be populated");
+        assert!(
+            status.total_steps.is_some(),
+            "total_steps should be populated"
+        );
+
+        let _ = run_git_command(&repo.path, &["bisect", "reset"]);
+    }
+
+    // Finding 96: bisect state must be detected inside a linked worktree, where
+    // `.git` is a file and per-worktree state lives under the resolved git dir.
+    #[tokio::test]
+    async fn test_bisect_status_in_worktree() {
+        let repo = TestRepo::with_initial_commit();
+        let good_oid = repo.head_oid().to_string();
+        for i in 2..=6 {
+            repo.create_commit(
+                &format!("Commit {}", i),
+                &[(format!("f{}.txt", i).as_str(), "x")],
+            );
+        }
+        let bad_oid = repo.head_oid().to_string();
+
+        let wt_parent = tempfile::TempDir::new().unwrap();
+        let wt_path = wt_parent.path().join("wt");
+        let out = std::process::Command::new("git")
+            .current_dir(&repo.path)
+            .args([
+                "worktree",
+                "add",
+                "--detach",
+                wt_path.to_str().unwrap(),
+                "HEAD",
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "worktree add failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        // In a linked worktree `.git` is a file, not a directory.
+        assert!(wt_path.join(".git").is_file());
+
+        let wt_str = wt_path.to_string_lossy().to_string();
+        bisect_start(wt_str.clone(), Some(bad_oid), Some(good_oid))
+            .await
+            .unwrap();
+
+        let status = get_bisect_status(wt_str).await.unwrap();
+        assert!(
+            status.active,
+            "bisect must be detected as active in a linked worktree"
+        );
+        assert!(status.bad_commit.is_some());
+
+        let _ = run_git_command(&wt_path, &["bisect", "reset"]);
+    }
+
+    // Finding 97: sessions started with custom terms must resolve bad/good via
+    // the recorded terms, and the bookkeeping "start" line must not pollute history.
+    #[tokio::test]
+    async fn test_bisect_status_custom_terms() {
+        let repo = TestRepo::with_initial_commit();
+        let good_oid = repo.head_oid().to_string();
+        for i in 2..=6 {
+            repo.create_commit(
+                &format!("Commit {}", i),
+                &[(format!("f{}.txt", i).as_str(), "x")],
+            );
+        }
+        let bad_oid = repo.head_oid().to_string();
+
+        run_git_command(
+            &repo.path,
+            &[
+                "bisect",
+                "start",
+                "--term-new=broken",
+                "--term-old=working",
+                bad_oid.as_str(),
+                good_oid.as_str(),
+            ],
+        )
+        .unwrap();
+
+        let status = get_bisect_status(repo.path_str()).await.unwrap();
+        assert!(status.active);
+        assert!(
+            status.bad_commit.is_some(),
+            "bad commit should resolve via custom term refs/bisect/broken"
+        );
+        assert!(
+            status.good_commit.is_some(),
+            "good commit should resolve via custom term refs/bisect/working-*"
+        );
+        assert!(
+            status
+                .log
+                .iter()
+                .all(|e| e.action != "start" && !e.commit_oid.starts_with('-')),
+            "the start bookkeeping line must not appear as a history entry"
+        );
+
+        let _ = run_git_command(&repo.path, &["bisect", "reset"]);
     }
 }

--- a/src-tauri/src/commands/branch.rs
+++ b/src-tauri/src/commands/branch.rs
@@ -123,11 +123,14 @@ pub async fn create_branch(
     let reference = branch.get();
 
     if checkout.unwrap_or(false) {
+        let old_head = crate::commands::hooks::head_oid_string(&repo);
         let obj = reference.peel(git2::ObjectType::Commit)?;
         repo.checkout_tree(&obj, None)?;
         repo.set_head(reference.name().map_err(|_| {
             LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
         })?)?;
+        let new_head = crate::commands::hooks::head_oid_string(&repo);
+        crate::commands::hooks::run_post_checkout(&repo, &old_head, &new_head, true);
     }
 
     Ok(Branch {
@@ -266,6 +269,10 @@ pub async fn rename_branch(
 pub async fn checkout(path: String, ref_name: String, force: Option<bool>) -> Result<()> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
+    // Capture HEAD before the switch so the post-checkout hook receives the
+    // correct <old-ref> argument (githooks(5)).
+    let old_head = crate::commands::hooks::head_oid_string(&repo);
+
     let mut checkout_opts = git2::build::CheckoutBuilder::new();
     if force.unwrap_or(false) {
         checkout_opts.force();
@@ -330,6 +337,10 @@ pub async fn checkout(path: String, ref_name: String, force: Option<bool>) -> Re
         repo.checkout_tree(&obj, Some(&mut checkout_opts))?;
         repo.set_head_detached(commit.id())?;
     }
+
+    // Branch/commit switch complete — run post-checkout (flag=1), non-blocking.
+    let new_head = crate::commands::hooks::head_oid_string(&repo);
+    crate::commands::hooks::run_post_checkout(&repo, &old_head, &new_head, true);
 
     Ok(())
 }
@@ -574,6 +585,9 @@ pub async fn checkout_with_autostash(
 ) -> Result<CheckoutWithStashResult> {
     let mut repo = git2::Repository::open(Path::new(&path))?;
 
+    // Capture HEAD before the switch for the post-checkout hook's <old-ref>.
+    let old_head = crate::commands::hooks::head_oid_string(&repo);
+
     // Check if there are uncommitted changes
     let has_changes = {
         let statuses = repo.statuses(None)?;
@@ -764,6 +778,11 @@ pub async fn checkout_with_autostash(
     } else {
         repo.set_head_detached(target_oid)?;
     }
+
+    // HEAD/working tree switched — run post-checkout (flag=1), non-blocking.
+    // Runs before the stash re-apply so it fires even if re-applying conflicts.
+    let new_head = crate::commands::hooks::head_oid_string(&repo);
+    crate::commands::hooks::run_post_checkout(&repo, &old_head, &new_head, true);
 
     // If we stashed, try to re-apply the stash.
     if stashed {
@@ -1886,5 +1905,98 @@ mod tests {
             1,
             "stash must be preserved so the user's changes aren't lost"
         );
+    }
+
+    // ---- post-checkout hook parity ----
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_checkout_runs_post_checkout_hook() {
+        let repo = TestRepo::with_initial_commit();
+        let main = repo.current_branch();
+        let old_head = repo.head_oid();
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature", &[("f.txt", "f")]);
+        let feature_head = repo.head_oid();
+        repo.checkout_branch(&main);
+
+        let marker = repo.path.join("post-checkout.log");
+        repo.install_hook(
+            "post-checkout",
+            &format!("#!/bin/sh\necho \"$1 $2 $3\" > \"{}\"\n", marker.display()),
+        );
+
+        // Switch to feature via the command under test.
+        checkout(repo.path_str(), "feature".to_string(), None)
+            .await
+            .unwrap();
+
+        let logged = std::fs::read_to_string(&marker).expect("post-checkout hook must run");
+        let logged = logged.trim();
+        assert_eq!(
+            logged,
+            format!("{} {} 1", old_head, feature_head),
+            "post-checkout must receive <old> <new> 1"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_checkout_post_checkout_hook_is_nonblocking() {
+        let repo = TestRepo::with_initial_commit();
+        let main = repo.current_branch();
+        repo.create_branch("feature");
+        repo.install_hook("post-checkout", "#!/bin/sh\nexit 1\n");
+
+        // A failing post-checkout hook must NOT fail the checkout.
+        let result = checkout(repo.path_str(), "feature".to_string(), None).await;
+        assert!(result.is_ok(), "post-checkout is non-blocking");
+        assert_eq!(repo.current_branch(), "feature");
+        let _ = main;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_checkout_with_autostash_runs_post_checkout_hook() {
+        let repo = TestRepo::with_initial_commit();
+        let main = repo.current_branch();
+        let old_head = repo.head_oid();
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature", &[("f.txt", "f")]);
+        let feature_head = repo.head_oid();
+        repo.checkout_branch(&main);
+
+        let marker = repo.path.join("post-checkout.log");
+        repo.install_hook(
+            "post-checkout",
+            &format!("#!/bin/sh\necho \"$1 $2 $3\" > \"{}\"\n", marker.display()),
+        );
+
+        checkout_with_autostash(repo.path_str(), "feature".to_string())
+            .await
+            .unwrap();
+
+        let logged = std::fs::read_to_string(&marker).expect("post-checkout hook must run");
+        assert_eq!(logged.trim(), format!("{} {} 1", old_head, feature_head));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_create_branch_checkout_runs_post_checkout_hook() {
+        let repo = TestRepo::with_initial_commit();
+        let marker = repo.path.join("post-checkout.log");
+        repo.install_hook(
+            "post-checkout",
+            &format!("#!/bin/sh\necho \"$3\" > \"{}\"\n", marker.display()),
+        );
+
+        create_branch(repo.path_str(), "brand-new".to_string(), None, Some(true))
+            .await
+            .unwrap();
+
+        let logged = std::fs::read_to_string(&marker).expect("post-checkout hook must run");
+        assert_eq!(logged.trim(), "1", "branch-switch flag must be 1");
     }
 }

--- a/src-tauri/src/commands/branch_cleanup.rs
+++ b/src-tauri/src/commands/branch_cleanup.rs
@@ -124,30 +124,7 @@ pub async fn get_cleanup_candidates(
             .ok()
             .and_then(|u| u.name().ok().flatten().map(|n| n.to_string()));
 
-        let ahead_behind = if let Ok(upstream_branch) = branch.upstream() {
-            if let Some(upstream_oid) = upstream_branch.get().target() {
-                repo.graph_ahead_behind(branch_oid, upstream_oid)
-                    .ok()
-                    .map(|(ahead, behind)| AheadBehind { ahead, behind })
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
         let protected = is_protected(&name);
-
-        // Check if merged: HEAD is a descendant of the branch commit
-        let is_merged = repo
-            .graph_descendant_of(head_oid, branch_oid)
-            .unwrap_or(false);
-
-        // Check if stale
-        let is_stale = stale_days > 0
-            && last_commit_timestamp
-                .map(|ts| ts < stale_threshold)
-                .unwrap_or(false);
 
         // Check if upstream is gone
         let is_gone = {
@@ -163,6 +140,41 @@ pub async fn get_cleanup_candidates(
             // Gone if upstream is configured but branch.upstream() fails
             has_merge && has_remote && branch.upstream().is_err()
         };
+
+        let ahead_behind = if let Ok(upstream_branch) = branch.upstream() {
+            if let Some(upstream_oid) = upstream_branch.get().target() {
+                repo.graph_ahead_behind(branch_oid, upstream_oid)
+                    .ok()
+                    .map(|(ahead, behind)| AheadBehind { ahead, behind })
+            } else {
+                None
+            }
+        } else if is_gone {
+            // Upstream was deleted, so ahead/behind relative to it is
+            // impossible. Measure divergence from HEAD instead: a gone branch
+            // with commits not in HEAD is exactly what `git branch -d` refuses
+            // as "not fully merged", so the UI must be able to flag it as risky
+            // (unpushed commits) rather than silently "safe".
+            repo.graph_ahead_behind(branch_oid, head_oid)
+                .ok()
+                .map(|(ahead, behind)| AheadBehind { ahead, behind })
+        } else {
+            None
+        };
+
+        // Check if merged: HEAD is a descendant of the branch commit, or the
+        // branch points at the exact same commit as HEAD (git treats a branch
+        // whose tip equals HEAD as merged — `git branch --merged` lists it).
+        let is_merged = branch_oid == head_oid
+            || repo
+                .graph_descendant_of(head_oid, branch_oid)
+                .unwrap_or(false);
+
+        // Check if stale
+        let is_stale = stale_days > 0
+            && last_commit_timestamp
+                .map(|ts| ts < stale_threshold)
+                .unwrap_or(false);
 
         let base = |category: &str| CleanupCandidate {
             name: name.clone(),
@@ -274,6 +286,78 @@ mod tests {
         assert!(
             !candidates.iter().any(|c| c.category == "stale"),
             "No stale candidates when stale_days=0"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_cleanup_candidates_branch_at_head_is_merged() {
+        // Finding 19: a branch pointing at the same commit as HEAD is merged.
+        // `git branch --merged` lists it and `git branch -d` deletes it, but
+        // graph_descendant_of(head, branch) returns false for equal OIDs.
+        let repo = TestRepo::with_initial_commit();
+        // Create branches at HEAD without advancing main.
+        repo.create_branch("b1");
+        repo.create_branch("b2");
+
+        let result = get_cleanup_candidates(repo.path_str(), Some(0)).await;
+        assert!(result.is_ok());
+        let candidates = result.unwrap();
+        assert!(
+            candidates
+                .iter()
+                .any(|c| c.name == "b1" && c.category == "merged"),
+            "Branch b1 at HEAD should be a merged candidate (git branch --merged lists it)"
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|c| c.name == "b2" && c.category == "merged"),
+            "Branch b2 at HEAD should be a merged candidate (git branch --merged lists it)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_cleanup_candidates_gone_branch_reports_unpushed_commits() {
+        // Finding 12: a branch whose upstream was deleted and which contains
+        // commits not in HEAD is exactly the case git protects (`git branch -d`
+        // refuses "not fully merged"). The backend must compute ahead relative
+        // to HEAD for gone branches so the UI flags them as risky, not merged.
+        let repo = TestRepo::with_initial_commit();
+
+        // Local branch "feature" configured to track origin/feature, but with
+        // NO remote-tracking ref present (simulating the remote branch being
+        // deleted and pruned) — so branch.upstream() fails ("gone" upstream).
+        repo.create_branch("feature");
+        {
+            let git_repo = repo.repo();
+            let mut config = git_repo.config().expect("config");
+            config
+                .set_str("branch.feature.remote", "origin")
+                .expect("set remote");
+            config
+                .set_str("branch.feature.merge", "refs/heads/feature")
+                .expect("set merge");
+        }
+        // Advance "feature" by 2 commits not contained in HEAD (main).
+        repo.checkout_branch("feature");
+        repo.create_commit("wip 1", &[("wip1.txt", "one")]);
+        repo.create_commit("wip 2", &[("wip2.txt", "two")]);
+        repo.checkout_branch("main");
+
+        let result = get_cleanup_candidates(repo.path_str(), Some(0)).await;
+        assert!(result.is_ok());
+        let candidates = result.unwrap();
+        let gone = candidates
+            .iter()
+            .find(|c| c.name == "feature" && c.category == "gone")
+            .expect("feature should be a gone candidate");
+        let ab = gone
+            .ahead_behind
+            .as_ref()
+            .expect("gone branch must report ahead/behind relative to HEAD");
+        assert_eq!(
+            ab.ahead, 2,
+            "gone branch with 2 unpushed commits must report ahead=2 so the UI flags it as risky"
         );
     }
 

--- a/src-tauri/src/commands/bundle.rs
+++ b/src-tauri/src/commands/bundle.rs
@@ -172,30 +172,62 @@ pub async fn bundle_verify(path: String, bundle_path: String) -> Result<BundleVe
 
     let is_valid = output.status.success();
 
-    // Parse refs and prerequisites from output
+    // Parse refs and prerequisites from output. `git bundle verify` groups
+    // its output into sections: "The bundle contains …" lists the refs the
+    // bundle provides (each line is "<oid> <refname>"), while "The bundle
+    // requires …" lists prerequisite commits the target must already have
+    // (each line is a bare "<oid>" with no refname). We must track the current
+    // section because a bare prerequisite oid is otherwise indistinguishable
+    // from a ref line, and older parsers that keyed off a "-" prefix never
+    // matched modern git output — leaving `requires` permanently empty.
     let mut refs = Vec::new();
     let mut requires = Vec::new();
 
+    #[derive(PartialEq)]
+    enum Section {
+        None,
+        Contains,
+        Requires,
+    }
+    let mut section = Section::None;
+
     for line in combined.lines() {
         let line = line.trim();
-        // Lines like "The bundle contains this ref:" or just refs listed
-        // Format: <oid> refs/heads/main
-        if line.len() >= 40 && line.chars().take(40).all(|c| c.is_ascii_hexdigit()) {
+        if line.is_empty() {
+            continue;
+        }
+        let lower = line.to_lowercase();
+        if lower.contains("the bundle requires") {
+            section = Section::Requires;
+            continue;
+        }
+        if lower.contains("the bundle contains") {
+            section = Section::Contains;
+            continue;
+        }
+
+        let first = line.split_whitespace().next().unwrap_or("");
+        let is_oid = (first.len() == 40 || first.len() == 64)
+            && first.chars().all(|c| c.is_ascii_hexdigit());
+        if !is_oid {
+            continue;
+        }
+
+        if section == Section::Requires {
+            // Prerequisite lines carry only the bare oid.
+            requires.push(first.to_string());
+        } else {
+            // A ref line: "<oid> <refname>". Skip the bundle's HEAD pseudo-ref
+            // so it isn't reported as a real branch.
             let parts: Vec<&str> = line.splitn(2, char::is_whitespace).collect();
             if parts.len() == 2 {
-                refs.push(BundleRef {
-                    oid: parts[0].to_string(),
-                    name: parts[1].trim().to_string(),
-                });
-            }
-        }
-        // Prerequisites are marked with "-" prefix in verify output
-        if line.starts_with('-') || line.contains("prerequisite") {
-            if let Some(oid) = line
-                .split_whitespace()
-                .find(|s| s.len() >= 7 && s.chars().all(|c| c.is_ascii_hexdigit()))
-            {
-                requires.push(oid.to_string());
+                let name = parts[1].trim().to_string();
+                if name != "HEAD" {
+                    refs.push(BundleRef {
+                        oid: parts[0].to_string(),
+                        name,
+                    });
+                }
             }
         }
     }
@@ -337,6 +369,7 @@ pub async fn bundle_unbundle(path: String, bundle_path: String) -> Result<Vec<Bu
 
         let stdout = String::from_utf8_lossy(&list_output.stdout);
         let mut fetched_refs = Vec::new();
+        let mut refused_refs: Vec<(String, String)> = Vec::new();
 
         // Fetch each ref individually
         for line in stdout.lines() {
@@ -345,9 +378,12 @@ pub async fn bundle_unbundle(path: String, bundle_path: String) -> Result<Vec<Bu
                 let oid = parts[0];
                 let refname = parts[1].trim();
 
-                // Fetch this specific ref. Skip refs that look like flags;
-                // they originate from the bundle file and are not trusted.
-                if refname.starts_with('-') {
+                // Skip the bundle's HEAD pseudo-ref and anything that is not a
+                // real ref. Fetching "HEAD:HEAD" would create a bogus local
+                // branch refs/heads/HEAD and make every later "HEAD" lookup
+                // ambiguous. Flag-like names originate from the untrusted
+                // bundle and are rejected for the same reason.
+                if refname == "HEAD" || !refname.starts_with("refs/") || refname.starts_with('-') {
                     continue;
                 }
                 let fetch_result = Command::new("git")
@@ -358,15 +394,54 @@ pub async fn bundle_unbundle(path: String, bundle_path: String) -> Result<Vec<Bu
                     .arg(format!("{}:{}", refname, refname))
                     .output();
 
-                if let Ok(result) = fetch_result {
-                    if result.status.success() {
+                match fetch_result {
+                    Ok(result) if result.status.success() => {
                         fetched_refs.push(BundleRef {
                             oid: oid.to_string(),
                             name: refname.to_string(),
                         });
                     }
+                    Ok(result) => {
+                        // git refuses to update a checked-out branch and rejects
+                        // non-fast-forward updates. Record why so the user is
+                        // told the ref was not updated instead of it silently
+                        // vanishing from the result.
+                        let stderr = String::from_utf8_lossy(&result.stderr);
+                        let reason = stderr
+                            .lines()
+                            .rev()
+                            .find(|l| !l.trim().is_empty())
+                            .unwrap_or("")
+                            .trim()
+                            .to_string();
+                        refused_refs.push((refname.to_string(), reason));
+                    }
+                    Err(e) => {
+                        refused_refs.push((refname.to_string(), e.to_string()));
+                    }
                 }
             }
+        }
+
+        // Surface refused refs rather than reporting success while the ref the
+        // user most likely wanted (e.g. the checked-out branch) was never
+        // updated.
+        if !refused_refs.is_empty() {
+            let detail = refused_refs
+                .iter()
+                .map(|(name, reason)| {
+                    if reason.is_empty() {
+                        name.clone()
+                    } else {
+                        format!("{} ({})", name, reason)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(LeviathanError::OperationFailed(format!(
+                "Some refs from the bundle could not be updated: {}. This usually means the branch is currently checked out or the update was not a fast-forward.",
+                detail
+            )));
         }
 
         if fetched_refs.is_empty() {
@@ -378,8 +453,13 @@ pub async fn bundle_unbundle(path: String, bundle_path: String) -> Result<Vec<Bu
         return Ok(fetched_refs);
     }
 
-    // Parse the fetched refs from the bundle
-    bundle_list_heads(bundle_path).await
+    // Parse the fetched refs from the bundle. The "*:*" refspec only updates
+    // refs/*, so exclude the bundle's HEAD pseudo-ref from the reported result.
+    let heads = bundle_list_heads(bundle_path).await?;
+    Ok(heads
+        .into_iter()
+        .filter(|r| r.name.starts_with("refs/"))
+        .collect())
 }
 
 #[cfg(test)]
@@ -583,6 +663,96 @@ mod tests {
             result.err()
         );
         assert!(bundle_file.exists());
+    }
+
+    // Finding 71: a partial bundle's prerequisites must be reported.
+    #[tokio::test]
+    async fn test_bundle_verify_reports_prerequisites() {
+        let repo = TestRepo::with_initial_commit();
+        let base = repo.head_oid();
+        repo.create_commit("Second", &[("a.txt", "a")]);
+        repo.create_commit("Third", &[("b.txt", "b")]);
+
+        // A bundle of just the last two commits requires `base` as a
+        // prerequisite (partial history).
+        let bundle_file = repo.path.join("partial.bundle");
+        bundle_create(
+            repo.path_str(),
+            bundle_file.to_string_lossy().to_string(),
+            vec![format!("{}..HEAD", base)],
+            false,
+        )
+        .await
+        .unwrap();
+
+        let result = bundle_verify(repo.path_str(), bundle_file.to_string_lossy().to_string())
+            .await
+            .unwrap();
+
+        assert!(result.is_valid);
+        assert!(
+            !result.requires.is_empty(),
+            "partial bundle must report prerequisites, got {:?}",
+            result.requires
+        );
+        assert!(
+            result.requires.iter().any(|o| o == &base.to_string()),
+            "prerequisite should be the base commit {}, got {:?}",
+            base,
+            result.requires
+        );
+        // The prerequisite oid must not leak into the refs list.
+        assert!(
+            result.refs.iter().all(|r| r.oid != base.to_string()),
+            "prerequisite must not appear as a ref: {:?}",
+            result.refs
+        );
+    }
+
+    // Findings 69 and 70: unbundling a --all bundle into a repo whose
+    // checked-out branch it contains must (a) not create a bogus refs/heads/HEAD
+    // branch and (b) surface the refused checked-out branch as an error rather
+    // than silently reporting success.
+    #[tokio::test]
+    async fn test_bundle_unbundle_reports_refused_checked_out_branch() {
+        let source = TestRepo::with_initial_commit();
+        source.create_commit("c2", &[("f.txt", "2")]);
+        source.create_branch("feature");
+        source.create_commit("c3", &[("f.txt", "3")]);
+
+        let bundle_file = source.path.join("all.bundle");
+        bundle_create(
+            source.path_str(),
+            bundle_file.to_string_lossy().to_string(),
+            vec![],
+            true,
+        )
+        .await
+        .unwrap();
+
+        // Target has `main` checked out; the bundle contains refs/heads/main.
+        let target = TestRepo::with_initial_commit();
+        let result =
+            bundle_unbundle(target.path_str(), bundle_file.to_string_lossy().to_string()).await;
+
+        assert!(
+            result.is_err(),
+            "refused checked-out branch must surface an error, got {:?}",
+            result
+        );
+        let msg = format!("{:?}", result.err().unwrap());
+        assert!(
+            msg.contains("main") || msg.to_lowercase().contains("checked out"),
+            "error should name the refused ref: {}",
+            msg
+        );
+
+        // Finding 70: no bogus refs/heads/HEAD branch created.
+        let git = target.repo();
+        assert!(
+            git.find_branch("HEAD", git2::BranchType::Local).is_err(),
+            "must not create a local branch named HEAD"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/checkout_file.rs
+++ b/src-tauri/src/commands/checkout_file.rs
@@ -111,6 +111,11 @@ pub async fn checkout_file_from_commit(
         .write()
         .map_err(|e| LeviathanError::OperationFailed(format!("Failed to write index: {}", e)))?;
 
+    // File checkout (retrieving a file from a commit): git runs post-checkout
+    // with flag=0 and HEAD unchanged as both old and new ref. Non-blocking.
+    let head = crate::commands::hooks::head_oid_string(&repo);
+    crate::commands::hooks::run_post_checkout(&repo, &head, &head, false);
+
     let content_str = if is_binary {
         String::new()
     } else {
@@ -174,6 +179,11 @@ pub async fn checkout_file_from_branch(
     index
         .write()
         .map_err(|e| LeviathanError::OperationFailed(format!("Failed to write index: {}", e)))?;
+
+    // File checkout (retrieving a file from a branch tip): git runs
+    // post-checkout with flag=0 and HEAD unchanged. Non-blocking.
+    let head = crate::commands::hooks::head_oid_string(&repo);
+    crate::commands::hooks::run_post_checkout(&repo, &head, &head, false);
 
     let content_str = if is_binary {
         String::new()
@@ -553,5 +563,64 @@ mod tests {
         let index = git_repo.index().unwrap();
         let entry = index.get_path(Path::new("README.md"), 0);
         assert!(entry.is_some());
+    }
+
+    // ---- post-checkout (flag=0) hook parity for file checkouts ----
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_checkout_file_from_commit_runs_post_checkout_flag0() {
+        let repo = TestRepo::with_initial_commit();
+        let first_oid = repo.head_oid();
+        repo.create_commit("Update README", &[("README.md", "# Updated Repo")]);
+        let head = repo.head_oid();
+
+        let marker = repo.path.join("pc.log");
+        repo.install_hook(
+            "post-checkout",
+            &format!("#!/bin/sh\necho \"$1 $2 $3\" > \"{}\"\n", marker.display()),
+        );
+
+        checkout_file_from_commit(
+            repo.path_str(),
+            "README.md".to_string(),
+            first_oid.to_string(),
+        )
+        .await
+        .unwrap();
+
+        let logged = std::fs::read_to_string(&marker).expect("post-checkout must run");
+        // File checkout: HEAD unchanged on both sides, flag 0.
+        assert_eq!(logged.trim(), format!("{} {} 0", head, head));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_checkout_file_from_branch_runs_post_checkout_flag0() {
+        let repo = TestRepo::with_initial_commit();
+        let main = repo.current_branch();
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("README.md", "# Feature")]);
+        repo.checkout_branch(&main);
+        let head = repo.head_oid();
+
+        let marker = repo.path.join("pc.log");
+        repo.install_hook(
+            "post-checkout",
+            &format!("#!/bin/sh\necho \"$3\" > \"{}\"\n", marker.display()),
+        );
+
+        checkout_file_from_branch(
+            repo.path_str(),
+            "README.md".to_string(),
+            "feature".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let logged = std::fs::read_to_string(&marker).expect("post-checkout must run");
+        assert_eq!(logged.trim(), "0", "file checkout flag must be 0");
+        let _ = head;
     }
 }

--- a/src-tauri/src/commands/clean.rs
+++ b/src-tauri/src/commands/clean.rs
@@ -498,7 +498,7 @@ mod tests {
         let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
 
         assert!(
-            paths.iter().any(|p| *p == "loose.txt"),
+            paths.contains(&"loose.txt"),
             "loose untracked file should be listed, got {:?}",
             paths
         );

--- a/src-tauri/src/commands/clean.rs
+++ b/src-tauri/src/commands/clean.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::Path;
 use tauri::command;
 
+use super::path_utils::validate_path_within_repo;
 use crate::error::Result;
 
 /// Entry representing a file that can be cleaned
@@ -14,6 +15,11 @@ pub struct CleanEntry {
     pub path: String,
     pub is_directory: bool,
     pub is_ignored: bool,
+    /// True when this entry is an untracked nested git repository (a directory
+    /// containing a `.git` entry). Deleting it destroys the embedded repo's
+    /// history, so `git clean` only removes it with a second `-f`; the UI must
+    /// confirm and pass `force_nested` before it can be cleaned.
+    pub is_nested_repo: bool,
     pub size: Option<u64>,
 }
 
@@ -34,12 +40,20 @@ pub async fn get_cleanable_files(
 
     let mut entries = Vec::new();
 
-    // Get status to find untracked files
+    // Get status to find untracked files.
+    //
+    // Do NOT recurse into fully-untracked directories: canonical `git clean`
+    // without `-d` never touches files inside untracked directories, and with
+    // `-d` it removes the whole directory as a single unit (printing
+    // "Removing dir/"), not file-by-file. Reporting untracked directories as a
+    // single entry lets `include_directories` behave exactly like `-d`
+    // (dropping them when off) and lets a full clean remove the directory
+    // itself instead of leaving an empty husk behind.
     let statuses = repo.statuses(Some(
         git2::StatusOptions::new()
             .include_untracked(true)
             .include_ignored(include_ignored)
-            .recurse_untracked_dirs(true),
+            .recurse_untracked_dirs(false),
     ))?;
 
     for entry in statuses.iter() {
@@ -67,6 +81,12 @@ pub async fn get_cleanable_files(
             continue;
         }
 
+        // A directory that itself contains a `.git` entry is an untracked
+        // nested repository; deleting it destroys its history. Flag it so the
+        // UI can require an explicit confirmation (mirroring `git clean`'s
+        // second `-f`).
+        let is_nested_repo = is_directory && full_path.join(".git").exists();
+
         // Get file size
         let size = if is_directory {
             None
@@ -78,6 +98,7 @@ pub async fn get_cleanable_files(
             path: file_path.to_string(),
             is_directory,
             is_ignored,
+            is_nested_repo,
             size,
         });
     }
@@ -92,28 +113,98 @@ pub async fn get_cleanable_files(
     Ok(entries)
 }
 
-/// Clean (remove) specified files
+/// Return true if the repository index tracks any path at or under `dir_rel`.
+///
+/// Used to guarantee we never `remove_dir_all` a directory that contains
+/// version-controlled content — `git clean` only ever removes untracked files.
+fn dir_contains_tracked(index: &git2::Index, dir_rel: &str) -> bool {
+    let trimmed = dir_rel.trim_end_matches('/');
+    if trimmed.is_empty() {
+        // The work-tree root itself — treat as containing tracked content so we
+        // never recursively delete the whole repository.
+        return !index.is_empty();
+    }
+    let prefix = format!("{}/", trimmed);
+    index.iter().any(|entry| {
+        let p = String::from_utf8_lossy(&entry.path);
+        p == trimmed || p.starts_with(&prefix)
+    })
+}
+
+/// Clean (remove) specified files.
+///
+/// Mirrors `git clean`'s safety guarantees:
+/// - Paths that escape the work tree (`..`, absolute) are rejected outright,
+///   matching git's fatal "is outside repository"; the whole operation refuses
+///   before deleting anything.
+/// - Tracked/version-controlled paths are silently skipped (git clean never
+///   deletes tracked content, even when named explicitly).
+/// - Untracked nested git repositories are refused unless `force_nested` is set,
+///   mirroring git's requirement of a second `-f` before destroying an embedded
+///   repo's history.
 #[command]
-pub async fn clean_files(path: String, paths: Vec<String>) -> Result<u32> {
+pub async fn clean_files(
+    path: String,
+    paths: Vec<String>,
+    force_nested: Option<bool>,
+) -> Result<u32> {
     let repo = git2::Repository::open(Path::new(&path))?;
     let workdir = repo.workdir().ok_or_else(|| {
         crate::error::LeviathanError::OperationFailed("Repository has no working directory".into())
     })?;
 
+    let force_nested = force_nested.unwrap_or(false);
+
+    // Validate containment for EVERY path up front. git rejects pathspecs that
+    // escape the work tree with a fatal error and deletes nothing; do the same
+    // so a single bad ("../x") path can never destroy data outside the repo.
+    let mut validated: Vec<(String, std::path::PathBuf)> = Vec::with_capacity(paths.len());
+    for file_path in &paths {
+        let full_path = validate_path_within_repo(workdir, file_path)?;
+        validated.push((file_path.clone(), full_path));
+    }
+
+    let index = repo.index()?;
     let mut removed_count = 0;
 
-    for file_path in &paths {
-        let full_path = workdir.join(file_path);
-
+    for (file_path, full_path) in &validated {
         if full_path.is_dir() {
-            if let Ok(()) = fs::remove_dir_all(&full_path) {
+            // Refuse to destroy an untracked nested repository unless the caller
+            // explicitly opted in (git clean needs a second `-f`).
+            if full_path.join(".git").exists() && !force_nested {
+                tracing::warn!(
+                    "Refusing to remove nested git repository without force: {}",
+                    file_path
+                );
+                continue;
+            }
+            // Never recursively delete a directory that holds tracked content.
+            if dir_contains_tracked(&index, file_path) {
+                tracing::warn!(
+                    "Refusing to remove directory with tracked files: {}",
+                    file_path
+                );
+                continue;
+            }
+            if fs::remove_dir_all(full_path).is_ok() {
                 removed_count += 1;
                 tracing::info!("Removed directory: {}", file_path);
             } else {
                 tracing::warn!("Failed to remove directory: {}", file_path);
             }
         } else if full_path.is_file() {
-            if let Ok(()) = fs::remove_file(&full_path) {
+            // Only remove untracked or ignored files. git clean silently skips
+            // tracked paths (including staged ones) and never deletes
+            // version-controlled content.
+            let removable = matches!(
+                repo.status_file(Path::new(file_path)),
+                Ok(s) if s.contains(git2::Status::WT_NEW) || s.contains(git2::Status::IGNORED)
+            );
+            if !removable {
+                tracing::warn!("Refusing to remove tracked path: {}", file_path);
+                continue;
+            }
+            if fs::remove_file(full_path).is_ok() {
                 removed_count += 1;
                 tracing::info!("Removed file: {}", file_path);
             } else {
@@ -135,7 +226,7 @@ pub async fn clean_all(
     let entries = get_cleanable_files(path.clone(), include_ignored, include_directories).await?;
 
     let paths: Vec<String> = entries.into_iter().map(|e| e.path).collect();
-    clean_files(path, paths).await
+    clean_files(path, paths, None).await
 }
 
 #[cfg(test)]
@@ -236,7 +327,7 @@ mod tests {
         // Verify file exists
         assert!(repo.path.join("to_delete.txt").exists());
 
-        let result = clean_files(repo.path_str(), vec!["to_delete.txt".to_string()]).await;
+        let result = clean_files(repo.path_str(), vec!["to_delete.txt".to_string()], None).await;
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 1);
@@ -255,7 +346,7 @@ mod tests {
         // Verify directory exists
         assert!(repo.path.join("temp_dir").exists());
 
-        let result = clean_files(repo.path_str(), vec!["temp_dir".to_string()]).await;
+        let result = clean_files(repo.path_str(), vec!["temp_dir".to_string()], None).await;
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 1);
@@ -280,6 +371,7 @@ mod tests {
                 "file2.txt".to_string(),
                 "file3.txt".to_string(),
             ],
+            None,
         )
         .await;
 
@@ -297,7 +389,7 @@ mod tests {
         let repo = TestRepo::with_initial_commit();
 
         // Try to clean a file that doesn't exist
-        let result = clean_files(repo.path_str(), vec!["nonexistent.txt".to_string()]).await;
+        let result = clean_files(repo.path_str(), vec!["nonexistent.txt".to_string()], None).await;
 
         // Should succeed but with 0 files removed
         assert!(result.is_ok());
@@ -380,7 +472,7 @@ mod tests {
 
         // Create an untracked file and clean only that
         repo.create_file("untracked.txt", "content");
-        let result = clean_files(repo.path_str(), vec!["untracked.txt".to_string()]).await;
+        let result = clean_files(repo.path_str(), vec!["untracked.txt".to_string()], None).await;
 
         assert!(result.is_ok());
 
@@ -388,5 +480,154 @@ mod tests {
         assert!(repo.path.join("README.md").exists());
         let after_content = std::fs::read_to_string(repo.path.join("README.md")).unwrap();
         assert_eq!(readme_content, after_content);
+    }
+
+    // Finding 52: with "include directories" off (== `git clean -f`, no `-d`),
+    // files inside untracked directories must NOT be listed — only loose
+    // untracked files. Turning directories off must protect everything under
+    // untracked directories.
+    #[tokio::test]
+    async fn test_get_cleanable_files_directories_off_protects_dir_contents() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_file("udir/keep.txt", "content");
+        repo.create_file("loose.txt", "content");
+
+        let result = get_cleanable_files(repo.path_str(), None, Some(false)).await;
+        assert!(result.is_ok());
+        let entries = result.unwrap();
+        let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
+
+        assert!(
+            paths.iter().any(|p| *p == "loose.txt"),
+            "loose untracked file should be listed, got {:?}",
+            paths
+        );
+        assert!(
+            !paths.iter().any(|p| p.starts_with("udir")),
+            "git clean -f must not list files inside untracked directories, got {:?}",
+            paths
+        );
+    }
+
+    // Finding 56: `git clean -fd` removes an untracked directory entirely
+    // ("Removing dir/"), leaving no empty husk. A full clean must remove the
+    // directory itself, not just its files.
+    #[tokio::test]
+    async fn test_clean_removes_untracked_directory_entirely() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_file("plaindir/inner.txt", "content");
+
+        let entries = get_cleanable_files(repo.path_str(), None, Some(true))
+            .await
+            .unwrap();
+        let paths: Vec<String> = entries.iter().map(|e| e.path.clone()).collect();
+
+        let removed = clean_files(repo.path_str(), paths, None).await.unwrap();
+        assert!(removed >= 1, "expected the directory to be removed");
+        assert!(
+            !repo.path.join("plaindir").exists(),
+            "empty directory husk left behind; git clean -fd removes the directory itself"
+        );
+    }
+
+    // Finding 51: an untracked nested git repository must be flagged, and must
+    // NOT be deleted without an explicit double-force (git clean -fd refuses;
+    // only -ff removes it). Deleting it destroys the embedded repo's history.
+    #[tokio::test]
+    async fn test_clean_refuses_nested_repo_without_force() {
+        let repo = TestRepo::with_initial_commit();
+
+        // Create an untracked nested git repository with local content.
+        let nested = repo.path.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        git2::Repository::init(&nested).unwrap();
+        std::fs::write(nested.join("work.txt"), "local wip").unwrap();
+
+        let entries = get_cleanable_files(repo.path_str(), None, Some(true))
+            .await
+            .unwrap();
+        let nested_entry = entries
+            .iter()
+            .find(|e| e.path.trim_end_matches('/') == "nested");
+        assert!(
+            nested_entry.is_some(),
+            "nested repo should be listed, got {:?}",
+            entries
+        );
+        assert!(
+            nested_entry.unwrap().is_nested_repo,
+            "nested repo must be flagged is_nested_repo"
+        );
+
+        let paths: Vec<String> = entries.iter().map(|e| e.path.clone()).collect();
+
+        // Without force, the nested repo must survive (git clean -fd leaves it).
+        clean_files(repo.path_str(), paths.clone(), Some(false))
+            .await
+            .unwrap();
+        assert!(
+            nested.join(".git").exists(),
+            "nested repository destroyed without double-force; git clean -fd refuses this"
+        );
+
+        // With force (== git clean -ff) it is removed.
+        clean_files(repo.path_str(), paths, Some(true))
+            .await
+            .unwrap();
+        assert!(
+            !nested.exists(),
+            "nested repository should be removed once force_nested is set"
+        );
+    }
+
+    // Finding 53: clean_files must not delete tracked/version-controlled files,
+    // even when named explicitly (git clean -f tracked.txt exits 0 and keeps
+    // the file). Simulates the TOCTOU where a listed path became tracked.
+    #[tokio::test]
+    async fn test_clean_files_skips_tracked_path() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("add tracked", &[("tracked.txt", "v1")]);
+
+        // Stage further edits: the file is now tracked with staged changes.
+        repo.create_file("tracked.txt", "v2 edits");
+        repo.stage_file("tracked.txt");
+
+        let removed = clean_files(repo.path_str(), vec!["tracked.txt".to_string()], None)
+            .await
+            .unwrap();
+        assert_eq!(removed, 0, "clean must not delete a tracked file");
+        assert!(
+            repo.path.join("tracked.txt").exists(),
+            "tracked file was deleted by clean"
+        );
+        let content = std::fs::read_to_string(repo.path.join("tracked.txt")).unwrap();
+        assert_eq!(content, "v2 edits", "tracked file content was lost");
+    }
+
+    // Finding 53: clean_files must reject paths that escape the work tree
+    // (git fatals with "is outside repository" and deletes nothing).
+    #[tokio::test]
+    async fn test_clean_files_rejects_path_outside_repo() {
+        let repo = TestRepo::with_initial_commit();
+
+        let outside = repo.path.parent().unwrap().join("outside_secret.txt");
+        std::fs::write(&outside, "keep me").unwrap();
+
+        let result = clean_files(
+            repo.path_str(),
+            vec!["../outside_secret.txt".to_string()],
+            None,
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "clean must reject a path that escapes the repository"
+        );
+        assert!(
+            outside.exists(),
+            "a file outside the repository was deleted"
+        );
+        std::fs::remove_file(&outside).ok();
     }
 }

--- a/src-tauri/src/commands/commit.rs
+++ b/src-tauri/src/commands/commit.rs
@@ -260,6 +260,12 @@ pub async fn create_commit(
     }
     let repo = repo;
 
+    // Run client-side hooks like canonical git does — the git2 commit path
+    // otherwise bypasses them entirely. pre-commit can veto the commit;
+    // commit-msg can veto or rewrite the message.
+    crate::commands::hooks::run_hook_blocking(&repo, "pre-commit", &[], None)?;
+    let message = crate::commands::hooks::run_commit_msg_hook(&repo, &message)?;
+
     let default_signature = repo.signature()?;
 
     // Build author and committer signatures, optionally with custom dates
@@ -331,6 +337,9 @@ pub async fn create_commit(
         }
         commit_oid
     };
+
+    // post-commit runs after the commit is created and never blocks it.
+    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
 
     let commit = repo.find_commit(commit_oid)?;
     Ok(Commit::from_git2(&commit))
@@ -407,7 +416,35 @@ async fn create_commit_with_git_cli(
 /// This only updates the commit message; the tree and parents remain the same.
 #[command]
 pub async fn amend_commit_message(path: String, message: String) -> Result<Commit> {
+    // libgit2's repo.commit() cannot sign and would strip any existing signature.
+    // When commit.gpgsign is enabled, amend via the CLI so the reworded commit is
+    // re-signed instead of silently emitted unsigned.
+    if should_sign_commit(&path, None)? {
+        let output = crate::utils::create_command("git")
+            .current_dir(&path)
+            .args(["commit", "--amend", "-S", "-m", &message])
+            .output()
+            .map_err(|e| {
+                LeviathanError::OperationFailed(format!("Failed to run git commit --amend: {}", e))
+            })?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(LeviathanError::OperationFailed(format!(
+                "Git commit --amend failed: {}",
+                stderr.trim()
+            )));
+        }
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let head_commit = repo.head()?.peel_to_commit()?;
+        return Ok(Commit::from_git2(&head_commit));
+    }
+
     let repo = git2::Repository::open(Path::new(&path))?;
+
+    // git runs pre-commit/commit-msg/post-commit for `git commit --amend` too;
+    // the git2 amend path otherwise bypasses them.
+    crate::commands::hooks::run_hook_blocking(&repo, "pre-commit", &[], None)?;
+    let message = crate::commands::hooks::run_commit_msg_hook(&repo, &message)?;
 
     let head_commit = repo
         .head()?
@@ -432,6 +469,8 @@ pub async fn amend_commit_message(path: String, message: String) -> Result<Commi
         &tree,
         &parent_refs,
     )?;
+
+    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
 
     let new_commit = repo.find_commit(new_oid)?;
     Ok(Commit::from_git2(&new_commit))
@@ -471,6 +510,9 @@ pub async fn amend_commit(
 
     let repo = git2::Repository::open(Path::new(&path))?;
 
+    // git runs pre-commit for `git commit --amend`; the git2 path bypasses it.
+    crate::commands::hooks::run_hook_blocking(&repo, "pre-commit", &[], None)?;
+
     let head_commit = repo
         .head()?
         .peel_to_commit()
@@ -483,6 +525,8 @@ pub async fn amend_commit(
     // Use the new message or keep the original
     let commit_message =
         message.unwrap_or_else(|| head_commit.message().ok().unwrap_or("").to_string());
+    // commit-msg may veto or rewrite the (possibly reused) message.
+    let commit_message = crate::commands::hooks::run_commit_msg_hook(&repo, &commit_message)?;
 
     // Use new author if reset_author is true, otherwise keep original
     let author = if reset_author.unwrap_or(false) {
@@ -524,6 +568,8 @@ pub async fn amend_commit(
     } else {
         repo.set_head_detached(new_oid)?;
     }
+
+    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
 
     Ok(AmendResult {
         new_oid: new_oid.to_string(),
@@ -2128,5 +2174,176 @@ mod tests {
             1,
             "a revert commit keeps a single parent"
         );
+    }
+
+    // Finding 100: amend_commit_message must honor commit.gpgsign and re-sign the
+    // reworded commit rather than emit it unsigned (libgit2 cannot sign).
+    #[tokio::test]
+    async fn test_amend_commit_message_signs_when_gpgsign_enabled() {
+        let repo = TestRepo::with_initial_commit();
+
+        // Configure SSH signing; skip if ssh-keygen is unavailable.
+        let keydir = tempfile::TempDir::new().unwrap();
+        let key = keydir.path().join("id");
+        let gen = std::process::Command::new("ssh-keygen")
+            .args(["-t", "ed25519", "-N", "", "-f", key.to_str().unwrap(), "-q"])
+            .output();
+        if gen.map(|o| !o.status.success()).unwrap_or(true) {
+            return;
+        }
+        let pubkey = format!("{}.pub", key.to_str().unwrap());
+        for (k, v) in [
+            ("gpg.format", "ssh"),
+            ("user.signingkey", pubkey.as_str()),
+            ("commit.gpgsign", "true"),
+        ] {
+            std::process::Command::new("git")
+                .current_dir(&repo.path)
+                .args(["config", k, v])
+                .output()
+                .unwrap();
+        }
+
+        let commit = amend_commit_message(repo.path_str(), "Reworded and signed".to_string())
+            .await
+            .unwrap();
+        assert_eq!(commit.summary, "Reworded and signed");
+
+        // The reworded commit must carry a signature.
+        let git_repo = repo.repo();
+        let oid = git2::Oid::from_str(&commit.oid).unwrap();
+        assert!(
+            git_repo.extract_signature(&oid, None).is_ok(),
+            "amended commit must be signed when commit.gpgsign=true"
+        );
+    }
+
+    // ---- Hook parity (git2 commit path) ----
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_create_commit_pre_commit_hook_aborts() {
+        let repo = TestRepo::with_initial_commit();
+        let head_before = repo.head_oid();
+        repo.install_hook("pre-commit", "#!/bin/sh\necho blocked 1>&2\nexit 1\n");
+        repo.create_file("new.txt", "x");
+        repo.stage_file("new.txt");
+
+        let result = create_commit(
+            repo.path_str(),
+            "Should be blocked".to_string(),
+            None,
+            Some(false),
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(result.is_err(), "pre-commit exit 1 must abort the commit");
+        assert!(result.unwrap_err().to_string().contains("blocked"));
+        // HEAD must not have advanced.
+        assert_eq!(repo.head_oid(), head_before);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_create_commit_runs_post_commit_hook() {
+        let repo = TestRepo::with_initial_commit();
+        let marker = repo.path.join("post-commit-ran");
+        repo.install_hook(
+            "post-commit",
+            &format!("#!/bin/sh\ntouch \"{}\"\n", marker.display()),
+        );
+        repo.create_file("new.txt", "x");
+        repo.stage_file("new.txt");
+
+        let result = create_commit(
+            repo.path_str(),
+            "With post-commit".to_string(),
+            None,
+            Some(false),
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(result.is_ok());
+        assert!(marker.exists(), "post-commit hook must run after commit");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_create_commit_commit_msg_hook_rewrites() {
+        let repo = TestRepo::with_initial_commit();
+        repo.install_hook(
+            "commit-msg",
+            "#!/bin/sh\nprintf '\\nEdited-by: hook' >> \"$1\"\n",
+        );
+        repo.create_file("new.txt", "x");
+        repo.stage_file("new.txt");
+
+        let commit = create_commit(
+            repo.path_str(),
+            "Base message".to_string(),
+            None,
+            Some(false),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let full = get_commit_message(repo.path_str(), commit.oid)
+            .await
+            .unwrap();
+        assert!(
+            full.contains("Edited-by: hook"),
+            "commit-msg rewrite must be persisted, got: {full:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_amend_commit_pre_commit_hook_aborts() {
+        let repo = TestRepo::with_initial_commit();
+        let head_before = repo.head_oid();
+        repo.install_hook("pre-commit", "#!/bin/sh\nexit 1\n");
+
+        let result = amend_commit(
+            repo.path_str(),
+            Some("new msg".to_string()),
+            None,
+            Some(false),
+        )
+        .await;
+        assert!(result.is_err(), "amend must honor pre-commit");
+        assert_eq!(repo.head_oid(), head_before, "HEAD must not move");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_amend_commit_runs_post_commit_and_commit_msg_hooks() {
+        let repo = TestRepo::with_initial_commit();
+        let marker = repo.path.join("amend-post-commit");
+        repo.install_hook(
+            "post-commit",
+            &format!("#!/bin/sh\ntouch \"{}\"\n", marker.display()),
+        );
+        repo.install_hook("commit-msg", "#!/bin/sh\nprintf '\\ntrailer' >> \"$1\"\n");
+
+        let result = amend_commit(
+            repo.path_str(),
+            Some("Reworded".to_string()),
+            None,
+            Some(false),
+        )
+        .await
+        .unwrap();
+        assert!(marker.exists(), "post-commit must run on amend");
+        let full = get_commit_message(repo.path_str(), result.new_oid)
+            .await
+            .unwrap();
+        assert!(full.contains("trailer"), "commit-msg rewrite must persist");
     }
 }

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -79,6 +79,83 @@ fn run_git_config(repo_path: Option<&Path>, args: &[&str]) -> Result<String> {
     }
 }
 
+/// Run git config and return raw, *untrimmed* stdout.
+///
+/// Unlike [`run_git_config`], this does not trim the output — it is used for
+/// NUL-terminated (`--null`) parsing where records and values are delimited
+/// explicitly, so trimming would corrupt values with leading/trailing
+/// whitespace or newlines (e.g. multi-line shell aliases).
+fn run_git_config_raw(repo_path: Option<&Path>, args: &[&str]) -> Result<String> {
+    let mut cmd = create_command("git");
+
+    if let Some(path) = repo_path {
+        cmd.current_dir(path);
+    }
+
+    cmd.arg("config");
+    cmd.args(args);
+
+    let output = cmd
+        .output()
+        .map_err(|e| LeviathanError::OperationFailed(format!("Failed to run git config: {}", e)))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        // Exit code 1 with no output means "key/section not found" — a benign
+        // empty result for --get / --get-regexp / --list.
+        if output.status.code() == Some(1) && stderr.is_empty() {
+            Ok(String::new())
+        } else {
+            Err(LeviathanError::OperationFailed(if stderr.is_empty() {
+                "Failed to read git configuration".to_string()
+            } else {
+                stderr
+            }))
+        }
+    }
+}
+
+/// Run `git config ... --unset ...`, refusing when git reports a real failure.
+///
+/// A missing key (git exits 5 with no stderr) is treated as a benign no-op —
+/// clearing an already-empty field should succeed. Every other failure
+/// (multi-valued key, locked config, read-only file) is surfaced so the UI can
+/// show it, exactly as the git CLI refuses these operations instead of silently
+/// doing nothing.
+fn run_git_config_unset(repo_path: Option<&Path>, args: &[&str]) -> Result<()> {
+    let mut cmd = create_command("git");
+
+    if let Some(path) = repo_path {
+        cmd.current_dir(path);
+    }
+
+    cmd.arg("config");
+    cmd.args(args);
+
+    let output = cmd
+        .output()
+        .map_err(|e| LeviathanError::OperationFailed(format!("Failed to run git config: {}", e)))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    // Exit code 5 with empty stderr => the key does not exist; unsetting it is a
+    // no-op. A multi-valued key also exits 5, but with a warning on stderr.
+    if output.status.code() == Some(5) && stderr.is_empty() {
+        return Ok(());
+    }
+
+    Err(LeviathanError::OperationFailed(if stderr.is_empty() {
+        "Failed to unset git configuration value".to_string()
+    } else {
+        stderr
+    }))
+}
+
 /// Get a single config value
 #[command]
 pub async fn get_config_value(
@@ -137,9 +214,9 @@ pub async fn unset_config_value(
         "--local"
     };
 
-    // --unset might fail if the key doesn't exist, which is fine
-    let _ = run_git_config(repo_path, &[scope, "--unset", &key]);
-    Ok(())
+    // A missing key is a benign no-op; any other failure (e.g. a multi-valued
+    // key) is surfaced to the user instead of being silently swallowed.
+    run_git_config_unset(repo_path, &[scope, "--unset", &key])
 }
 
 /// Get all config entries from a specific scope
@@ -162,20 +239,22 @@ pub async fn get_config_list(
         "local"
     };
 
-    let result = run_git_config(repo_path, &[scope_arg, "--list"])?;
+    // Use NUL-terminated output so multi-line values (e.g. shell aliases) are
+    // preserved intact. Each record is `key\nvalue`, records separated by NUL.
+    let result = run_git_config_raw(repo_path, &[scope_arg, "--null", "--list"])?;
 
     let entries: Vec<ConfigEntry> = result
-        .lines()
-        .filter_map(|line| {
-            let parts: Vec<&str> = line.splitn(2, '=').collect();
-            if parts.len() == 2 {
-                Some(ConfigEntry {
-                    key: parts[0].to_string(),
-                    value: parts[1].to_string(),
-                    scope: scope_name.to_string(),
-                })
-            } else {
-                None
+        .split('\0')
+        .filter(|record| !record.is_empty())
+        .map(|record| {
+            let (key, value) = match record.split_once('\n') {
+                Some((k, v)) => (k.to_string(), v.to_string()),
+                None => (record.to_string(), String::new()),
+            };
+            ConfigEntry {
+                key,
+                value,
+                scope: scope_name.to_string(),
             }
         })
         .collect();
@@ -183,41 +262,43 @@ pub async fn get_config_list(
     Ok(entries)
 }
 
+/// Resolve the *effective* value of a config key with repository context,
+/// returning the value and whether it resolves from the global scope.
+///
+/// Runs `git config --show-scope --null --get <key>` with the repo as the
+/// working directory, so the result matches what commits actually use:
+/// libgit2's `repo.signature()` honours the file precedence
+/// (system → global → local → worktree) and conditional includes
+/// (`includeIf gitdir:`) that a bare `--global --get` (run without a working
+/// directory) silently ignores.
+fn read_effective_config(repo_path: &Path, key: &str) -> (Option<String>, String) {
+    let raw = run_git_config_raw(Some(repo_path), &["--show-scope", "--null", "--get", key])
+        .unwrap_or_default();
+    // Output format: `scope\0value` (with a trailing NUL).
+    let trimmed = raw.strip_suffix('\0').unwrap_or(raw.as_str());
+    match trimmed.split_once('\0') {
+        Some((scope, value)) if !value.is_empty() => (Some(value.to_string()), scope.to_string()),
+        _ => (None, String::new()),
+    }
+}
+
 /// Get user identity (name and email)
 #[command]
 pub async fn get_user_identity(path: String) -> Result<UserIdentity> {
     let repo_path = Path::new(&path);
 
-    // Get local values first
-    let local_name = run_git_config(Some(repo_path), &["--local", "--get", "user.name"]).ok();
-    let local_email = run_git_config(Some(repo_path), &["--local", "--get", "user.email"]).ok();
-
-    // Get global values
-    let global_name = run_git_config(None, &["--global", "--get", "user.name"]).ok();
-    let global_email = run_git_config(None, &["--global", "--get", "user.email"]).ok();
-
-    // Determine effective values and where they come from
-    let (name, name_is_global) = if let Some(n) = local_name.filter(|s| !s.is_empty()) {
-        (Some(n), false)
-    } else if let Some(n) = global_name.filter(|s| !s.is_empty()) {
-        (Some(n), true)
-    } else {
-        (None, false)
-    };
-
-    let (email, email_is_global) = if let Some(e) = local_email.filter(|s| !s.is_empty()) {
-        (Some(e), false)
-    } else if let Some(e) = global_email.filter(|s| !s.is_empty()) {
-        (Some(e), true)
-    } else {
-        (None, false)
-    };
+    // Resolve the effective identity the way libgit2 does when it signs a
+    // commit: with repository context, honouring system scope and conditional
+    // includes. This keeps the displayed identity in sync with the recorded
+    // commit author.
+    let (name, name_scope) = read_effective_config(repo_path, "user.name");
+    let (email, email_scope) = read_effective_config(repo_path, "user.email");
 
     Ok(UserIdentity {
         name,
         email,
-        name_is_global,
-        email_is_global,
+        name_is_global: name_scope == "global",
+        email_is_global: email_scope == "global",
     })
 }
 
@@ -239,7 +320,7 @@ pub async fn set_user_identity(
 
     if let Some(n) = name {
         if n.is_empty() {
-            let _ = run_git_config(repo_path, &[scope, "--unset", "user.name"]);
+            run_git_config_unset(repo_path, &[scope, "--unset", "user.name"])?;
         } else {
             run_git_config(repo_path, &[scope, "user.name", &n])?;
         }
@@ -247,7 +328,7 @@ pub async fn set_user_identity(
 
     if let Some(e) = email {
         if e.is_empty() {
-            let _ = run_git_config(repo_path, &[scope, "--unset", "user.email"]);
+            run_git_config_unset(repo_path, &[scope, "--unset", "user.email"])?;
         } else {
             run_git_config(repo_path, &[scope, "user.email", &e])?;
         }
@@ -261,58 +342,44 @@ pub async fn set_user_identity(
 pub async fn get_aliases(path: Option<String>) -> Result<Vec<GitAlias>> {
     let repo_path = path.as_ref().map(|p| Path::new(p.as_str()));
 
-    // Get global aliases
-    let global_result = run_git_config(None, &["--global", "--get-regexp", "^alias\\."])?;
-    let global_aliases: Vec<GitAlias> = global_result
-        .lines()
-        .filter_map(|line| {
-            let parts: Vec<&str> = line.splitn(2, ' ').collect();
-            if parts.len() == 2 && parts[0].starts_with("alias.") {
-                Some(GitAlias {
-                    name: parts[0]
-                        .strip_prefix("alias.")
-                        .unwrap_or(parts[0])
-                        .to_string(),
-                    command: parts[1].to_string(),
-                    is_global: true,
-                })
-            } else {
-                None
-            }
-        })
-        .collect();
+    // Resolve every alias across all scopes in one pass, with repository
+    // context so system-scope and conditional-include aliases are visible.
+    // `--show-scope --null` emits `scope\0key\nvalue` records in increasing
+    // precedence (system → global → local → worktree), so a later record for
+    // the same alias name overrides an earlier one — matching git's own
+    // effective resolution. NUL termination keeps multi-line alias bodies
+    // intact.
+    let raw = run_git_config_raw(
+        repo_path,
+        &["--show-scope", "--null", "--get-regexp", "^alias\\."],
+    )?;
 
-    // Get local aliases if repo path is provided
-    let mut all_aliases = global_aliases;
-
-    if repo_path.is_some() {
-        let local_result = run_git_config(repo_path, &["--local", "--get-regexp", "^alias\\."])
-            .unwrap_or_default();
-
-        for line in local_result.lines() {
-            let parts: Vec<&str> = line.splitn(2, ' ').collect();
-            if parts.len() == 2 && parts[0].starts_with("alias.") {
-                let name = parts[0]
-                    .strip_prefix("alias.")
-                    .unwrap_or(parts[0])
-                    .to_string();
-
-                // Check if we already have a global alias with this name
-                // If so, replace it with the local one
-                if let Some(idx) = all_aliases.iter().position(|a| a.name == name) {
-                    all_aliases[idx] = GitAlias {
-                        name,
-                        command: parts[1].to_string(),
-                        is_global: false,
-                    };
-                } else {
-                    all_aliases.push(GitAlias {
-                        name,
-                        command: parts[1].to_string(),
-                        is_global: false,
-                    });
-                }
-            }
+    let mut all_aliases: Vec<GitAlias> = Vec::new();
+    let mut fields = raw.split('\0');
+    while let Some(scope) = fields.next() {
+        if scope.is_empty() {
+            continue;
+        }
+        let Some(record) = fields.next() else {
+            break;
+        };
+        let (key, command) = match record.split_once('\n') {
+            Some((k, v)) => (k, v),
+            None => (record, ""),
+        };
+        let Some(name) = key.strip_prefix("alias.") else {
+            continue;
+        };
+        let alias = GitAlias {
+            name: name.to_string(),
+            command: command.to_string(),
+            is_global: scope == "global",
+        };
+        // Later (higher-precedence) scope wins for a duplicate alias name.
+        if let Some(idx) = all_aliases.iter().position(|a| a.name == alias.name) {
+            all_aliases[idx] = alias;
+        } else {
+            all_aliases.push(alias);
         }
     }
 
@@ -388,21 +455,15 @@ pub async fn get_common_settings(path: String) -> Result<Vec<ConfigEntry>> {
     let mut settings = Vec::new();
 
     for key in common_keys {
-        // Try local first, then global
-        let local_value = run_git_config(Some(repo_path), &["--local", "--get", key]).ok();
-        let global_value = run_git_config(None, &["--global", "--get", key]).ok();
-
-        if let Some(val) = local_value.filter(|s| !s.is_empty()) {
+        // Resolve the effective value with repository context so system-scope
+        // settings (e.g. core.autocrlf set by the Windows Git installer) and
+        // conditional includes are reflected, with their true scope.
+        let (value, scope) = read_effective_config(repo_path, key);
+        if let Some(val) = value {
             settings.push(ConfigEntry {
                 key: key.to_string(),
                 value: val,
-                scope: "local".to_string(),
-            });
-        } else if let Some(val) = global_value.filter(|s| !s.is_empty()) {
-            settings.push(ConfigEntry {
-                key: key.to_string(),
-                value: val,
-                scope: "global".to_string(),
+                scope,
             });
         }
     }
@@ -512,42 +573,29 @@ pub async fn set_git_config(
 #[command]
 pub async fn get_all_git_config(path: String) -> Result<Vec<GitConfig>> {
     let repo_path = Path::new(&path);
-    let result = run_git_config(Some(repo_path), &["--list", "--show-scope"])?;
+    // NUL-terminated output: `scope\0key\nvalue` records, so multi-line values
+    // (e.g. shell aliases) are preserved instead of spawning phantom entries.
+    let raw = run_git_config_raw(Some(repo_path), &["--show-scope", "--null", "--list"])?;
 
-    let entries: Vec<GitConfig> = result
-        .lines()
-        .filter_map(|line| {
-            // Format: "scope\tkey=value" or "scope key=value"
-            // git config --show-scope outputs: "local   key=value" (tab-separated)
-            let (scope, rest) = if let Some(idx) = line.find('\t') {
-                (&line[..idx], &line[idx + 1..])
-            } else {
-                // Fallback: try splitting on first space
-                let parts: Vec<&str> = line.splitn(2, ' ').collect();
-                if parts.len() == 2 {
-                    (parts[0], parts[1])
-                } else {
-                    return None;
-                }
-            };
-
-            let kv_parts: Vec<&str> = rest.splitn(2, '=').collect();
-            if kv_parts.len() == 2 {
-                Some(GitConfig {
-                    key: kv_parts[0].to_string(),
-                    value: kv_parts[1].to_string(),
-                    scope: scope.trim().to_string(),
-                })
-            } else {
-                // Key with no value
-                Some(GitConfig {
-                    key: rest.to_string(),
-                    value: String::new(),
-                    scope: scope.trim().to_string(),
-                })
-            }
-        })
-        .collect();
+    let mut entries: Vec<GitConfig> = Vec::new();
+    let mut fields = raw.split('\0');
+    while let Some(scope) = fields.next() {
+        if scope.is_empty() {
+            continue;
+        }
+        let Some(record) = fields.next() else {
+            break;
+        };
+        let (key, value) = match record.split_once('\n') {
+            Some((k, v)) => (k.to_string(), v.to_string()),
+            None => (record.to_string(), String::new()),
+        };
+        entries.push(GitConfig {
+            key,
+            value,
+            scope: scope.to_string(),
+        });
+    }
 
     Ok(entries)
 }
@@ -557,13 +605,13 @@ pub async fn get_all_git_config(path: String) -> Result<Vec<GitConfig>> {
 pub async fn unset_git_config(path: String, key: String, global: Option<bool>) -> Result<()> {
     let repo_path = Path::new(&path);
 
+    // A missing key is a benign no-op; any other failure (e.g. a multi-valued
+    // key) is surfaced to the user rather than silently swallowed.
     if global.unwrap_or(false) {
-        let _ = run_git_config(Some(repo_path), &["--global", "--unset", &key]);
+        run_git_config_unset(Some(repo_path), &["--global", "--unset", &key])
     } else {
-        let _ = run_git_config(Some(repo_path), &["--unset", &key]);
+        run_git_config_unset(Some(repo_path), &["--unset", &key])
     }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -698,5 +746,164 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(val2, None);
+    }
+
+    // --- Finding 3: multi-line config values must be preserved ---
+
+    const MULTILINE_ALIAS: &str = "!f() {\n  git push -u origin HEAD\n}\nf";
+
+    fn set_local_config(repo: &TestRepo, key: &str, value: &str) {
+        let r = repo.repo();
+        let mut cfg = r.config().expect("config");
+        cfg.set_str(key, value).expect("set config value");
+    }
+
+    #[tokio::test]
+    async fn test_get_aliases_preserves_multiline_value() {
+        let repo = TestRepo::with_initial_commit();
+        set_local_config(&repo, "alias.publish", MULTILINE_ALIAS);
+
+        let aliases = get_aliases(Some(repo.path_str())).await.unwrap();
+        let publish = aliases
+            .iter()
+            .find(|a| a.name == "publish")
+            .expect("publish alias present");
+        assert_eq!(publish.command, MULTILINE_ALIAS);
+        assert!(!publish.is_global);
+    }
+
+    #[tokio::test]
+    async fn test_get_all_git_config_preserves_multiline_value() {
+        let repo = TestRepo::with_initial_commit();
+        set_local_config(&repo, "alias.publish", MULTILINE_ALIAS);
+
+        let entries = get_all_git_config(repo.path_str()).await.unwrap();
+        let entry = entries
+            .iter()
+            .find(|e| e.key == "alias.publish")
+            .expect("alias.publish present");
+        assert_eq!(entry.value, MULTILINE_ALIAS);
+        assert_eq!(entry.scope, "local");
+        // No phantom entries: only the real alias carries the multi-line body.
+        assert!(entries
+            .iter()
+            .all(|e| e.key == "alias.publish" || !e.value.contains('\n')));
+    }
+
+    #[tokio::test]
+    async fn test_get_config_list_preserves_multiline_value() {
+        let repo = TestRepo::with_initial_commit();
+        set_local_config(&repo, "alias.publish", MULTILINE_ALIAS);
+
+        let entries = get_config_list(Some(repo.path_str()), Some(false))
+            .await
+            .unwrap();
+        let entry = entries
+            .iter()
+            .find(|e| e.key == "alias.publish")
+            .expect("alias.publish present");
+        assert_eq!(entry.value, MULTILINE_ALIAS);
+    }
+
+    // --- Finding 1: identity/settings must reflect the effective value ---
+
+    #[tokio::test]
+    async fn test_get_user_identity_follows_includes() {
+        // The effective identity libgit2 uses for commits honours included
+        // config files; a bare `--local --get` does not. get_user_identity must
+        // report the value commits are actually recorded with.
+        let repo = TestRepo::new();
+        let extra = repo.path.join("extra.cfg");
+        std::fs::write(&extra, "[user]\n\temail = included@example.com\n").unwrap();
+        {
+            let r = repo.repo();
+            let mut cfg = r.config().unwrap();
+            // Drop the direct email so the effective value comes from the include.
+            let _ = cfg.remove("user.email");
+            cfg.set_str("include.path", extra.to_str().unwrap())
+                .unwrap();
+        }
+
+        let identity = get_user_identity(repo.path_str()).await.unwrap();
+        assert_eq!(identity.email.as_deref(), Some("included@example.com"));
+    }
+
+    #[tokio::test]
+    async fn test_get_common_settings_reads_included_value() {
+        let repo = TestRepo::new();
+        let extra = repo.path.join("extra.cfg");
+        std::fs::write(&extra, "[core]\n\tautocrlf = input\n").unwrap();
+        set_local_config(&repo, "include.path", extra.to_str().unwrap());
+
+        let settings = get_common_settings(repo.path_str()).await.unwrap();
+        let autocrlf = settings
+            .iter()
+            .find(|e| e.key == "core.autocrlf")
+            .expect("core.autocrlf present via include");
+        assert_eq!(autocrlf.value, "input");
+    }
+
+    // --- Finding 5: unset must refuse on real failures, not report success ---
+
+    #[tokio::test]
+    async fn test_unset_config_value_multivalue_errors() {
+        let repo = TestRepo::new();
+        {
+            let r = repo.repo();
+            let mut cfg = r.config().unwrap();
+            // Add two values for the same key.
+            cfg.set_multivar("test.multi", "^nomatch$", "one").unwrap();
+            cfg.set_multivar("test.multi", "^nomatch$", "two").unwrap();
+        }
+
+        let result =
+            unset_config_value(Some(repo.path_str()), "test.multi".to_string(), Some(false)).await;
+        assert!(
+            result.is_err(),
+            "unsetting a multi-valued key must fail like git, not silently succeed"
+        );
+
+        // Both values are still present — nothing was destroyed.
+        let raw = run_git_config_raw(Some(&repo.path), &["--get-all", "test.multi"]).unwrap();
+        assert!(raw.contains("one") && raw.contains("two"));
+    }
+
+    #[tokio::test]
+    async fn test_set_user_identity_clear_multivalue_email_errors() {
+        let repo = TestRepo::new();
+        {
+            let r = repo.repo();
+            let mut cfg = r.config().unwrap();
+            cfg.set_multivar("user.email", "^nomatch$", "second@example.com")
+                .unwrap();
+        }
+
+        // Clearing the email field must refuse when the key is multi-valued.
+        let result = set_user_identity(
+            Some(repo.path_str()),
+            None,
+            Some(String::new()),
+            Some(false),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "clearing a multi-valued user.email must fail, matching git"
+        );
+
+        let raw = run_git_config_raw(Some(&repo.path), &["--get-all", "user.email"]).unwrap();
+        assert!(raw.contains("second@example.com"));
+    }
+
+    #[tokio::test]
+    async fn test_unset_config_value_missing_key_is_noop() {
+        let repo = TestRepo::with_initial_commit();
+        let result = unset_config_value(
+            Some(repo.path_str()),
+            "nonexistent.key".to_string(),
+            Some(false),
+        )
+        .await;
+        assert!(result.is_ok(), "clearing an absent key is a benign no-op");
     }
 }

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -50,81 +50,37 @@ fn apply_diff_options(
     }
 }
 
-/// Check if a file extension indicates a known text file type.
-/// This is used to override git's binary detection for common text formats
-/// that may be incorrectly flagged as binary (e.g., UTF-16 encoded JSON).
-fn is_known_text_extension(path: &str) -> bool {
-    let path_lower = path.to_lowercase();
-    let text_extensions = [
-        ".json",
-        ".txt",
-        ".md",
-        ".markdown",
-        ".xml",
-        ".yaml",
-        ".yml",
-        ".toml",
-        ".html",
-        ".htm",
-        ".css",
-        ".scss",
-        ".sass",
-        ".less",
-        ".js",
-        ".jsx",
-        ".ts",
-        ".tsx",
-        ".mjs",
-        ".cjs",
-        ".rs",
-        ".py",
-        ".rb",
-        ".java",
-        ".kt",
-        ".scala",
-        ".go",
-        ".c",
-        ".cpp",
-        ".h",
-        ".hpp",
-        ".cs",
-        ".fs",
-        ".vb",
-        ".swift",
-        ".m",
-        ".mm",
-        ".sh",
-        ".bash",
-        ".zsh",
-        ".fish",
-        ".ps1",
-        ".bat",
-        ".cmd",
-        ".sql",
-        ".graphql",
-        ".gql",
-        ".env",
-        ".ini",
-        ".cfg",
-        ".conf",
-        ".config",
-        ".gitignore",
-        ".gitattributes",
-        ".editorconfig",
-        ".dockerfile",
-        ".containerfile",
-        ".tf",
-        ".tfvars",
-        ".hcl",
-        ".vue",
-        ".svelte",
-        ".astro",
-        ".csv",
-        ".tsv",
-        ".log",
-    ];
-    text_extensions.iter().any(|ext| path_lower.ends_with(ext))
+/// Resolve the HEAD tree, tolerating an unborn HEAD (a repository with no
+/// commits yet). Returns `None` when HEAD is unborn/missing so callers can diff
+/// against the empty tree, exactly as `git diff --cached` does before the first
+/// commit.
+fn head_tree_opt(repo: &git2::Repository) -> Result<Option<git2::Tree<'_>>> {
+    match repo.head() {
+        Ok(head) => Ok(Some(head.peel_to_tree()?)),
+        Err(e)
+            if e.code() == git2::ErrorCode::UnbornBranch
+                || e.code() == git2::ErrorCode::NotFound =>
+        {
+            Ok(None)
+        }
+        Err(e) => Err(e.into()),
+    }
 }
+
+/// Enable rename detection on a diff, mirroring git's default `diff.renames`
+/// (on by default since git 2.9). Without this, libgit2 reports a rename as a
+/// delete + add pair and never yields `Delta::Renamed`.
+fn detect_renames(diff: &mut git2::Diff) -> Result<()> {
+    let mut find_opts = git2::DiffFindOptions::new();
+    find_opts.renames(true);
+    diff.find_similar(Some(&mut find_opts))?;
+    Ok(())
+}
+
+// NOTE: git's binary detection is now reported faithfully. The former
+// `is_known_text_extension` override faked `is_binary = false` for
+// text-extension files that libgit2 flagged binary (e.g. UTF-16 JSON),
+// which produced an empty, non-binary diff with no indication.
 
 /// Get diff for all changed files
 #[command]
@@ -136,7 +92,7 @@ pub async fn get_diff(
 ) -> Result<Vec<DiffFile>> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
-    let diff = if let Some(ref commit_oid) = commit {
+    let mut diff = if let Some(ref commit_oid) = commit {
         // Diff between two commits or commit and parent
         let commit = repo.find_commit(git2::Oid::from_str(commit_oid)?)?;
 
@@ -149,13 +105,16 @@ pub async fn get_diff(
             repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?
         }
     } else if staged.unwrap_or(false) {
-        // Staged changes (index vs HEAD)
-        let head = repo.head()?.peel_to_tree()?;
-        repo.diff_tree_to_index(Some(&head), None, None)?
+        // Staged changes (index vs HEAD, or the empty tree on an unborn HEAD)
+        let head_tree = head_tree_opt(&repo)?;
+        repo.diff_tree_to_index(head_tree.as_ref(), None, None)?
     } else {
         // Unstaged changes (working directory vs index)
         repo.diff_index_to_workdir(None, None)?
     };
+
+    // Detect renames/copies (git's default) so a move is one entry, not add+del.
+    detect_renames(&mut diff)?;
 
     parse_diff(&diff)
 }
@@ -208,7 +167,7 @@ pub async fn get_diff_with_options(
         opts.show_untracked_content(true);
     }
 
-    let diff = if let Some(ref commit_oid) = commit {
+    let mut diff = if let Some(ref commit_oid) = commit {
         // Diff between two commits or commit and parent
         let commit_obj = repo.find_commit(git2::Oid::from_str(commit_oid)?)?;
 
@@ -229,13 +188,15 @@ pub async fn get_diff_with_options(
             )?
         }
     } else if staged.unwrap_or(false) {
-        // Staged changes (index vs HEAD)
-        let head = repo.head()?.peel_to_tree()?;
-        repo.diff_tree_to_index(Some(&head), None, Some(&mut opts))?
+        // Staged changes (index vs HEAD, or the empty tree on an unborn HEAD)
+        let head_tree = head_tree_opt(&repo)?;
+        repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut opts))?
     } else {
         // Unstaged changes (working directory vs index)
         repo.diff_index_to_workdir(None, Some(&mut opts))?
     };
+
+    detect_renames(&mut diff)?;
 
     let files = parse_diff(&diff)?;
     Ok(files
@@ -266,14 +227,16 @@ pub async fn get_file_diff(
 
     let is_staged = staged.unwrap_or(false);
 
-    let diff = if is_staged {
-        // Staged changes: compare HEAD to index
-        let head = repo.head()?.peel_to_tree()?;
-        repo.diff_tree_to_index(Some(&head), None, Some(&mut opts))?
+    let mut diff = if is_staged {
+        // Staged changes: compare HEAD to index (empty tree on an unborn HEAD)
+        let head_tree = head_tree_opt(&repo)?;
+        repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut opts))?
     } else {
         // Unstaged changes: compare index to workdir
         repo.diff_index_to_workdir(None, Some(&mut opts))?
     };
+
+    detect_renames(&mut diff)?;
 
     let files = parse_diff(&diff)?;
 
@@ -291,12 +254,14 @@ pub async fn get_file_diff(
     fallback_opts.recurse_untracked_dirs(true);
     fallback_opts.show_untracked_content(true);
 
-    let fallback_diff = if is_staged {
-        let head = repo.head()?.peel_to_tree()?;
-        repo.diff_tree_to_index(Some(&head), None, Some(&mut fallback_opts))?
+    let mut fallback_diff = if is_staged {
+        let head_tree = head_tree_opt(&repo)?;
+        repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut fallback_opts))?
     } else {
         repo.diff_index_to_workdir(None, Some(&mut fallback_opts))?
     };
+
+    detect_renames(&mut fallback_diff)?;
 
     let all_files = parse_diff(&fallback_diff)?;
 
@@ -305,41 +270,16 @@ pub async fn get_file_diff(
         return Ok(maybe_truncate_diff(file.clone(), max_lines));
     }
 
-    // Try case-insensitive match
+    // Try case-insensitive match (handles case-sensitivity mismatches on
+    // Windows). We deliberately do NOT fall back to a filename-suffix match or
+    // to the opposite staging area: `git diff [--cached] -- <path>` is strict
+    // about the path and never substitutes a different file's diff. Doing so
+    // here previously returned an unrelated file (e.g. vendor/foo.c for a
+    // request of src/foo.c) or presented staged hunks as unstaged.
     if let Some(file) = all_files
         .iter()
         .find(|f| f.path.eq_ignore_ascii_case(&normalized_file_path))
     {
-        return Ok(maybe_truncate_diff(file.clone(), max_lines));
-    }
-
-    // Try matching by filename only (handles path prefix mismatches)
-    let filename = normalized_file_path
-        .rsplit('/')
-        .next()
-        .unwrap_or(&normalized_file_path);
-    if let Some(file) = all_files
-        .iter()
-        .find(|f| f.path.ends_with(filename) || f.path.eq_ignore_ascii_case(filename))
-    {
-        return Ok(maybe_truncate_diff(file.clone(), max_lines));
-    }
-
-    // Try the opposite staging state as fallback
-    // (sometimes a file shows in status but diff is in the other state)
-    let opposite_diff = if is_staged {
-        repo.diff_index_to_workdir(None, Some(&mut fallback_opts))?
-    } else {
-        let head = repo.head()?.peel_to_tree()?;
-        repo.diff_tree_to_index(Some(&head), None, Some(&mut fallback_opts))?
-    };
-
-    let opposite_files = parse_diff(&opposite_diff)?;
-    if let Some(file) = opposite_files.iter().find(|f| {
-        f.path == normalized_file_path
-            || f.path.eq_ignore_ascii_case(&normalized_file_path)
-            || f.path.ends_with(filename)
-    }) {
         return Ok(maybe_truncate_diff(file.clone(), max_lines));
     }
 
@@ -514,9 +454,10 @@ fn parse_diff(diff: &git2::Diff) -> Result<Vec<DiffFile>> {
 
             let is_image = is_image_file(&file_path);
             let image_type = get_image_type(&file_path);
-            // Override binary detection for known text file extensions
-            // (git may flag UTF-16 or files with long lines as binary)
-            let is_binary = delta.flags().is_binary() && !is_known_text_extension(&file_path);
+            // Report git's binary status faithfully. libgit2 may only set the
+            // binary flag on a later callback (after inspecting the blob), so
+            // this is refreshed below for existing entries too.
+            let is_binary = delta.flags().is_binary();
 
             files.push(DiffFile {
                 path: file_path.clone(),
@@ -539,6 +480,13 @@ fn parse_diff(diff: &git2::Diff) -> Result<Vec<DiffFile>> {
                 .last_mut()
                 .expect("files vec must be non-empty after push")
         };
+
+        // The binary flag may only be raised on a later callback for this
+        // file (once libgit2 has loaded the blob), so keep it current. This
+        // prevents a binary file from being rendered as an empty text diff.
+        if delta.flags().is_binary() {
+            file_entry.is_binary = true;
+        }
 
         // Handle hunk header
         if let Some(hunk) = hunk {
@@ -591,6 +539,8 @@ fn parse_diff(diff: &git2::Diff) -> Result<Vec<DiffFile>> {
 #[serde(rename_all = "camelCase")]
 pub struct CommitFileEntry {
     pub path: String,
+    /// For a renamed/copied file, the previous path; `None` otherwise.
+    pub old_path: Option<String>,
     pub status: FileStatus,
     pub additions: usize,
     pub deletions: usize,
@@ -606,7 +556,11 @@ pub async fn get_commit_files(path: String, commit_oid: String) -> Result<Vec<Co
     let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
     let commit_tree = commit.tree()?;
 
-    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)?;
+    let mut diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)?;
+
+    // Detect renames/copies (git's default) so a moved file is a single
+    // "renamed" entry instead of a delete + add pair.
+    detect_renames(&mut diff)?;
 
     // First pass: collect file info
     let mut files: Vec<CommitFileEntry> = Vec::new();
@@ -628,8 +582,18 @@ pub async fn get_commit_files(path: String, commit_oid: String) -> Result<Vec<Co
             _ => FileStatus::Modified,
         };
 
+        // Surface the previous path for renames/copies so the UI can show it.
+        let old_path = match delta.status() {
+            git2::Delta::Renamed | git2::Delta::Copied => delta
+                .old_file()
+                .path()
+                .map(|p| p.to_string_lossy().to_string()),
+            _ => None,
+        };
+
         files.push(CommitFileEntry {
             path: file_path,
+            old_path,
             status,
             additions: 0,
             deletions: 0,
@@ -702,13 +666,21 @@ pub async fn get_commits_stats(path: String, commit_oids: Vec<String>) -> Result
             }
         };
 
-        let diff = match repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None) {
+        let mut diff = match repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)
+        {
             Ok(d) => d,
             Err(_) => {
                 skipped_diff += 1;
                 continue;
             }
         };
+
+        // Detect renames so a pure rename reports 0/0 like git, rather than
+        // over-counting the full file as +N/-N (delete + add).
+        if detect_renames(&mut diff).is_err() {
+            skipped_diff += 1;
+            continue;
+        }
 
         let (additions, deletions, files_changed) = match diff.stats() {
             Ok(s) => (s.insertions(), s.deletions(), s.files_changed()),
@@ -772,7 +744,10 @@ pub async fn get_commit_file_diff(
     let mut opts = git2::DiffOptions::new();
     opts.pathspec(&file_path);
 
-    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), Some(&mut opts))?;
+    let mut diff =
+        repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), Some(&mut opts))?;
+
+    detect_renames(&mut diff)?;
 
     let files = parse_diff(&diff)?;
     files
@@ -858,6 +833,18 @@ pub async fn get_file_blame(
         std::fs::read_to_string(full_path).unwrap_or_default()
     };
 
+    // For a working-tree blame (no explicit commit), libgit2 blamed the file
+    // as of HEAD, which misaligns with a modified working copy. Reconcile the
+    // committed blame with the actual working-tree buffer so inserted/deleted
+    // lines stay aligned and uncommitted lines are attributed to the zero OID
+    // (git's "Not Committed Yet"). libgit2 has no direct working-tree blame.
+    let buffer_blame = if commit_oid.is_none() {
+        Some(blame.blame_buffer(file_content.as_bytes())?)
+    } else {
+        None
+    };
+    let active_blame = buffer_blame.as_ref().unwrap_or(&blame);
+
     let content_lines: Vec<&str> = file_content.lines().collect();
     let total_lines = content_lines.len() as u32;
 
@@ -879,9 +866,26 @@ pub async fn get_file_blame(
     {
         let line_num = i + 1;
 
-        if let Some(hunk) = blame.get_line(line_num) {
+        if let Some(hunk) = active_blame.get_line(line_num) {
             let commit_id = hunk.final_commit_id();
             let short_id = commit_id.to_string()[..7].to_string();
+
+            // A zero OID means the line differs from HEAD, i.e. it is not yet
+            // committed (git shows "Not Committed Yet").
+            if commit_id.is_zero() {
+                lines.push(BlameLine {
+                    line_number: line_num,
+                    content: line_content.to_string(),
+                    commit_oid: commit_id.to_string(),
+                    commit_short_id: short_id,
+                    author_name: "Not Committed Yet".to_string(),
+                    author_email: String::new(),
+                    timestamp: 0,
+                    summary: String::new(),
+                    is_boundary: hunk.is_boundary(),
+                });
+                continue;
+            }
 
             // Get commit details
             let (author_name, author_email, timestamp, summary) =
@@ -1484,20 +1488,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_is_known_text_extension() {
-        assert!(is_known_text_extension("file.json"));
-        assert!(is_known_text_extension("file.txt"));
-        assert!(is_known_text_extension("file.rs"));
-        assert!(is_known_text_extension("file.py"));
-        assert!(is_known_text_extension("file.ts"));
-        assert!(is_known_text_extension("file.tsx"));
-        assert!(is_known_text_extension("FILE.JSON")); // case insensitive
-        assert!(!is_known_text_extension("file.exe"));
-        assert!(!is_known_text_extension("file.dll"));
-        assert!(!is_known_text_extension("file"));
-    }
-
-    #[tokio::test]
     async fn test_get_diff_new_untracked_file() {
         let repo = TestRepo::with_initial_commit();
 
@@ -2067,5 +2057,202 @@ mod tests {
         assert!(out.hunks.is_empty(), "partial hunk must never be included");
         assert_eq!(out.truncated, Some(true));
         assert_eq!(out.total_lines, Some(100));
+    }
+
+    /// Commit a single renamed file (delete old + add identical new content).
+    fn commit_rename(repo: &TestRepo, old: &str, new: &str, content: &str) -> git2::Oid {
+        repo.create_file(new, content);
+        std::fs::remove_file(repo.path.join(old)).unwrap();
+        let git = repo.repo();
+        let mut index = git.index().unwrap();
+        index.remove_path(Path::new(old)).unwrap();
+        index.add_path(Path::new(new)).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = git.find_tree(tree_oid).unwrap();
+        let sig = git.signature().unwrap();
+        let parent = git.head().unwrap().peel_to_commit().unwrap();
+        git.commit(Some("HEAD"), &sig, &sig, "rename", &tree, &[&parent])
+            .unwrap()
+    }
+
+    /// Finding 61: a committed rename must be one "renamed" entry with 0/0
+    /// stats, not a delete + add pair, matching `git show --name-status`.
+    #[tokio::test]
+    async fn test_get_commit_files_detects_rename() {
+        let repo = TestRepo::with_initial_commit();
+        let content = "line1\nline2\nline3\nline4\nline5\n";
+        repo.create_commit("add", &[("file_a.txt", content)]);
+        let oid = commit_rename(&repo, "file_a.txt", "file_b.txt", content);
+
+        let files = get_commit_files(repo.path_str(), oid.to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(files.len(), 1, "rename must be a single entry, not add+del");
+        assert_eq!(files[0].status, FileStatus::Renamed);
+        assert_eq!(files[0].path, "file_b.txt");
+        assert_eq!(files[0].old_path.as_deref(), Some("file_a.txt"));
+        assert_eq!(files[0].additions, 0, "pure rename has 0 insertions");
+        assert_eq!(files[0].deletions, 0, "pure rename has 0 deletions");
+    }
+
+    /// Finding 61: get_commits_stats must report 0/0/1 for a pure rename.
+    #[tokio::test]
+    async fn test_get_commits_stats_rename_is_zero() {
+        let repo = TestRepo::with_initial_commit();
+        let content = "alpha\nbeta\ngamma\ndelta\nepsilon\n";
+        repo.create_commit("add", &[("orig.txt", content)]);
+        let oid = commit_rename(&repo, "orig.txt", "moved.txt", content);
+
+        let stats = get_commits_stats(repo.path_str(), vec![oid.to_string()])
+            .await
+            .unwrap();
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats[0].additions, 0);
+        assert_eq!(stats[0].deletions, 0);
+        assert_eq!(stats[0].files_changed, 1);
+    }
+
+    /// Finding 62: a working-tree blame with an uncommitted inserted line must
+    /// attribute that line to "Not Committed Yet" and keep the rest aligned.
+    #[tokio::test]
+    async fn test_get_file_blame_working_tree_uncommitted_line() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("add", &[("f.txt", "alpha\nbeta\ngamma\n")]);
+
+        // Insert a new line at the top of the working copy only.
+        repo.create_file("f.txt", "NEWLINE\nalpha\nbeta\ngamma\n");
+
+        let result = get_file_blame(repo.path_str(), "f.txt".to_string(), None, None, None)
+            .await
+            .unwrap();
+
+        // All four working-tree lines must be present (no trailing drop).
+        assert_eq!(result.lines.len(), 4);
+        assert_eq!(result.lines[0].content, "NEWLINE");
+        assert_eq!(result.lines[0].author_name, "Not Committed Yet");
+        assert_eq!(result.lines[0].commit_oid, "0".repeat(40));
+        // Existing lines keep their real attribution, correctly aligned.
+        assert_eq!(result.lines[1].content, "alpha");
+        assert_ne!(result.lines[1].commit_oid, "0".repeat(40));
+        assert_eq!(result.lines[3].content, "gamma");
+        assert_ne!(result.lines[3].commit_oid, "0".repeat(40));
+    }
+
+    /// Finding 63: staged diff of the first file in a repo with no commits
+    /// (unborn HEAD) must succeed against the empty tree, like `git diff --cached`.
+    #[tokio::test]
+    async fn test_get_file_diff_staged_unborn_head() {
+        let repo = TestRepo::new(); // no initial commit -> unborn HEAD
+        repo.create_file("first.txt", "hello\nworld\n");
+        repo.stage_file("first.txt");
+
+        let result =
+            get_file_diff(repo.path_str(), "first.txt".to_string(), Some(true), None).await;
+        assert!(
+            result.is_ok(),
+            "staged diff on unborn HEAD should succeed: {:?}",
+            result.err()
+        );
+        let f = result.unwrap();
+        assert_eq!(f.path, "first.txt");
+        assert_eq!(f.status, FileStatus::New);
+        assert!(f.additions >= 2);
+    }
+
+    /// Finding 63: get_diff staged also works on an unborn HEAD.
+    #[tokio::test]
+    async fn test_get_diff_staged_unborn_head() {
+        let repo = TestRepo::new();
+        repo.create_file("first.txt", "content\n");
+        repo.stage_file("first.txt");
+
+        let result = get_diff(repo.path_str(), Some(true), None, None).await;
+        assert!(
+            result.is_ok(),
+            "unborn HEAD staged diff: {:?}",
+            result.err()
+        );
+        let files = result.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "first.txt");
+        assert_eq!(files[0].status, FileStatus::New);
+    }
+
+    /// Finding 66: a UTF-16 file that git flags binary must be reported as
+    /// binary (git's default), not as an empty non-binary diff.
+    #[tokio::test]
+    async fn test_utf16_file_reported_as_binary() {
+        let repo = TestRepo::with_initial_commit();
+
+        // UTF-16LE bytes for {"a":2} (with BOM), committed.
+        let to_utf16le = |s: &str| -> Vec<u8> {
+            let mut v = vec![0xFF, 0xFE];
+            for u in s.encode_utf16() {
+                v.extend_from_slice(&u.to_le_bytes());
+            }
+            v
+        };
+        let git = repo.repo();
+        std::fs::write(repo.path.join("data.json"), to_utf16le("{\"a\":2}")).unwrap();
+        let mut index = git.index().unwrap();
+        index.add_path(Path::new("data.json")).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = git.find_tree(tree_oid).unwrap();
+        let sig = git.signature().unwrap();
+        let parent = git.head().unwrap().peel_to_commit().unwrap();
+        git.commit(Some("HEAD"), &sig, &sig, "add utf16", &tree, &[&parent])
+            .unwrap();
+
+        // Modify the working copy.
+        std::fs::write(repo.path.join("data.json"), to_utf16le("{\"a\":3}")).unwrap();
+
+        let result = get_file_diff(repo.path_str(), "data.json".to_string(), Some(false), None)
+            .await
+            .unwrap();
+        assert!(
+            result.is_binary,
+            "UTF-16 file must be reported as binary, not an empty text diff"
+        );
+    }
+
+    /// Finding 67: requesting the diff of an unchanged path must not substitute
+    /// another file that merely shares a basename.
+    #[tokio::test]
+    async fn test_get_file_diff_no_basename_substitution() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit(
+            "add",
+            &[("vendor/foo.c", "a\nb\nc\n"), ("src/foo.c", "x\ny\nz\n")],
+        );
+        // Only vendor/foo.c is modified.
+        repo.create_file("vendor/foo.c", "a\nb\nMODIFIED\n");
+
+        // Requesting the unchanged src/foo.c must NOT return vendor/foo.c's diff.
+        let result =
+            get_file_diff(repo.path_str(), "src/foo.c".to_string(), Some(false), None).await;
+        assert!(
+            result.is_err(),
+            "unchanged src/foo.c must not resolve to vendor/foo.c's diff"
+        );
+    }
+
+    /// Finding 67: the unstaged diff of a fully-staged file must not return the
+    /// staged hunks (the opposite staging area).
+    #[tokio::test]
+    async fn test_get_file_diff_unstaged_does_not_return_staged() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("base", &[("f.txt", "base\n")]);
+        // Stage a change; working tree == index (no unstaged change).
+        repo.create_file("f.txt", "staged change\n");
+        repo.stage_file("f.txt");
+
+        let result = get_file_diff(repo.path_str(), "f.txt".to_string(), Some(false), None).await;
+        assert!(
+            result.is_err(),
+            "unstaged diff of a fully-staged file must not surface the staged hunks"
+        );
     }
 }

--- a/src-tauri/src/commands/difftool.rs
+++ b/src-tauri/src/commands/difftool.rs
@@ -257,8 +257,26 @@ pub async fn launch_diff_tool(
 
     // Determine what to diff
     if let Some(ref commit_oid) = commit {
-        // Diff against a specific commit
-        cmd.arg(commit_oid);
+        // Show the change introduced BY this commit (parent vs commit), which
+        // matches the in-app commit diff view. `git difftool <commit>` alone
+        // would compare the commit against the current working tree instead.
+        let has_parent = git2::Repository::open(repo_path)
+            .ok()
+            .and_then(|r| {
+                let oid = git2::Oid::from_str(commit_oid).ok()?;
+                let c = r.find_commit(oid).ok()?;
+                Some(c.parent_count() > 0)
+            })
+            .unwrap_or(true);
+
+        if has_parent {
+            cmd.arg(format!("{}^", commit_oid));
+            cmd.arg(commit_oid);
+        } else {
+            // Root (parentless) commit: diff against the empty tree.
+            cmd.arg("4b825dc642cb6eb9a060e54bf8d69288fbee4904");
+            cmd.arg(commit_oid);
+        }
     } else if staged.unwrap_or(false) {
         // Diff staged changes (index vs HEAD)
         cmd.arg("--staged");
@@ -395,6 +413,54 @@ mod tests {
             launch_diff_tool(repo.path_str(), "nonexistent.txt".to_string(), None, None).await;
         // Git difftool should handle this gracefully
         assert!(result.is_ok());
+    }
+
+    /// Finding 60: launching the diff tool for a commit's file must show the
+    /// change introduced BY the commit (parent vs commit), NOT commit vs the
+    /// current working tree.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_launch_diff_tool_commit_shows_parent_vs_commit() {
+        let repo = TestRepo::new();
+        // C1: f.txt = v1
+        repo.create_commit("c1", &[("f.txt", "v1\n")]);
+        // C2: f.txt = v2
+        let c2 = repo.create_commit("c2", &[("f.txt", "v2\n")]);
+        // Worktree edited to something different entirely.
+        repo.create_file("f.txt", "worktree-version\n");
+
+        // Capture dir for the mock diff tool to record LEFT/RIGHT.
+        let capture = repo.path.join("capture");
+        std::fs::create_dir_all(&capture).unwrap();
+        let cmd = format!(
+            "cp \"$LOCAL\" '{}/left.txt'; cp \"$REMOTE\" '{}/right.txt'",
+            capture.display(),
+            capture.display()
+        );
+        run_git_config(Some(Path::new(&repo.path_str())), &["diff.tool", "mock"]).unwrap();
+        run_git_config(
+            Some(Path::new(&repo.path_str())),
+            &["difftool.mock.cmd", &cmd],
+        )
+        .unwrap();
+
+        let result = launch_diff_tool(
+            repo.path_str(),
+            "f.txt".to_string(),
+            None,
+            Some(c2.to_string()),
+        )
+        .await;
+        assert!(result.is_ok(), "launch failed: {:?}", result.err());
+        assert!(result.unwrap().success);
+
+        let left = std::fs::read_to_string(capture.join("left.txt")).unwrap();
+        let right = std::fs::read_to_string(capture.join("right.txt")).unwrap();
+        assert_eq!(left, "v1\n", "LEFT should be the parent version");
+        assert_eq!(
+            right, "v2\n",
+            "RIGHT should be the commit version, not the worktree"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/encoding.rs
+++ b/src-tauri/src/commands/encoding.rs
@@ -278,50 +278,98 @@ pub async fn convert_file_encoding(
     let bom_len = detect_bom(&data).map(|(_, len)| len).unwrap_or(0);
     let content_data = &data[bom_len..];
 
-    // Decode the source content
-    let source_encoding = encoding_rs::Encoding::for_label(source_encoding_name.as_bytes())
-        .unwrap_or(encoding_rs::UTF_8);
+    // Decode the source content into a Rust string. encoding_rs can decode
+    // FROM UTF-16 but not UTF-32, so UTF-32 sources are decoded manually to
+    // avoid the for_label() fallback silently treating them as UTF-8 (mojibake).
+    let source_upper = source_encoding_name.to_uppercase();
+    let decoded: std::borrow::Cow<str> = if source_upper == "UTF-32LE" || source_upper == "UTF-32BE"
+    {
+        let le = source_upper == "UTF-32LE";
+        let mut s = String::new();
+        for chunk in content_data.chunks(4) {
+            if chunk.len() < 4 {
+                break;
+            }
+            let cp = if le {
+                u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]])
+            } else {
+                u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]])
+            };
+            s.push(char::from_u32(cp).unwrap_or('\u{FFFD}'));
+        }
+        std::borrow::Cow::Owned(s)
+    } else {
+        let source_encoding = encoding_rs::Encoding::for_label(source_encoding_name.as_bytes())
+            .unwrap_or(encoding_rs::UTF_8);
+        let (decoded, _, had_errors) = source_encoding.decode(content_data);
+        if had_errors {
+            tracing::warn!(
+                "Encountered errors decoding file from {}",
+                source_encoding_name
+            );
+        }
+        decoded
+    };
 
-    let (decoded, _, had_errors) = source_encoding.decode(content_data);
-    if had_errors {
-        tracing::warn!(
-            "Encountered errors decoding file from {}",
-            source_encoding_name
-        );
-    }
-
-    // Encode to target encoding
-    let target_encoding_lower = targetEncoding.to_lowercase();
-    let target_enc = encoding_rs::Encoding::for_label(target_encoding_lower.as_bytes())
-        .ok_or_else(|| {
-            LeviathanError::OperationFailed(format!(
-                "Unsupported target encoding: {}",
-                targetEncoding
-            ))
-        })?;
-
-    let (encoded, _, had_encode_errors) = target_enc.encode(&decoded);
-    if had_encode_errors {
-        tracing::warn!("Encountered errors encoding file to {}", target_enc.name());
-    }
+    // Encode to the target encoding. encoding_rs::encode() maps UTF-16/UTF-32
+    // targets back to UTF-8 (it cannot emit those units), so those must be
+    // handled manually; otherwise we would write UTF-8 bytes behind a UTF-16
+    // BOM and corrupt the file.
+    let target_norm = targetEncoding.to_lowercase().replace('_', "-");
+    let (body, target_name): (Vec<u8>, String) = match target_norm.as_str() {
+        "utf-16" | "utf16" | "utf-16le" | "utf16le" => {
+            let bytes = decoded
+                .encode_utf16()
+                .flat_map(|u| u.to_le_bytes())
+                .collect();
+            (bytes, "UTF-16LE".to_string())
+        }
+        "utf-16be" | "utf16be" => {
+            let bytes = decoded
+                .encode_utf16()
+                .flat_map(|u| u.to_be_bytes())
+                .collect();
+            (bytes, "UTF-16BE".to_string())
+        }
+        "utf-32" | "utf32" | "utf-32le" | "utf32le" | "utf-32be" | "utf32be" => {
+            return Err(LeviathanError::OperationFailed(
+                "UTF-32 encoding is not supported. Please choose UTF-8, UTF-16LE, or UTF-16BE."
+                    .to_string(),
+            ));
+        }
+        _ => {
+            let target_enc =
+                encoding_rs::Encoding::for_label(target_norm.as_bytes()).ok_or_else(|| {
+                    LeviathanError::OperationFailed(format!(
+                        "Unsupported target encoding: {}",
+                        targetEncoding
+                    ))
+                })?;
+            let (encoded, _, had_encode_errors) = target_enc.encode(&decoded);
+            if had_encode_errors {
+                tracing::warn!("Encountered errors encoding file to {}", target_enc.name());
+            }
+            (encoded.into_owned(), target_enc.name().to_string())
+        }
+    };
 
     // Build output with optional BOM
     let mut output = Vec::new();
-    let target_name = target_enc.name().to_uppercase();
+    let target_name_upper = target_name.to_uppercase();
 
     // Add BOM for UTF encodings if appropriate
-    if target_name.contains("UTF-8") {
+    if target_name_upper.contains("UTF-8") {
         // UTF-8 BOM is optional; we add it if the source had a BOM
         if detect_bom(&data).is_some() {
             output.extend_from_slice(BOM_UTF8);
         }
-    } else if target_name.contains("UTF-16LE") {
+    } else if target_name_upper.contains("UTF-16LE") {
         output.extend_from_slice(BOM_UTF16_LE);
-    } else if target_name.contains("UTF-16BE") {
+    } else if target_name_upper.contains("UTF-16BE") {
         output.extend_from_slice(BOM_UTF16_BE);
     }
 
-    output.extend_from_slice(&encoded);
+    output.extend_from_slice(&body);
 
     let bytes_written = output.len();
 
@@ -333,7 +381,7 @@ pub async fn convert_file_encoding(
     Ok(ConvertEncodingResult {
         success: true,
         source_encoding: source_encoding_name,
-        target_encoding: target_enc.name().to_string(),
+        target_encoding: target_name,
         bytes_written,
     })
 }
@@ -665,6 +713,90 @@ mod tests {
         // Read and verify content is preserved
         let content = fs::read_to_string(repo.path.join("preserve_test.txt")).unwrap();
         assert_eq!(content, original_text);
+    }
+
+    /// Finding 59: converting to UTF-16LE must emit real UTF-16 code units,
+    /// not UTF-8 bytes behind a UTF-16 BOM.
+    #[tokio::test]
+    async fn test_convert_to_utf16le_produces_valid_utf16() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_file("u16.txt", "hello");
+
+        let result = convert_file_encoding(
+            repo.path_str(),
+            "u16.txt".to_string(),
+            "utf-16le".to_string(),
+        )
+        .await;
+        assert!(result.is_ok(), "utf-16le conversion should succeed");
+
+        let bytes = fs::read(repo.path.join("u16.txt")).unwrap();
+        // Expect BOM FF FE followed by 2-byte little-endian code units.
+        assert_eq!(
+            bytes,
+            vec![0xFF, 0xFE, b'h', 0x00, b'e', 0x00, b'l', 0x00, b'l', 0x00, b'o', 0x00,],
+            "UTF-16LE output must be BOM + 2-byte LE units, got {:?}",
+            bytes
+        );
+    }
+
+    /// Finding 59: converting to UTF-16BE must emit big-endian code units.
+    #[tokio::test]
+    async fn test_convert_to_utf16be_produces_valid_utf16() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_file("u16be.txt", "Ab");
+
+        let result = convert_file_encoding(
+            repo.path_str(),
+            "u16be.txt".to_string(),
+            "utf-16be".to_string(),
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let bytes = fs::read(repo.path.join("u16be.txt")).unwrap();
+        assert_eq!(bytes, vec![0xFE, 0xFF, 0x00, b'A', 0x00, b'b']);
+    }
+
+    /// Finding 59: UTF-16 output must round-trip back through detection as UTF-16.
+    #[tokio::test]
+    async fn test_convert_to_utf16le_detected_as_utf16() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_file("rt.txt", "roundtrip");
+
+        convert_file_encoding(
+            repo.path_str(),
+            "rt.txt".to_string(),
+            "utf-16le".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let info = detect_file_encoding(repo.path_str(), "rt.txt".to_string())
+            .await
+            .unwrap();
+        assert_eq!(info.encoding, "UTF-16LE");
+        assert!(info.has_bom);
+    }
+
+    /// Finding 59: UTF-32 targets can't be emitted correctly, so refuse cleanly.
+    #[tokio::test]
+    async fn test_convert_to_utf32_is_refused() {
+        let repo = TestRepo::with_initial_commit();
+        let original = "keep me safe";
+        repo.create_file("u32.txt", original);
+
+        let result = convert_file_encoding(
+            repo.path_str(),
+            "u32.txt".to_string(),
+            "utf-32le".to_string(),
+        )
+        .await;
+        assert!(result.is_err(), "UTF-32 target must be refused");
+
+        // The original file must be left untouched (no corruption / data loss).
+        let after = fs::read_to_string(repo.path.join("u32.txt")).unwrap();
+        assert_eq!(after, original);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/gitattributes.rs
+++ b/src-tauri/src/commands/gitattributes.rs
@@ -72,6 +72,66 @@ fn parse_attribute_token(token: &str) -> AttributeEntry {
     }
 }
 
+/// Split a trimmed .gitattributes line into its pattern and the remainder
+/// (the attribute list).
+///
+/// Per gitattributes(5), a pattern containing whitespace may be wrapped in
+/// double quotes, with C-style escapes (`\"`, `\\`, `\n`, `\t`, octal `\nnn`)
+/// inside. Otherwise the pattern is the first whitespace-delimited token.
+fn split_pattern_and_rest(trimmed: &str) -> (String, &str) {
+    if let Some(after_quote) = trimmed.strip_prefix('"') {
+        let bytes = after_quote.as_bytes();
+        let mut out: Vec<u8> = Vec::new();
+        let mut i = 0;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'"' => {
+                    // Closing quote: everything after it is the attribute list.
+                    let rest = &after_quote[i + 1..];
+                    return (String::from_utf8_lossy(&out).into_owned(), rest);
+                }
+                b'\\' => {
+                    i += 1;
+                    if i >= bytes.len() {
+                        break;
+                    }
+                    match bytes[i] {
+                        b'n' => out.push(b'\n'),
+                        b't' => out.push(b'\t'),
+                        b'r' => out.push(b'\r'),
+                        c @ b'0'..=b'7' => {
+                            // Up to three octal digits.
+                            let mut val = (c - b'0') as u32;
+                            let mut digits = 1;
+                            while digits < 3
+                                && i + 1 < bytes.len()
+                                && (b'0'..=b'7').contains(&bytes[i + 1])
+                            {
+                                i += 1;
+                                val = val * 8 + (bytes[i] - b'0') as u32;
+                                digits += 1;
+                            }
+                            out.push(val as u8);
+                        }
+                        other => out.push(other),
+                    }
+                    i += 1;
+                }
+                b => {
+                    out.push(b);
+                    i += 1;
+                }
+            }
+        }
+        // Malformed (no closing quote): fall through to the unquoted split below.
+    }
+
+    match trimmed.split_once(char::is_whitespace) {
+        Some((pattern, rest)) => (pattern.to_string(), rest),
+        None => (trimmed.to_string(), ""),
+    }
+}
+
 /// Parse the entire .gitattributes content into structured entries
 fn parse_gitattributes(content: &str) -> Vec<GitAttribute> {
     let mut entries = Vec::new();
@@ -84,15 +144,15 @@ fn parse_gitattributes(content: &str) -> Vec<GitAttribute> {
             continue;
         }
 
-        // Split line into pattern and attributes
-        // The pattern is the first whitespace-delimited token
-        let mut parts = trimmed.split_whitespace();
-        let pattern = match parts.next() {
-            Some(p) => p.to_string(),
-            None => continue,
-        };
+        // Split line into pattern and attributes. The pattern may be quoted if it
+        // contains whitespace, so it is not simply the first whitespace token.
+        let (pattern, rest) = split_pattern_and_rest(trimmed);
+        if pattern.is_empty() {
+            continue;
+        }
 
-        let attributes: Vec<AttributeEntry> = parts.map(parse_attribute_token).collect();
+        let attributes: Vec<AttributeEntry> =
+            rest.split_whitespace().map(parse_attribute_token).collect();
 
         entries.push(GitAttribute {
             pattern,
@@ -376,6 +436,50 @@ mod tests {
             entries[0].attributes[3].value,
             AttributeValue::Unspecified
         ));
+    }
+
+    // Regression (finding 93): a quoted pattern containing whitespace must be
+    // parsed as a single pattern with C-style unescaping, per gitattributes(5).
+    // Canonical git: `"foo bar.txt" text` assigns `text` to the file `foo bar.txt`.
+    #[test]
+    fn test_parse_gitattributes_quoted_pattern_with_space() {
+        let content = "\"foo bar.txt\" text\n";
+        let entries = parse_gitattributes(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].pattern, "foo bar.txt");
+        assert_eq!(entries[0].attributes.len(), 1);
+        assert_eq!(entries[0].attributes[0].name, "text");
+        assert!(matches!(
+            entries[0].attributes[0].value,
+            AttributeValue::Set
+        ));
+    }
+
+    #[test]
+    fn test_parse_gitattributes_quoted_pattern_multiple_attrs() {
+        let content = "\"my dir/file name.psd\" filter=lfs diff=lfs -text\n";
+        let entries = parse_gitattributes(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].pattern, "my dir/file name.psd");
+        assert_eq!(entries[0].attributes.len(), 3);
+        assert_eq!(entries[0].attributes[0].name, "filter");
+        assert_eq!(entries[0].attributes[2].name, "text");
+        assert!(matches!(
+            entries[0].attributes[2].value,
+            AttributeValue::Unset
+        ));
+    }
+
+    #[test]
+    fn test_parse_gitattributes_quoted_pattern_octal_escape() {
+        // git writes non-ASCII bytes as octal escapes inside quotes; "caf\303\251"
+        // is the UTF-8 encoding of "café".
+        let content = "\"caf\\303\\251.log\" text\n";
+        let entries = parse_gitattributes(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].pattern, "café.log");
+        assert_eq!(entries[0].attributes.len(), 1);
+        assert_eq!(entries[0].attributes[0].name, "text");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/gitignore.rs
+++ b/src-tauri/src/commands/gitignore.rs
@@ -100,11 +100,27 @@ pub async fn remove_from_gitignore(path: String, pattern: String) -> Result<()> 
     Ok(())
 }
 
+/// Whether a path is tracked (present in the index at stage 0).
+///
+/// Git never applies gitignore rules to tracked files, so callers must treat a
+/// tracked path as not ignored regardless of what the gitignore patterns say.
+fn is_path_tracked(repo: &git2::Repository, path: &Path) -> bool {
+    match repo.index() {
+        Ok(index) => index.get_path(path, 0).is_some(),
+        Err(_) => false,
+    }
+}
+
 /// Check if a file path matches any gitignore pattern
 #[command]
 pub async fn is_ignored(path: String, file_path: String) -> Result<bool> {
     let repo = git2::Repository::open(Path::new(&path))?;
-    Ok(repo.is_path_ignored(Path::new(&file_path))?)
+    let file = Path::new(&file_path);
+    // gitignore only affects untracked files; a tracked file is never ignored.
+    if is_path_tracked(&repo, file) {
+        return Ok(false);
+    }
+    Ok(repo.is_path_ignored(file)?)
 }
 
 /// Result of checking whether a file is ignored by gitignore rules
@@ -138,7 +154,13 @@ pub async fn check_ignore(path: String, file_paths: Vec<String>) -> Result<Vec<I
 
     let mut results = Vec::with_capacity(file_paths.len());
     for file_path in &file_paths {
-        let is_ignored = repo.is_path_ignored(Path::new(file_path)).unwrap_or(false);
+        let file = Path::new(file_path);
+        // gitignore only affects untracked files; a tracked file is never ignored.
+        let is_ignored = if is_path_tracked(&repo, file) {
+            false
+        } else {
+            repo.is_path_ignored(file).unwrap_or(false)
+        };
         results.push(IgnoreCheckResult {
             path: file_path.clone(),
             is_ignored,
@@ -150,8 +172,13 @@ pub async fn check_ignore(path: String, file_paths: Vec<String>) -> Result<Vec<I
 
 /// Check if files are ignored by gitignore rules, with verbose rule details.
 ///
-/// Uses `git check-ignore -v --no-index` to get the source file, line number,
-/// and pattern that matches each path.
+/// Uses `git check-ignore -v -n -z --stdin` to get the source file, line number,
+/// and pattern that matches each path. The `-z` / `--stdin` combination:
+///   * consults the index natively, so tracked files are reported as NOT ignored
+///     (matching `git check-ignore`; gitignore rules only affect untracked files),
+///   * NUL-separates the four output fields and disables pathname C-quoting, so
+///     non-ASCII paths and patterns containing `:` are handled correctly, and
+///   * passes pathnames on stdin, avoiding argument-length limits.
 #[command]
 pub async fn check_ignore_verbose(
     path: String,
@@ -161,135 +188,99 @@ pub async fn check_ignore_verbose(
         return Ok(Vec::new());
     }
 
-    // Use git check-ignore -v --no-index -n to get verbose output for all paths.
-    // -v gives source:linenum:pattern\tpath
-    // --no-index checks against gitignore rules without requiring the file to exist
-    // -n (--non-matching) also shows paths that are NOT ignored
-    let output = create_command("git")
+    // Feed the paths on stdin, NUL-separated (required by -z / --stdin).
+    let mut stdin_bytes = Vec::new();
+    for file_path in &file_paths {
+        stdin_bytes.extend_from_slice(file_path.as_bytes());
+        stdin_bytes.push(0);
+    }
+
+    let mut child = create_command("git")
         .arg("-C")
         .arg(&path)
         .arg("check-ignore")
         .arg("-v")
-        .arg("--no-index")
         .arg("-n")
-        .args(&file_paths)
-        .output()
+        .arg("-z")
+        .arg("--stdin")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
         .map_err(|e| {
             LeviathanError::OperationFailed(format!("Failed to run git check-ignore: {}", e))
         })?;
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // Parse the output. Each line has the format:
-    // source:linenum:pattern\tpathname    (for matched paths)
-    // ::\t pathname                        (for non-matched paths with -n)
-    let mut results: Vec<IgnoreCheckVerboseResult> = Vec::with_capacity(file_paths.len());
-    let mut seen_paths = std::collections::HashSet::new();
-
-    for line in stdout.lines() {
-        if line.is_empty() {
-            continue;
-        }
-
-        if let Some(result) = parse_check_ignore_verbose_line(line) {
-            seen_paths.insert(result.path.clone());
-            results.push(result);
-        }
+    if let Some(mut stdin) = child.stdin.take() {
+        use std::io::Write;
+        stdin.write_all(&stdin_bytes).map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to write to git check-ignore: {}", e))
+        })?;
     }
 
-    // For any paths not in the output (shouldn't happen with -n, but be safe),
-    // fall back to git2 is_path_ignored
-    let repo = git2::Repository::open(Path::new(&path))?;
-    for file_path in &file_paths {
-        if !seen_paths.contains(file_path.as_str()) {
-            let is_ignored = repo.is_path_ignored(Path::new(file_path)).unwrap_or(false);
+    let output = child.wait_with_output().map_err(|e| {
+        LeviathanError::OperationFailed(format!("Failed to run git check-ignore: {}", e))
+    })?;
+
+    Ok(parse_check_ignore_z(&output.stdout))
+}
+
+/// Parse the NUL-separated output of `git check-ignore -v -n -z --stdin`.
+///
+/// Records are groups of four NUL-terminated fields:
+/// `<source>\0<linenum>\0<pattern>\0<pathname>\0`. A non-matching path has empty
+/// `source`, `linenum`, and `pattern` fields.
+fn parse_check_ignore_z(stdout: &[u8]) -> Vec<IgnoreCheckVerboseResult> {
+    // Collect NUL-terminated fields, dropping the trailing empty field after the
+    // final NUL. Fields are decoded lossily (paths are otherwise raw bytes).
+    let mut fields: Vec<String> = stdout
+        .split(|b| *b == 0)
+        .map(|f| String::from_utf8_lossy(f).into_owned())
+        .collect();
+    if fields.last().map(|f| f.is_empty()).unwrap_or(false) {
+        fields.pop();
+    }
+
+    let mut results = Vec::with_capacity(fields.len() / 4);
+    for record in fields.chunks_exact(4) {
+        let source = &record[0];
+        let line_num_str = &record[1];
+        let pattern = &record[2];
+        let path_name = record[3].clone();
+
+        // Non-matching path: all rule fields empty.
+        if source.is_empty() && pattern.is_empty() {
             results.push(IgnoreCheckVerboseResult {
-                path: file_path.clone(),
-                is_ignored,
+                path: path_name,
+                is_ignored: false,
                 source_file: None,
                 source_line: None,
                 pattern: None,
                 is_negated: false,
             });
+            continue;
         }
-    }
 
-    Ok(results)
-}
-
-/// Parse a single line of `git check-ignore -v --no-index -n` output.
-///
-/// Format: `source:linenum:pattern\tpathname`
-/// For non-matching (with -n): `::\t pathname`
-fn parse_check_ignore_verbose_line(line: &str) -> Option<IgnoreCheckVerboseResult> {
-    // Split on tab to separate the rule info from the path
-    let tab_pos = line.find('\t')?;
-    let rule_part = &line[..tab_pos];
-    let path_part = line[tab_pos + 1..].trim().to_string();
-
-    if path_part.is_empty() {
-        return None;
-    }
-
-    // Parse rule_part which is "source:linenum:pattern"
-    // For non-matching lines: "::"
-    // We need to split on ':' but be careful - source paths on Windows can contain ':'
-    // The format is: source_file:line_number:pattern
-    // Non-matching: ::
-
-    if rule_part == "::" {
-        // Non-matching path
-        return Some(IgnoreCheckVerboseResult {
-            path: path_part,
-            is_ignored: false,
-            source_file: None,
-            source_line: None,
-            pattern: None,
-            is_negated: false,
+        let is_negated = pattern.starts_with('!');
+        results.push(IgnoreCheckVerboseResult {
+            path: path_name,
+            is_ignored: !is_negated,
+            source_file: if source.is_empty() {
+                None
+            } else {
+                Some(source.clone())
+            },
+            source_line: line_num_str.parse::<u32>().ok(),
+            pattern: if pattern.is_empty() {
+                None
+            } else {
+                Some(pattern.clone())
+            },
+            is_negated,
         });
     }
 
-    // Find the pattern by splitting from the right on ':'
-    // Pattern is after the last ':', line number is between second-to-last and last ':'
-    // Source file is everything before the second-to-last ':'
-    let mut colon_positions: Vec<usize> = Vec::new();
-    for (i, ch) in rule_part.char_indices() {
-        if ch == ':' {
-            colon_positions.push(i);
-        }
-    }
-
-    if colon_positions.len() < 2 {
-        return None;
-    }
-
-    let last_colon = colon_positions[colon_positions.len() - 1];
-    let second_last_colon = colon_positions[colon_positions.len() - 2];
-
-    let source_file = &rule_part[..second_last_colon];
-    let line_num_str = &rule_part[second_last_colon + 1..last_colon];
-    let pattern_str = &rule_part[last_colon + 1..];
-
-    let source_line = line_num_str.parse::<u32>().ok();
-    let is_negated = pattern_str.starts_with('!');
-    let is_ignored = !is_negated;
-
-    Some(IgnoreCheckVerboseResult {
-        path: path_part,
-        is_ignored,
-        source_file: if source_file.is_empty() {
-            None
-        } else {
-            Some(source_file.to_string())
-        },
-        source_line,
-        pattern: if pattern_str.is_empty() {
-            None
-        } else {
-            Some(pattern_str.to_string())
-        },
-        is_negated,
-    })
+    results
 }
 
 /// Get common gitignore templates
@@ -565,6 +556,87 @@ mod tests {
         assert!(!rs_result.is_ignored);
     }
 
+    // Regression (finding 91): ignore rules never apply to tracked files.
+    // Canonical git: `git check-ignore -v tracked.log` prints nothing / exits 1,
+    // and `git status --ignored` never lists a tracked file.
+    #[tokio::test]
+    async fn test_tracked_file_is_never_ignored() {
+        let repo = TestRepo::with_initial_commit();
+        // Commit both the ignore rule and a file the rule would otherwise match.
+        repo.create_commit(
+            "Add gitignore and tracked log",
+            &[(".gitignore", "*.log\n"), ("tracked.log", "data\n")],
+        );
+
+        // is_ignored: tracked file must be reported as NOT ignored.
+        let single = is_ignored(repo.path_str(), "tracked.log".to_string())
+            .await
+            .unwrap();
+        assert!(!single, "tracked.log is tracked, so it must not be ignored");
+
+        // Sanity: an untracked *.log file is still ignored.
+        let untracked = is_ignored(repo.path_str(), "untracked.log".to_string())
+            .await
+            .unwrap();
+        assert!(untracked, "untracked.log must still be ignored");
+
+        // check_ignore: tracked file must be NOT ignored.
+        let results = check_ignore(
+            repo.path_str(),
+            vec!["tracked.log".to_string(), "untracked.log".to_string()],
+        )
+        .await
+        .unwrap();
+        let tracked = results.iter().find(|r| r.path == "tracked.log").unwrap();
+        assert!(
+            !tracked.is_ignored,
+            "check_ignore must not ignore tracked.log"
+        );
+        let untracked = results.iter().find(|r| r.path == "untracked.log").unwrap();
+        assert!(
+            untracked.is_ignored,
+            "check_ignore must ignore untracked.log"
+        );
+
+        // check_ignore_verbose: tracked file must be NOT ignored, with no rule details.
+        let verbose = check_ignore_verbose(
+            repo.path_str(),
+            vec!["tracked.log".to_string(), "untracked.log".to_string()],
+        )
+        .await
+        .unwrap();
+        let tracked = verbose.iter().find(|r| r.path == "tracked.log").unwrap();
+        assert!(
+            !tracked.is_ignored,
+            "check_ignore_verbose must not ignore tracked.log"
+        );
+        assert!(tracked.source_file.is_none());
+        assert!(tracked.pattern.is_none());
+        let untracked = verbose.iter().find(|r| r.path == "untracked.log").unwrap();
+        assert!(untracked.is_ignored);
+        assert_eq!(untracked.pattern.as_deref(), Some("*.log"));
+    }
+
+    // Regression (finding 92): non-ASCII pathnames must be reported once, unquoted.
+    #[tokio::test]
+    async fn test_check_ignore_verbose_non_ascii_path() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add gitignore", &[(".gitignore", "caf*\n")]);
+
+        let verbose = check_ignore_verbose(repo.path_str(), vec!["café.log".to_string()])
+            .await
+            .unwrap();
+
+        // Exactly one entry for one input path (no garbled duplicate).
+        assert_eq!(verbose.len(), 1, "expected a single result for one path");
+        let entry = &verbose[0];
+        assert_eq!(entry.path, "café.log", "path must be returned unquoted");
+        assert!(entry.is_ignored);
+        assert_eq!(entry.source_file.as_deref(), Some(".gitignore"));
+        assert_eq!(entry.source_line, Some(1));
+        assert_eq!(entry.pattern.as_deref(), Some("caf*"));
+    }
+
     #[tokio::test]
     async fn test_check_ignore_verbose_empty_list() {
         let repo = TestRepo::with_initial_commit();
@@ -573,48 +645,95 @@ mod tests {
         assert!(results.is_empty());
     }
 
-    #[test]
-    fn test_parse_check_ignore_verbose_line_matching() {
-        let line = ".gitignore:1:*.log\ttest.log";
-        let result = parse_check_ignore_verbose_line(line).unwrap();
-        assert_eq!(result.path, "test.log");
-        assert!(result.is_ignored);
-        assert_eq!(result.source_file.as_deref(), Some(".gitignore"));
-        assert_eq!(result.source_line, Some(1));
-        assert_eq!(result.pattern.as_deref(), Some("*.log"));
-        assert!(!result.is_negated);
+    // Build the NUL-separated output of `git check-ignore -v -n -z` for the given
+    // records of (source, linenum, pattern, path).
+    fn z_output(records: &[(&str, &str, &str, &str)]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for (source, linenum, pattern, path) in records {
+            for field in [source, linenum, pattern, path] {
+                out.extend_from_slice(field.as_bytes());
+                out.push(0);
+            }
+        }
+        out
     }
 
     #[test]
-    fn test_parse_check_ignore_verbose_line_non_matching() {
-        let line = "::\tsrc/main.rs";
-        let result = parse_check_ignore_verbose_line(line).unwrap();
-        assert_eq!(result.path, "src/main.rs");
-        assert!(!result.is_ignored);
-        assert!(result.source_file.is_none());
-        assert!(result.source_line.is_none());
-        assert!(result.pattern.is_none());
-        assert!(!result.is_negated);
+    fn test_parse_check_ignore_z_matching() {
+        let out = z_output(&[(".gitignore", "1", "*.log", "test.log")]);
+        let results = parse_check_ignore_z(&out);
+        assert_eq!(results.len(), 1);
+        let r = &results[0];
+        assert_eq!(r.path, "test.log");
+        assert!(r.is_ignored);
+        assert_eq!(r.source_file.as_deref(), Some(".gitignore"));
+        assert_eq!(r.source_line, Some(1));
+        assert_eq!(r.pattern.as_deref(), Some("*.log"));
+        assert!(!r.is_negated);
     }
 
     #[test]
-    fn test_parse_check_ignore_verbose_line_negated() {
-        let line = ".gitignore:3:!important.log\timportant.log";
-        let result = parse_check_ignore_verbose_line(line).unwrap();
-        assert_eq!(result.path, "important.log");
-        assert!(!result.is_ignored);
-        assert!(result.is_negated);
-        assert_eq!(result.pattern.as_deref(), Some("!important.log"));
+    fn test_parse_check_ignore_z_non_matching() {
+        let out = z_output(&[("", "", "", "src/main.rs")]);
+        let results = parse_check_ignore_z(&out);
+        assert_eq!(results.len(), 1);
+        let r = &results[0];
+        assert_eq!(r.path, "src/main.rs");
+        assert!(!r.is_ignored);
+        assert!(r.source_file.is_none());
+        assert!(r.source_line.is_none());
+        assert!(r.pattern.is_none());
+        assert!(!r.is_negated);
     }
 
     #[test]
-    fn test_parse_check_ignore_verbose_line_subdirectory_gitignore() {
-        let line = "src/.gitignore:2:*.tmp\tsrc/data.tmp";
-        let result = parse_check_ignore_verbose_line(line).unwrap();
-        assert_eq!(result.path, "src/data.tmp");
-        assert!(result.is_ignored);
-        assert_eq!(result.source_file.as_deref(), Some("src/.gitignore"));
-        assert_eq!(result.source_line, Some(2));
-        assert_eq!(result.pattern.as_deref(), Some("*.tmp"));
+    fn test_parse_check_ignore_z_negated() {
+        let out = z_output(&[(".gitignore", "3", "!important.log", "important.log")]);
+        let results = parse_check_ignore_z(&out);
+        assert_eq!(results.len(), 1);
+        let r = &results[0];
+        assert_eq!(r.path, "important.log");
+        assert!(!r.is_ignored);
+        assert!(r.is_negated);
+        assert_eq!(r.pattern.as_deref(), Some("!important.log"));
+    }
+
+    #[test]
+    fn test_parse_check_ignore_z_multiple_records() {
+        let out = z_output(&[
+            ("src/.gitignore", "2", "*.tmp", "src/data.tmp"),
+            ("", "", "", "keep.txt"),
+        ]);
+        let results = parse_check_ignore_z(&out);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].path, "src/data.tmp");
+        assert!(results[0].is_ignored);
+        assert_eq!(results[0].source_file.as_deref(), Some("src/.gitignore"));
+        assert_eq!(results[0].source_line, Some(2));
+        assert_eq!(results[0].pattern.as_deref(), Some("*.tmp"));
+        assert_eq!(results[1].path, "keep.txt");
+        assert!(!results[1].is_ignored);
+    }
+
+    #[test]
+    fn test_parse_check_ignore_z_non_ascii_path() {
+        // With -z there is no C-quoting: the raw UTF-8 path comes through verbatim.
+        let out = z_output(&[(".gitignore", "3", "caf*", "café.log")]);
+        let results = parse_check_ignore_z(&out);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "café.log");
+        assert!(results[0].is_ignored);
+        assert_eq!(results[0].pattern.as_deref(), Some("caf*"));
+    }
+
+    #[test]
+    fn test_parse_check_ignore_z_pattern_with_colon() {
+        // A pattern containing ':' must survive (the old colon-splitting parser
+        // mangled it); -z fields are unambiguous.
+        let out = z_output(&[(".gitignore", "5", "foo:bar", "foo:bar")]);
+        let results = parse_check_ignore_z(&out);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].pattern.as_deref(), Some("foo:bar"));
+        assert_eq!(results[0].path, "foo:bar");
     }
 }

--- a/src-tauri/src/commands/gpg.rs
+++ b/src-tauri/src/commands/gpg.rs
@@ -49,6 +49,8 @@ pub struct GpgConfig {
     pub sign_tags: bool,
     /// GPG program path
     pub gpg_program: Option<String>,
+    /// Signature format (gpg.format): "openpgp" (default), "ssh", or "x509"
+    pub gpg_format: Option<String>,
 }
 
 /// Commit signature information
@@ -128,11 +130,40 @@ fn run_git_command(repo_path: &Path, args: &[&str]) -> Result<String> {
 
 /// Check if GPG is available
 fn is_gpg_available() -> bool {
-    create_command("gpg")
+    gpg_binary_available("gpg")
+}
+
+/// Check whether a given OpenPGP program (gpg.program, default "gpg") is runnable.
+fn gpg_binary_available(program: &str) -> bool {
+    create_command(program)
         .arg("--version")
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+/// Expand a leading "~/" to the user's home directory.
+fn expand_tilde(p: &str) -> String {
+    if let Some(rest) = p.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return Path::new(&home).join(rest).to_string_lossy().to_string();
+        }
+    }
+    p.to_string()
+}
+
+/// Whether a configured SSH signing key is usable: either a literal public key
+/// ("ssh-..." or "key::...") or a path to an existing key file. SSH signing does
+/// not involve the gpg binary at all.
+fn ssh_key_is_usable(key: &str) -> bool {
+    let key = key.trim();
+    if key.is_empty() {
+        return false;
+    }
+    if key.starts_with("ssh-") || key.starts_with("key::") {
+        return true;
+    }
+    Path::new(&expand_tilde(key)).exists()
 }
 
 /// Get GPG version
@@ -181,6 +212,11 @@ pub async fn get_gpg_config(path: String) -> Result<GpgConfig> {
         .ok()
         .filter(|s| !s.is_empty());
 
+    // Get the configured signature format (openpgp / ssh / x509)
+    let gpg_format = run_git_command(repo_path, &["config", "--get", "gpg.format"])
+        .ok()
+        .filter(|s| !s.is_empty());
+
     Ok(GpgConfig {
         gpg_available,
         gpg_version,
@@ -188,6 +224,7 @@ pub async fn get_gpg_config(path: String) -> Result<GpgConfig> {
         sign_commits,
         sign_tags,
         gpg_program,
+        gpg_format,
     })
 }
 
@@ -198,7 +235,6 @@ pub async fn get_gpg_config(path: String) -> Result<GpgConfig> {
 #[command]
 pub async fn get_signing_status(path: String) -> Result<SigningStatus> {
     let repo_path = Path::new(&path);
-    let gpg_available = is_gpg_available();
 
     // Check if commit signing is enabled
     let gpg_sign_enabled = run_git_command(repo_path, &["config", "--get", "commit.gpgsign"])
@@ -216,22 +252,35 @@ pub async fn get_signing_status(path: String) -> Result<SigningStatus> {
         .ok()
         .filter(|s| !s.is_empty());
 
-    // Determine if signing is possible
-    // We can sign if GPG is available and either:
-    // 1. A signing key is explicitly configured, or
-    // 2. There are GPG secret keys available (GPG will use default)
-    let can_sign = if !gpg_available {
-        false
-    } else if signing_key.is_some() {
-        // A signing key is configured - verify it exists
-        let key_id = signing_key.as_ref().unwrap();
-        run_command("gpg", &["--list-secret-keys", key_id]).is_ok()
-    } else {
-        // No signing key configured - check if there are any secret keys
-        run_command("gpg", &["--list-secret-keys"])
-            .ok()
-            .map(|output| output.contains("sec"))
+    // Signature format determines HOW we sign: SSH keys never touch the gpg binary.
+    let gpg_format = run_git_command(repo_path, &["config", "--get", "gpg.format"])
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    // Determine if signing is possible.
+    let can_sign = if gpg_format.as_deref() == Some("ssh") {
+        // SSH signing: git signs with the configured key (a literal key or a key
+        // file); gpg is irrelevant. A usable signing key is sufficient.
+        signing_key
+            .as_ref()
+            .map(|k| ssh_key_is_usable(k))
             .unwrap_or(false)
+    } else {
+        // OpenPGP (default) / x509: invoke the configured gpg program.
+        let program = gpg_program.as_deref().unwrap_or("gpg");
+        if !gpg_binary_available(program) {
+            false
+        } else if let Some(key_id) = signing_key.as_ref() {
+            // A signing key is configured - verify it exists in the keyring.
+            run_command(program, &["--list-secret-keys", key_id]).is_ok()
+        } else {
+            // No signing key configured - check if there are any secret keys.
+            run_command(program, &["--list-secret-keys"])
+                .ok()
+                .map(|output| output.contains("sec"))
+                .unwrap_or(false)
+        }
     };
 
     Ok(SigningStatus {
@@ -415,6 +464,20 @@ pub async fn set_tag_signing(path: String, enabled: bool, global: Option<bool>) 
     Ok(())
 }
 
+/// Whether a commit object carries a signature blob (gpgsig header), regardless
+/// of whether it can be verified locally. Covers both PGP and SSH signatures.
+fn commit_has_signature(repo_path: &Path, oid: &str) -> bool {
+    let repo = match git2::Repository::open(repo_path) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    let oid = match git2::Oid::from_str(oid) {
+        Ok(o) => o,
+        Err(_) => return false,
+    };
+    repo.extract_signature(&oid, None).is_ok()
+}
+
 /// Get signature information for a commit
 #[command]
 pub async fn get_commit_signature(path: String, commit_oid: String) -> Result<CommitSignature> {
@@ -429,12 +492,22 @@ pub async fn get_commit_signature(path: String, commit_oid: String) -> Result<Co
     match output {
         Ok(line) => {
             let parts: Vec<&str> = line.split('|').collect();
-            let status = parts.first().map(|s| s.to_string());
+            let mut status = parts.first().map(|s| s.to_string());
 
-            let signed = status
+            let mut signed = status
                 .as_ref()
                 .map(|s| !s.is_empty() && s != "N")
                 .unwrap_or(false);
+
+            // A %G? of 'N' is ambiguous: it means either "no signature" OR
+            // "signature present but unverifiable" (e.g. an SSH signature with no
+            // gpg.ssh.allowedSignersFile configured). Distinguish by checking for
+            // an actual signature blob on the object; if one exists the commit IS
+            // signed, just not locally verifiable ('E' = cannot check).
+            if !signed && commit_has_signature(repo_path, &commit_oid) {
+                signed = true;
+                status = Some("E".to_string());
+            }
 
             let valid = status
                 .as_ref()
@@ -710,6 +783,7 @@ mod tests {
             sign_commits: true,
             sign_tags: false,
             gpg_program: None,
+            gpg_format: None,
         };
 
         assert!(config.gpg_available);
@@ -760,6 +834,7 @@ mod tests {
             sign_commits: false,
             sign_tags: false,
             gpg_program: None,
+            gpg_format: None,
         };
 
         assert!(!config.gpg_available);
@@ -868,5 +943,94 @@ mod tests {
         assert!(status.signing_key.is_none());
         assert!(status.gpg_program.is_none());
         assert!(!status.can_sign);
+    }
+
+    // Finding 98: an SSH signing key configured via gpg.format=ssh must be
+    // recognized as usable, without any gpg keyring being present.
+    #[tokio::test]
+    async fn test_get_signing_status_ssh_key_file() {
+        let repo = TestRepo::with_initial_commit();
+        let key_path = repo.path.join("signing_key.pub");
+        std::fs::write(&key_path, "ssh-ed25519 AAAAC3NzTEST test@example.com\n").unwrap();
+
+        run_git_command(&repo.path, &["config", "gpg.format", "ssh"]).unwrap();
+        run_git_command(
+            &repo.path,
+            &["config", "user.signingkey", key_path.to_str().unwrap()],
+        )
+        .unwrap();
+
+        let status = get_signing_status(repo.path_str()).await.unwrap();
+        assert_eq!(status.signing_key.as_deref(), key_path.to_str());
+        assert!(
+            status.can_sign,
+            "SSH signing with an existing key file must be reported as possible"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_signing_status_ssh_literal_key() {
+        let repo = TestRepo::with_initial_commit();
+        run_git_command(&repo.path, &["config", "gpg.format", "ssh"]).unwrap();
+        run_git_command(
+            &repo.path,
+            &["config", "user.signingkey", "ssh-ed25519 AAAAC3NzLITERAL"],
+        )
+        .unwrap();
+
+        let status = get_signing_status(repo.path_str()).await.unwrap();
+        assert!(
+            status.can_sign,
+            "a literal SSH public key must be reported as usable"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_gpg_config_reports_ssh_format() {
+        let repo = TestRepo::with_initial_commit();
+        run_git_command(&repo.path, &["config", "gpg.format", "ssh"]).unwrap();
+
+        let config = get_gpg_config(repo.path_str()).await.unwrap();
+        assert_eq!(config.gpg_format.as_deref(), Some("ssh"));
+    }
+
+    // Finding 101: an SSH-signed commit with no gpg.ssh.allowedSignersFile
+    // configured (%G? == 'N') must still be reported as signed.
+    #[tokio::test]
+    async fn test_get_commit_signature_ssh_signed_no_allowed_signers() {
+        let keydir = tempfile::TempDir::new().unwrap();
+        let key = keydir.path().join("id");
+        let gen = std::process::Command::new("ssh-keygen")
+            .args(["-t", "ed25519", "-N", "", "-f", key.to_str().unwrap(), "-q"])
+            .output();
+        if gen.map(|o| !o.status.success()).unwrap_or(true) {
+            // ssh-keygen unavailable in this environment; nothing to exercise.
+            return;
+        }
+
+        let repo = TestRepo::with_initial_commit();
+        let pubkey = format!("{}.pub", key.to_str().unwrap());
+        run_git_command(&repo.path, &["config", "gpg.format", "ssh"]).unwrap();
+        run_git_command(&repo.path, &["config", "user.signingkey", &pubkey]).unwrap();
+
+        repo.create_file("s.txt", "x");
+        repo.stage_file("s.txt");
+        let out = std::process::Command::new("git")
+            .current_dir(&repo.path)
+            .args(["commit", "-S", "-m", "signed"])
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "ssh-signed commit failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let head = repo.head_oid().to_string();
+        let sig = get_commit_signature(repo.path_str(), head).await.unwrap();
+        assert!(
+            sig.signed,
+            "an SSH-signed commit must be reported as signed even with no allowedSignersFile"
+        );
     }
 }

--- a/src-tauri/src/commands/graph.rs
+++ b/src-tauri/src/commands/graph.rs
@@ -133,6 +133,19 @@ fn build_refs_map(repo: &git2::Repository) -> HashMap<String, Vec<GraphRef>> {
         }
     }
 
+    // Detached HEAD: `git log --decorate` marks the checked-out commit with
+    // "(HEAD)". libgit2 reports HEAD as a reference literally named "HEAD"
+    // (skipped above) that matches no branch/tag, so add the decoration here.
+    if repo.head_detached().unwrap_or(false) {
+        if let Some(oid) = head.as_ref().and_then(|h| h.target()) {
+            refs_map.entry(oid.to_string()).or_default().push(GraphRef {
+                name: "HEAD".to_string(),
+                ref_type: "head".to_string(),
+                is_current: true,
+            });
+        }
+    }
+
     refs_map
 }
 
@@ -703,6 +716,37 @@ mod tests {
         assert!(
             initial_node.is_fork,
             "Initial commit should be a fork point"
+        );
+    }
+
+    // Finding 112: with a detached HEAD, `git log --decorate` marks the
+    // checked-out commit with "(HEAD)". The graph must emit a current "head"
+    // ref on that commit even though no branch points at it.
+    #[tokio::test]
+    async fn test_get_commit_graph_detached_head_decoration() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Second commit", &[("f.txt", "x")]);
+        let detached_oid = repo.head_oid();
+        {
+            let git = repo.repo();
+            git.set_head_detached(detached_oid)
+                .expect("Failed to detach HEAD");
+        }
+
+        let result = get_commit_graph(repo.path_str(), Some(100), None, None).await;
+        assert!(result.is_ok());
+        let graph = result.unwrap();
+
+        let node = graph
+            .nodes
+            .iter()
+            .find(|n| n.oid == detached_oid.to_string())
+            .expect("checked-out commit should be in the graph");
+        assert!(
+            node.refs
+                .iter()
+                .any(|r| r.ref_type == "head" && r.is_current),
+            "detached HEAD commit should carry a current 'head' decoration"
         );
     }
 

--- a/src-tauri/src/commands/hooks.rs
+++ b/src-tauri/src/commands/hooks.rs
@@ -1,10 +1,314 @@
 //! Git Hooks management command handlers
 //! View, edit, enable/disable git hooks
+//!
+//! In addition to the management commands (list/edit/toggle), this module
+//! provides a small hook *runner* used by the git2-based write paths so they
+//! invoke client-side hooks with the same semantics as canonical git
+//! (githooks(5)). libgit2 runs no hooks, so without this the app would
+//! silently bypass pre-commit/commit-msg/pre-push/etc. on its default paths.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use tauri::command;
 
-use crate::error::Result;
+use crate::error::{LeviathanError, Result};
+
+/// Resolve the hooks directory exactly as git does:
+/// - `core.hooksPath` if set. A leading `~` is expanded to `$HOME`; a relative
+///   path resolves against the repository working directory (git resolves it
+///   against the repo's top-level working tree).
+/// - otherwise `<commondir>/hooks` (using `commondir()`, NOT `path()`, so
+///   linked worktrees share the main repo's hooks like git).
+fn resolve_hooks_dir(repo: &git2::Repository) -> PathBuf {
+    if let Ok(config) = repo.config() {
+        if let Ok(hooks_path) = config.get_string("core.hooksPath") {
+            if !hooks_path.is_empty() {
+                let expanded = expand_tilde(&hooks_path);
+                let p = Path::new(&expanded);
+                if p.is_absolute() {
+                    return p.to_path_buf();
+                }
+                // Relative: resolve against the working directory (git's rule).
+                if let Some(workdir) = repo.workdir() {
+                    return workdir.join(p);
+                }
+                return p.to_path_buf();
+            }
+        }
+    }
+    repo.commondir().join("hooks")
+}
+
+/// Expand a leading `~` (or `~/`) to the user's home directory, like git.
+fn expand_tilde(path: &str) -> String {
+    if path == "~" {
+        if let Some(home) = home_dir() {
+            return home.to_string_lossy().to_string();
+        }
+    } else if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return home.join(rest).to_string_lossy().to_string();
+        }
+    }
+    path.to_string()
+}
+
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(unix)]
+    {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+    #[cfg(not(unix))]
+    {
+        std::env::var_os("USERPROFILE").map(PathBuf::from)
+    }
+}
+
+/// Whether `path` is an existing, executable regular file.
+///
+/// On non-unix platforms executability cannot be reliably determined from the
+/// filesystem, so hooks are best-effort skipped there (documented deviation).
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|m| m.is_file() && (m.permissions().mode() & 0o111 != 0))
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(_path: &Path) -> bool {
+    false
+}
+
+/// Outcome of attempting to run a hook.
+pub struct HookOutcome {
+    /// The hook existed, was executable, and was executed.
+    pub ran: bool,
+    /// Exit status success (true when the hook did not run).
+    pub success: bool,
+    /// Combined stdout+stderr the hook produced (empty when it did not run).
+    pub output: String,
+}
+
+/// Run a single git hook with githooks(5) semantics.
+///
+/// - Resolves the hook via [`resolve_hooks_dir`] and runs it only if the file
+///   exists and is executable.
+/// - Executes with the current directory set to the repository working tree.
+/// - `args` are passed as positional arguments; `stdin_data`, when `Some`, is
+///   fed on the hook's stdin (otherwise stdin is `/dev/null` so a hook that
+///   reads stdin can never hang the GUI on inherited process stdin).
+pub fn run_hook(
+    repo: &git2::Repository,
+    name: &str,
+    args: &[&str],
+    stdin_data: Option<&str>,
+) -> Result<HookOutcome> {
+    let not_run = HookOutcome {
+        ran: false,
+        success: true,
+        output: String::new(),
+    };
+
+    // Bare repositories have no working tree to run hooks against.
+    let workdir = match repo.workdir() {
+        Some(w) => w.to_path_buf(),
+        None => return Ok(not_run),
+    };
+
+    let hook_path = resolve_hooks_dir(repo).join(name);
+    if !is_executable(&hook_path) {
+        return Ok(not_run);
+    }
+
+    let mut cmd = std::process::Command::new(&hook_path);
+    cmd.current_dir(&workdir);
+    cmd.args(args);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    if stdin_data.is_some() {
+        cmd.stdin(Stdio::piped());
+    } else {
+        cmd.stdin(Stdio::null());
+    }
+
+    // Do NOT export GIT_DIR/GIT_WORK_TREE: hooks (e.g. husky, lint-staged)
+    // discover the repository from the working directory, and a stale GIT_DIR
+    // would misdirect them (and break linked worktrees). cwd = workdir is
+    // exactly what git relies on.
+
+    let mut child = cmd.spawn().map_err(|e| {
+        LeviathanError::OperationFailed(format!("Failed to run {} hook: {}", name, e))
+    })?;
+
+    if let Some(data) = stdin_data {
+        use std::io::Write;
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(data.as_bytes());
+        }
+        // stdin dropped here -> EOF for the hook.
+    }
+
+    let output = child.wait_with_output().map_err(|e| {
+        LeviathanError::OperationFailed(format!("Failed to run {} hook: {}", name, e))
+    })?;
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stderr.is_empty() {
+        if !combined.is_empty() && !combined.ends_with('\n') {
+            combined.push('\n');
+        }
+        combined.push_str(&stderr);
+    }
+
+    Ok(HookOutcome {
+        ran: true,
+        success: output.status.success(),
+        output: combined,
+    })
+}
+
+/// Run a blocking hook (pre-commit, commit-msg, pre-merge-commit, pre-push).
+/// A non-zero exit aborts the operation with the hook's output in the error,
+/// mirroring canonical git.
+pub fn run_hook_blocking(
+    repo: &git2::Repository,
+    name: &str,
+    args: &[&str],
+    stdin_data: Option<&str>,
+) -> Result<()> {
+    let outcome = run_hook(repo, name, args, stdin_data)?;
+    if outcome.ran && !outcome.success {
+        let detail = outcome.output.trim();
+        return Err(LeviathanError::OperationFailed(if detail.is_empty() {
+            format!("{} hook failed", name)
+        } else {
+            format!("{} hook failed:\n{}", name, detail)
+        }));
+    }
+    Ok(())
+}
+
+/// Run a non-blocking hook (post-commit, post-checkout, post-merge). Failures
+/// are logged but never abort the operation, mirroring canonical git.
+pub fn run_hook_noblock(repo: &git2::Repository, name: &str, args: &[&str]) {
+    match run_hook(repo, name, args, None) {
+        Ok(outcome) => {
+            if outcome.ran && !outcome.success {
+                tracing::warn!("{} hook exited non-zero: {}", name, outcome.output.trim());
+            }
+        }
+        Err(e) => tracing::warn!("failed to run {} hook: {}", name, e),
+    }
+}
+
+/// Run the commit-msg hook: write `message` to the per-worktree
+/// `COMMIT_EDITMSG` file, pass its path to the hook (which may rewrite it),
+/// and return the possibly-modified message. A non-zero exit aborts the commit.
+pub fn run_commit_msg_hook(repo: &git2::Repository, message: &str) -> Result<String> {
+    let hook_path = resolve_hooks_dir(repo).join("commit-msg");
+    if !is_executable(&hook_path) {
+        return Ok(message.to_string());
+    }
+
+    let msg_file = repo.path().join("COMMIT_EDITMSG");
+    std::fs::write(&msg_file, message)?;
+
+    let arg = msg_file.to_string_lossy().to_string();
+    run_hook_blocking(repo, "commit-msg", &[arg.as_str()], None)?;
+
+    // The hook may have edited the message file in place.
+    Ok(std::fs::read_to_string(&msg_file).unwrap_or_else(|_| message.to_string()))
+}
+
+/// Convenience wrapper for the post-checkout hook.
+/// `branch_switch` selects the flag argument git passes (1 = branch checkout,
+/// 0 = file checkout).
+pub fn run_post_checkout(
+    repo: &git2::Repository,
+    old_oid: &str,
+    new_oid: &str,
+    branch_switch: bool,
+) {
+    let flag = if branch_switch { "1" } else { "0" };
+    run_hook_noblock(repo, "post-checkout", &[old_oid, new_oid, flag]);
+}
+
+/// The all-zeros object id git uses for a missing ref (e.g. unborn HEAD or a
+/// remote ref that does not yet exist).
+pub const ZERO_OID: &str = "0000000000000000000000000000000000000000";
+
+/// Resolve HEAD to a full oid string, or [`ZERO_OID`] when HEAD is unborn.
+pub fn head_oid_string(repo: &git2::Repository) -> String {
+    repo.head()
+        .ok()
+        .and_then(|h| h.target())
+        .map(|o| o.to_string())
+        .unwrap_or_else(|| ZERO_OID.to_string())
+}
+
+/// The remote's fetch URL, falling back to the remote name (git passes the
+/// name as the second pre-push argument when no URL is configured).
+fn remote_url(repo: &git2::Repository, remote_name: &str) -> String {
+    let url = repo
+        .find_remote(remote_name)
+        .ok()
+        .map(|r| r.url().unwrap_or("").to_string())
+        .unwrap_or_default();
+    if url.is_empty() {
+        remote_name.to_string()
+    } else {
+        url
+    }
+}
+
+/// Run the pre-push hook for a branch push (blocking, git parity).
+///
+/// Passes `<remote-name> <remote-url>` as arguments and feeds the ref update
+/// line `<local ref> <local oid> <remote ref> <remote oid>` on stdin, per
+/// githooks(5). The remote oid is the known remote-tracking value or all-zeros
+/// when the remote ref does not exist yet. A non-zero exit aborts the push.
+pub fn run_pre_push_branch(
+    repo: &git2::Repository,
+    remote_name: &str,
+    branch_name: &str,
+) -> Result<()> {
+    let url = remote_url(repo, remote_name);
+
+    let local_ref = format!("refs/heads/{}", branch_name);
+    let local_oid = repo
+        .refname_to_id(&local_ref)
+        .map(|o| o.to_string())
+        .unwrap_or_else(|_| ZERO_OID.to_string());
+    let remote_ref = format!("refs/heads/{}", branch_name);
+    let remote_oid = repo
+        .refname_to_id(&format!("refs/remotes/{}/{}", remote_name, branch_name))
+        .map(|o| o.to_string())
+        .unwrap_or_else(|_| ZERO_OID.to_string());
+
+    let stdin = format!(
+        "{} {} {} {}\n",
+        local_ref, local_oid, remote_ref, remote_oid
+    );
+    run_hook_blocking(repo, "pre-push", &[remote_name, &url], Some(&stdin))
+}
+
+/// Run the pre-push hook for a tag push (blocking, git parity).
+pub fn run_pre_push_tag(repo: &git2::Repository, remote_name: &str, tag_name: &str) -> Result<()> {
+    let url = remote_url(repo, remote_name);
+
+    let local_ref = format!("refs/tags/{}", tag_name);
+    let local_oid = repo
+        .refname_to_id(&local_ref)
+        .map(|o| o.to_string())
+        .unwrap_or_else(|_| ZERO_OID.to_string());
+    // Tag refs are not mirrored into refs/remotes, so the remote side is
+    // treated as absent (all-zeros), matching a first-time tag push.
+    let stdin = format!("{} {} {} {}\n", local_ref, local_oid, local_ref, ZERO_OID);
+    run_hook_blocking(repo, "pre-push", &[remote_name, &url], Some(&stdin))
+}
 
 /// A git hook
 #[derive(Debug, Clone, serde::Serialize)]
@@ -323,5 +627,123 @@ mod tests {
         let repo = TestRepo::with_initial_commit();
         let result = delete_hook(repo.path_str(), "pre-commit".to_string()).await;
         assert!(result.is_ok()); // Should not error
+    }
+
+    // ---- Hook runner tests ----
+
+    #[cfg(unix)]
+    #[test]
+    fn test_run_hook_skips_nonexecutable() {
+        let repo = TestRepo::with_initial_commit();
+        // Write a hook file WITHOUT the executable bit.
+        let hooks_dir = repo.path.join(".git").join("hooks");
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+        std::fs::write(hooks_dir.join("pre-commit"), "#!/bin/sh\nexit 1\n").unwrap();
+
+        let git_repo = repo.repo();
+        let outcome = run_hook(&git_repo, "pre-commit", &[], None).unwrap();
+        assert!(!outcome.ran, "non-executable hook must be skipped");
+        // Blocking wrapper must NOT abort for a skipped hook.
+        assert!(run_hook_blocking(&git_repo, "pre-commit", &[], None).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_run_hook_blocking_aborts_on_failure() {
+        let repo = TestRepo::with_initial_commit();
+        repo.install_hook("pre-commit", "#!/bin/sh\necho nope 1>&2\nexit 1\n");
+        let git_repo = repo.repo();
+        let err = run_hook_blocking(&git_repo, "pre-commit", &[], None).unwrap_err();
+        assert!(
+            err.to_string().contains("nope"),
+            "hook output missing: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_run_hook_noblock_ignores_failure() {
+        let repo = TestRepo::with_initial_commit();
+        repo.install_hook("post-commit", "#!/bin/sh\nexit 3\n");
+        let git_repo = repo.repo();
+        // Must not panic or abort.
+        run_hook_noblock(&git_repo, "post-commit", &[]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_hookspath_absolute() {
+        let repo = TestRepo::with_initial_commit();
+        let alt = tempfile::tempdir().unwrap();
+        // Install an executable pre-commit in the alternate absolute dir.
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let hook = alt.path().join("pre-commit");
+            let marker = repo.path.join("abs-marker");
+            std::fs::write(
+                &hook,
+                format!("#!/bin/sh\ntouch \"{}\"\n", marker.display()),
+            )
+            .unwrap();
+            std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        {
+            let git_repo = repo.repo();
+            let mut cfg = git_repo.config().unwrap();
+            cfg.set_str("core.hooksPath", &alt.path().to_string_lossy())
+                .unwrap();
+        }
+        let git_repo = repo.repo();
+        let outcome = run_hook(&git_repo, "pre-commit", &[], None).unwrap();
+        assert!(outcome.ran, "hook under absolute core.hooksPath must run");
+        assert!(repo.path.join("abs-marker").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_hookspath_relative_resolves_against_workdir() {
+        let repo = TestRepo::with_initial_commit();
+        // Relative hooksPath resolves against the working directory.
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = repo.path.join("myhooks");
+            std::fs::create_dir_all(&dir).unwrap();
+            let hook = dir.join("pre-commit");
+            std::fs::write(&hook, "#!/bin/sh\nexit 7\n").unwrap();
+            std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        {
+            let git_repo = repo.repo();
+            let mut cfg = git_repo.config().unwrap();
+            cfg.set_str("core.hooksPath", "myhooks").unwrap();
+        }
+        let git_repo = repo.repo();
+        let outcome = run_hook(&git_repo, "pre-commit", &[], None).unwrap();
+        assert!(outcome.ran, "relative core.hooksPath hook must run");
+        assert!(!outcome.success, "hook exited 7");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_commit_msg_hook_rewrites_message() {
+        let repo = TestRepo::with_initial_commit();
+        // Append a trailer to whatever message is passed.
+        repo.install_hook(
+            "commit-msg",
+            "#!/bin/sh\necho '\nSigned-off-by: hook' >> \"$1\"\nexit 0\n",
+        );
+        let git_repo = repo.repo();
+        let out = run_commit_msg_hook(&git_repo, "original message").unwrap();
+        assert!(out.starts_with("original message"));
+        assert!(out.contains("Signed-off-by: hook"), "got: {out:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_commit_msg_hook_can_abort() {
+        let repo = TestRepo::with_initial_commit();
+        repo.install_hook("commit-msg", "#!/bin/sh\nexit 1\n");
+        let git_repo = repo.repo();
+        assert!(run_commit_msg_hook(&git_repo, "msg").is_err());
     }
 }

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -122,11 +122,24 @@ pub async fn merge(
         // state so the user isn't stuck with a half-merged repo.
         repo.merge(&[&annotated_commit], None, None)?;
 
-        let result = (|| -> Result<()> {
-            if repo.index()?.has_conflicts() {
-                return Err(LeviathanError::MergeConflict);
-            }
+        // A conflict is the expected "user must resolve" path; the UI drives a
+        // conflict-resolution flow that needs MERGE_HEAD intact (and
+        // `abort_merge` to undo), so return before any cleanup.
+        if repo.index()?.has_conflicts() {
+            return Err(LeviathanError::MergeConflict);
+        }
 
+        // git runs pre-merge-commit before creating the automatic merge commit,
+        // but a non-zero exit does NOT abort the merge — git leaves
+        // MERGE_HEAD/MERGE_MSG in place ("Not committing merge; use 'git commit'
+        // to complete the merge"). So on a veto, return WITHOUT cleanup_state,
+        // keeping the merge resumable via commit_merge and abortable via
+        // abort_merge. (A squash merge records no merge commit, so no hook.)
+        if !squash.unwrap_or(false) {
+            crate::commands::hooks::run_hook_blocking(&repo, "pre-merge-commit", &[], None)?;
+        }
+
+        let result = (|| -> Result<()> {
             let signature = repo.signature()?;
             let head = repo.head()?.peel_to_commit()?;
             let tree_oid = repo.index()?.write_tree()?;
@@ -148,10 +161,6 @@ pub async fn merge(
                     &[&head],
                 )?;
             } else {
-                // git runs pre-merge-commit before creating an automatic merge
-                // commit; a non-zero exit aborts the merge (blocking).
-                crate::commands::hooks::run_hook_blocking(&repo, "pre-merge-commit", &[], None)?;
-
                 let source_commit = repo.find_commit(annotated_commit.id())?;
                 repo.commit(
                     Some("HEAD"),
@@ -168,19 +177,11 @@ pub async fn merge(
             Ok(())
         })();
 
-        // MergeConflict is the expected "user must resolve" path; the UI
-        // drives a conflict-resolution flow that needs MERGE_HEAD intact
-        // (and `abort_merge` to undo). Only call cleanup_state for
-        // non-conflict errors (disk-full, signature missing, etc.).
-        match result {
-            Err(LeviathanError::MergeConflict) => {
-                return Err(LeviathanError::MergeConflict);
-            }
-            Err(e) => {
-                let _ = repo.cleanup_state();
-                return Err(e);
-            }
-            Ok(()) => {}
+        // A genuine commit-phase failure (missing signature, disk error) still
+        // resets the half-merged state so the user isn't stuck.
+        if let Err(e) = result {
+            let _ = repo.cleanup_state();
+            return Err(e);
         }
 
         repo.cleanup_state()?;
@@ -2516,14 +2517,26 @@ theirs
         .await;
         assert!(
             result.is_err(),
-            "pre-merge-commit exit 1 must abort the merge"
+            "pre-merge-commit exit 1 must stop the automatic merge commit"
         );
         assert!(result.unwrap_err().to_string().contains("denied"));
 
-        // Merge must be aborted: state clean and HEAD unmoved.
+        // git does NOT abort on a pre-merge-commit veto: it leaves the merge
+        // resumable ("use 'git commit' to complete the merge"). So MERGE_HEAD
+        // must survive (state == Merge) and HEAD must not have moved yet.
         let git_repo = repo.repo();
-        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        assert_eq!(git_repo.state(), git2::RepositoryState::Merge);
         assert_eq!(repo.head_oid(), head_before);
+
+        // The merge must remain completable via commit_merge (hooks aside).
+        commit_merge(repo.path_str(), None, None).await.unwrap();
+        let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(
+            head.parent_count(),
+            2,
+            "completing the merge yields a merge commit"
+        );
+        assert_eq!(repo.repo().state(), git2::RepositoryState::Clean);
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -139,17 +139,27 @@ pub async fn merge(
             crate::commands::hooks::run_hook_blocking(&repo, "pre-merge-commit", &[], None)?;
         }
 
+        // Default to the MERGE_MSG libgit2 wrote during repo.merge() — git's
+        // canonical auto-message ("Merge branch 'feature'") — with '#' comment
+        // lines stripped, like `git commit` does.
+        let commit_message = message.unwrap_or_else(|| default_merge_message(&repo, &source_ref));
+
+        // git runs commit-msg for an automatic merge commit (after
+        // pre-merge-commit); the hook may rewrite the message or veto it. Like
+        // pre-merge-commit, a veto leaves the merge resumable, so run it before
+        // the cleanup-guarded commit closure. (A squash merge records no merge
+        // commit, so no hook — matching `git merge --squash`.)
+        let commit_message = if squash.unwrap_or(false) {
+            commit_message
+        } else {
+            crate::commands::hooks::run_commit_msg_hook(&repo, &commit_message)?
+        };
+
         let result = (|| -> Result<()> {
             let signature = repo.signature()?;
             let head = repo.head()?.peel_to_commit()?;
             let tree_oid = repo.index()?.write_tree()?;
             let tree = repo.find_tree(tree_oid)?;
-
-            // Default to the MERGE_MSG libgit2 wrote during repo.merge() —
-            // git's canonical auto-message ("Merge branch 'feature'") — with
-            // '#' comment lines stripped, like `git commit` does.
-            let commit_message =
-                message.unwrap_or_else(|| default_merge_message(&repo, &source_ref));
 
             if squash.unwrap_or(false) {
                 repo.commit(
@@ -2537,6 +2547,42 @@ theirs
             "completing the merge yields a merge commit"
         );
         assert_eq!(repo.repo().state(), git2::RepositoryState::Clean);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_merge_runs_commit_msg_hook() {
+        // git runs commit-msg for an automatic (non-conflict) merge commit; the
+        // hook may rewrite the message. Verify it fires and its edit lands.
+        let repo = TestRepo::with_initial_commit();
+        let initial = repo.current_branch();
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature", &[("feature.txt", "content")]);
+        repo.checkout_branch(&initial);
+
+        repo.install_hook(
+            "commit-msg",
+            "#!/bin/sh\necho 'Reviewed-by: hook' >> \"$1\"\n",
+        );
+
+        merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let git_repo = repo.repo();
+        let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+        assert!(
+            head.message().unwrap().contains("Reviewed-by: hook"),
+            "commit-msg hook must run and rewrite the auto-merge message, got: {:?}",
+            head.message()
+        );
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -112,6 +112,10 @@ pub async fn merge(
 
         let mut reference = repo.find_reference(refname)?;
         reference.set_target(target_oid, "Fast-forward merge")?;
+
+        // git runs post-merge after a fast-forward merge too (flag 0 = not a
+        // squash merge). Non-blocking.
+        crate::commands::hooks::run_hook_noblock(&repo, "post-merge", &["0"]);
     } else {
         // Normal or squash merge. Once repo.merge() succeeds the index/working
         // tree is in MERGING state; any subsequent failure must reset that
@@ -144,6 +148,10 @@ pub async fn merge(
                     &[&head],
                 )?;
             } else {
+                // git runs pre-merge-commit before creating an automatic merge
+                // commit; a non-zero exit aborts the merge (blocking).
+                crate::commands::hooks::run_hook_blocking(&repo, "pre-merge-commit", &[], None)?;
+
                 let source_commit = repo.find_commit(annotated_commit.id())?;
                 repo.commit(
                     Some("HEAD"),
@@ -153,6 +161,9 @@ pub async fn merge(
                     &tree,
                     &[&head, &source_commit],
                 )?;
+
+                // post-merge after the merge commit (flag 0 = not a squash).
+                crate::commands::hooks::run_hook_noblock(&repo, "post-merge", &["0"]);
             }
             Ok(())
         })();
@@ -309,10 +320,17 @@ pub async fn commit_merge(
         })
         .unwrap_or_else(|| "Merge".to_string());
 
-    // Route signed commits through the git CLI (git2 cannot sign).
+    // Route signed commits through the git CLI (git2 cannot sign) — which runs
+    // hooks natively.
     if crate::commands::commit::should_sign_commit(&path, None)? {
         return commit_merge_signed(&path, &commit_message, is_squash).await;
     }
+
+    // Concluding a (conflicted) merge via `git commit` runs pre-commit and
+    // commit-msg; the git2 path otherwise bypasses them. pre-commit can veto;
+    // commit-msg can veto or rewrite the message.
+    crate::commands::hooks::run_hook_blocking(&repo, "pre-commit", &[], None)?;
+    let commit_message = crate::commands::hooks::run_commit_msg_hook(&repo, &commit_message)?;
 
     let mut index = repo.index()?;
     let tree_oid = index.write_tree()?;
@@ -347,6 +365,10 @@ pub async fn commit_merge(
         )?;
     }
     repo.cleanup_state()?;
+
+    // post-commit runs after the merge commit is recorded; never blocks.
+    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
+
     Ok(())
 }
 
@@ -2412,5 +2434,99 @@ theirs
 
         let result = get_conflict_details(repo.path_str(), "nonexistent.txt".to_string()).await;
         assert!(result.is_err());
+    }
+
+    // ---- merge hook parity ----
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_merge_pre_merge_commit_hook_aborts() {
+        let repo = TestRepo::with_initial_commit();
+        let initial = repo.current_branch();
+        let head_before = repo.head_oid();
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature", &[("feature.txt", "content")]);
+        repo.checkout_branch(&initial);
+
+        repo.install_hook("pre-merge-commit", "#!/bin/sh\necho denied 1>&2\nexit 1\n");
+
+        // no_ff forces an actual merge commit, so pre-merge-commit must run.
+        let result = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "pre-merge-commit exit 1 must abort the merge"
+        );
+        assert!(result.unwrap_err().to_string().contains("denied"));
+
+        // Merge must be aborted: state clean and HEAD unmoved.
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        assert_eq!(repo.head_oid(), head_before);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_merge_runs_post_merge_hook() {
+        let repo = TestRepo::with_initial_commit();
+        let initial = repo.current_branch();
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature", &[("feature.txt", "content")]);
+        repo.checkout_branch(&initial);
+
+        let marker = repo.path.join("post-merge.log");
+        repo.install_hook(
+            "post-merge",
+            &format!("#!/bin/sh\necho \"$1\" > \"{}\"\n", marker.display()),
+        );
+
+        merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let logged = std::fs::read_to_string(&marker).expect("post-merge must run");
+        assert_eq!(logged.trim(), "0", "post-merge flag must be 0 (not squash)");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_fast_forward_merge_runs_post_merge_hook() {
+        let repo = TestRepo::with_initial_commit();
+        let initial = repo.current_branch();
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature", &[("feature.txt", "content")]);
+        repo.checkout_branch(&initial);
+
+        let marker = repo.path.join("post-merge.log");
+        repo.install_hook(
+            "post-merge",
+            &format!("#!/bin/sh\ntouch \"{}\"\n", marker.display()),
+        );
+
+        // Plain fast-forward merge.
+        merge(repo.path_str(), "feature".to_string(), None, None, None)
+            .await
+            .unwrap();
+
+        assert!(
+            marker.exists(),
+            "post-merge must run after fast-forward too"
+        );
     }
 }

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -31,6 +31,27 @@ pub async fn merge(
 ) -> Result<()> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
+    // Like git's pre-merge checks: refuse to start a merge while another
+    // operation is in progress, with an actionable message (instead of the
+    // misleading libgit2 "uncommitted change would be overwritten" error).
+    match repo.state() {
+        git2::RepositoryState::Clean => {}
+        git2::RepositoryState::Merge => {
+            return Err(LeviathanError::OperationFailed(
+                "You have not concluded your merge (MERGE_HEAD exists). \
+                 Resolve the conflicts and commit, or abort the merge, before merging again."
+                    .to_string(),
+            ));
+        }
+        state => {
+            return Err(LeviathanError::OperationFailed(format!(
+                "Cannot merge: another operation is in progress ({:?}). \
+                 Complete or abort it first.",
+                state
+            )));
+        }
+    }
+
     // Find the commit to merge
     let reference = repo
         .find_reference(&format!("refs/heads/{}", source_ref))
@@ -45,17 +66,52 @@ pub async fn merge(
     }
 
     if analysis.is_fast_forward() && !no_ff.unwrap_or(false) && !squash.unwrap_or(false) {
-        // Fast-forward merge
+        // Fast-forward merge. Check out the target tree SAFELY first — git
+        // aborts a merge that would overwrite local changes or untracked
+        // files — and only move the branch ref once the checkout succeeded.
         let target_oid = annotated_commit.id();
+        let target_commit = repo.find_commit(target_oid)?;
         let head = repo.head()?;
         let refname = head
             .name()
             .ok()
             .ok_or_else(|| LeviathanError::InvalidReference)?;
 
+        // Collect the conflicting paths so the error can name them, like
+        // git's "Your local changes to the following files ..." message.
+        let conflict_paths = std::rc::Rc::new(std::cell::RefCell::new(Vec::<String>::new()));
+        let notify_paths = std::rc::Rc::clone(&conflict_paths);
+        let mut checkout = git2::build::CheckoutBuilder::new();
+        checkout
+            .notify_on(git2::CheckoutNotificationType::CONFLICT)
+            .notify(move |_why, path, _baseline, _target, _workdir| {
+                if let Some(p) = path {
+                    notify_paths.borrow_mut().push(p.display().to_string());
+                }
+                true
+            });
+
+        match repo.checkout_tree(target_commit.as_object(), Some(&mut checkout)) {
+            Ok(()) => {}
+            Err(e) if e.code() == git2::ErrorCode::Conflict => {
+                let files = conflict_paths.borrow().join(", ");
+                return Err(LeviathanError::OperationFailed(if files.is_empty() {
+                    "Your local changes would be overwritten by merge. \
+                     Commit or stash them before you merge."
+                        .to_string()
+                } else {
+                    format!(
+                        "Your local changes to the following files would be \
+                         overwritten by merge: {}. Commit or stash them before you merge.",
+                        files
+                    )
+                }));
+            }
+            Err(e) => return Err(e.into()),
+        }
+
         let mut reference = repo.find_reference(refname)?;
         reference.set_target(target_oid, "Fast-forward merge")?;
-        repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
     } else {
         // Normal or squash merge. Once repo.merge() succeeds the index/working
         // tree is in MERGING state; any subsequent failure must reset that
@@ -72,8 +128,11 @@ pub async fn merge(
             let tree_oid = repo.index()?.write_tree()?;
             let tree = repo.find_tree(tree_oid)?;
 
+            // Default to the MERGE_MSG libgit2 wrote during repo.merge() —
+            // git's canonical auto-message ("Merge branch 'feature'") — with
+            // '#' comment lines stripped, like `git commit` does.
             let commit_message =
-                message.unwrap_or_else(|| format!("Merge '{}' into HEAD", source_ref));
+                message.unwrap_or_else(|| default_merge_message(&repo, &source_ref));
 
             if squash.unwrap_or(false) {
                 repo.commit(
@@ -119,12 +178,71 @@ pub async fn merge(
     Ok(())
 }
 
-/// Abort an in-progress merge
+/// Default merge-commit message: the MERGE_MSG that libgit2 wrote when the
+/// merge started (git's canonical wording, e.g. "Merge branch 'feature'"),
+/// with '#' comment lines stripped the way `git commit` cleans messages.
+/// Falls back to git's canonical subject if MERGE_MSG is missing or empty.
+fn default_merge_message(repo: &git2::Repository, source_ref: &str) -> String {
+    std::fs::read_to_string(repo.path().join("MERGE_MSG"))
+        .ok()
+        .map(|m| {
+            m.lines()
+                .filter(|line| !line.starts_with('#'))
+                .collect::<Vec<_>>()
+                .join("\n")
+                .trim_end()
+                .to_string()
+        })
+        .filter(|m| !m.trim().is_empty())
+        .unwrap_or_else(|| format!("Merge branch '{}'", source_ref))
+}
+
+/// Abort an in-progress merge.
+///
+/// Mirrors `git merge --abort` (implemented as `git reset --merge`): only the
+/// paths the merge touched — where the index differs from HEAD, including
+/// conflicted and newly-added entries — are restored to HEAD. Uncommitted
+/// changes to files the merge did not touch are preserved, exactly like git.
 #[command]
 pub async fn abort_merge(path: String) -> Result<()> {
     let repo = git2::Repository::open(Path::new(&path))?;
+
+    // git: "fatal: There is no merge to abort (MERGE_HEAD missing)."
+    if repo.state() != git2::RepositoryState::Merge {
+        return Err(LeviathanError::OperationFailed(
+            "There is no merge to abort (MERGE_HEAD missing).".to_string(),
+        ));
+    }
+
+    // Paths written by the merge: everything where the index (auto-merged,
+    // conflicted, or newly added by the merge) differs from HEAD.
+    let head_tree = repo.head()?.peel_to_tree()?;
+    let index = repo.index()?;
+    let diff = repo.diff_tree_to_index(Some(&head_tree), Some(&index), None)?;
+
+    let mut touched: Vec<std::path::PathBuf> = Vec::new();
+    for delta in diff.deltas() {
+        for file in [delta.old_file(), delta.new_file()] {
+            if let Some(p) = file.path() {
+                if !touched.iter().any(|t| t == p) {
+                    touched.push(p.to_path_buf());
+                }
+            }
+        }
+    }
+
+    // Restore ONLY those paths to HEAD (force is scoped to them); everything
+    // else in the working tree is left alone.
+    if !touched.is_empty() {
+        let mut checkout = git2::build::CheckoutBuilder::new();
+        checkout.force();
+        for p in &touched {
+            checkout.path(p);
+        }
+        repo.checkout_head(Some(&mut checkout))?;
+    }
+
     repo.cleanup_state()?;
-    repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
     Ok(())
 }
 
@@ -1263,13 +1381,78 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_abort_merge() {
+    async fn test_abort_merge_without_merge_in_progress_errors() {
+        // `git merge --abort` fails with "fatal: There is no merge to abort
+        // (MERGE_HEAD missing)." and leaves staged work untouched. It must
+        // NOT silently hard-reset the index and working tree.
         let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add file", &[("a.txt", "base")]);
+        repo.create_file("a.txt", "staged precious work");
+        repo.stage_file("a.txt");
 
-        // Even without an active merge, abort_merge should succeed
-        // (it just cleans up state and checks out HEAD)
         let result = abort_merge(repo.path_str()).await;
-        assert!(result.is_ok());
+        assert!(
+            result.is_err(),
+            "abort_merge without a merge in progress must fail like git"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("no merge to abort"),
+            "unexpected message: {msg}"
+        );
+
+        // The staged edit is untouched.
+        let content = std::fs::read_to_string(repo.path.join("a.txt")).unwrap();
+        assert_eq!(content, "staged precious work");
+        let git_repo = repo.repo();
+        let statuses = git_repo.statuses(None).unwrap();
+        let entry = statuses
+            .iter()
+            .find(|s| s.path().ok() == Some("a.txt"))
+            .expect("a.txt should still have a status entry");
+        assert!(entry.status().contains(git2::Status::INDEX_MODIFIED));
+    }
+
+    #[tokio::test]
+    async fn test_abort_merge_preserves_unrelated_uncommitted_changes() {
+        // `git merge --abort` (git reset --merge) restores only what the
+        // merge touched; uncommitted changes to unrelated files survive.
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit(
+            "Add files",
+            &[("shared.txt", "base"), ("notes.txt", "notes\n")],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+
+        // Uncommitted edit to a file the merge does not touch.
+        repo.create_file("notes.txt", "notes\nmy uncommitted notes\n");
+
+        let result = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        assert!(matches!(result, Err(LeviathanError::MergeConflict)));
+
+        abort_merge(repo.path_str()).await.unwrap();
+
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        assert!(!git_repo.index().unwrap().has_conflicts());
+        // The merged file is restored to HEAD...
+        let shared = std::fs::read_to_string(repo.path.join("shared.txt")).unwrap();
+        assert_eq!(shared, "main content");
+        // ...but the unrelated uncommitted edit is preserved, like git.
+        let notes = std::fs::read_to_string(repo.path.join("notes.txt")).unwrap();
+        assert_eq!(notes, "notes\nmy uncommitted notes\n");
     }
 
     #[tokio::test]
@@ -1476,6 +1659,132 @@ mod tests {
 
         // Should return MergeConflict error
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_merge_ff_refuses_to_overwrite_local_changes() {
+        // git aborts a fast-forward merge that would overwrite uncommitted
+        // local changes ("Your local changes to the following files would be
+        // overwritten by merge ... Aborting"), leaving the ref unmoved.
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit("Add file", &[("file.txt", "base")]);
+        let pre_merge_oid = repo.head_oid();
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("file.txt", "feature")]);
+        repo.checkout_branch(&initial_branch);
+
+        // Uncommitted local edit the fast-forward checkout would overwrite.
+        repo.create_file("file.txt", "my precious local edit");
+
+        let result = merge(repo.path_str(), "feature".to_string(), None, None, None).await;
+        assert!(
+            result.is_err(),
+            "fast-forward merge over local changes must refuse like git"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("overwritten by merge"),
+            "unexpected message: {msg}"
+        );
+
+        // Local edit preserved and ref unmoved.
+        let content = std::fs::read_to_string(repo.path.join("file.txt")).unwrap();
+        assert_eq!(content, "my precious local edit");
+        assert_eq!(repo.head_oid(), pre_merge_oid);
+    }
+
+    #[tokio::test]
+    async fn test_merge_ff_refuses_to_overwrite_untracked_file() {
+        // git: "The following untracked working tree files would be
+        // overwritten by merge ... Aborting".
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Add new file", &[("new.txt", "feature version")]);
+        repo.checkout_branch(&initial_branch);
+        let pre_merge_oid = repo.head_oid();
+
+        // Precious untracked file the fast-forward would overwrite.
+        repo.create_file("new.txt", "precious untracked content");
+
+        let result = merge(repo.path_str(), "feature".to_string(), None, None, None).await;
+        assert!(
+            result.is_err(),
+            "fast-forward merge over an untracked file must refuse like git"
+        );
+
+        let content = std::fs::read_to_string(repo.path.join("new.txt")).unwrap();
+        assert_eq!(content, "precious untracked content");
+        assert_eq!(repo.head_oid(), pre_merge_oid);
+    }
+
+    #[tokio::test]
+    async fn test_merge_refuses_when_merge_already_in_progress() {
+        // git: "error: Merging is not possible because you have unmerged
+        // files." / "You have not concluded your merge (MERGE_HEAD exists)."
+        // — not a misleading "uncommitted change would be overwritten".
+        let repo = TestRepo::with_initial_commit();
+        setup_conflicting_branches(&repo);
+
+        let result = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        assert!(matches!(result, Err(LeviathanError::MergeConflict)));
+
+        let result = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        let msg = result
+            .expect_err("merging while a merge is in progress must fail")
+            .to_string();
+        assert!(
+            msg.contains("not concluded your merge"),
+            "unexpected message: {msg}"
+        );
+        // The original merge state stays intact for resolve/abort.
+        assert_eq!(repo.repo().state(), git2::RepositoryState::Merge);
+    }
+
+    #[tokio::test]
+    async fn test_merge_default_message_is_canonical() {
+        // `git merge --no-edit feature` produces the subject
+        // "Merge branch 'feature'", not "Merge 'feature' into HEAD".
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature commit", &[("feature.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+
+        merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let git_repo = repo.repo();
+        let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(head.summary().unwrap(), Some("Merge branch 'feature'"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -194,7 +194,7 @@ pub async fn merge(
 /// with '#' comment lines stripped the way `git commit` cleans messages.
 /// Falls back to git's canonical subject if MERGE_MSG is missing or empty.
 fn default_merge_message(repo: &git2::Repository, source_ref: &str) -> String {
-    std::fs::read_to_string(repo.path().join("MERGE_MSG"))
+    let base = std::fs::read_to_string(repo.path().join("MERGE_MSG"))
         .ok()
         .map(|m| {
             m.lines()
@@ -205,7 +205,29 @@ fn default_merge_message(repo: &git2::Repository, source_ref: &str) -> String {
                 .to_string()
         })
         .filter(|m| !m.trim().is_empty())
-        .unwrap_or_else(|| format!("Merge branch '{}'", source_ref))
+        .unwrap_or_else(|| format!("Merge branch '{}'", source_ref));
+
+    // git appends " into <branch>" to the merge subject unless the current
+    // branch is "master" or "main" (see fmt-merge-msg / builtin/merge.c).
+    // libgit2's MERGE_MSG never adds this suffix, so apply git's rule here so
+    // teams whose integration branch is develop/trunk/release get the canonical
+    // subject ("Merge branch 'feature' into develop").
+    let current: Option<String> = match repo.head() {
+        Ok(h) => h.shorthand().map(|s| s.to_string()).ok(),
+        Err(_) => None,
+    };
+    match current.as_deref() {
+        Some(branch) if branch != "master" && branch != "main" && branch != "HEAD" => {
+            let mut lines: Vec<String> = base.lines().map(|s| s.to_string()).collect();
+            if let Some(first) = lines.first_mut() {
+                if !first.contains(" into ") {
+                    *first = format!("{first} into {branch}");
+                }
+            }
+            lines.join("\n")
+        }
+        _ => base,
+    }
 }
 
 /// Abort an in-progress merge.
@@ -1807,6 +1829,37 @@ mod tests {
         let git_repo = repo.repo();
         let head = git_repo.head().unwrap().peel_to_commit().unwrap();
         assert_eq!(head.summary().unwrap(), Some("Merge branch 'feature'"));
+    }
+
+    #[tokio::test]
+    async fn test_merge_default_message_into_nondefault_branch() {
+        // git appends " into <branch>" to the merge subject for any branch
+        // other than master/main. Merging feature into "develop" must yield
+        // "Merge branch 'feature' into develop".
+        let repo = TestRepo::with_initial_commit();
+        repo.create_branch("develop");
+        repo.checkout_branch("develop");
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature commit", &[("feature.txt", "content")]);
+        repo.checkout_branch("develop");
+
+        merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let git_repo = repo.repo();
+        let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(
+            head.summary().unwrap(),
+            Some("Merge branch 'feature' into develop")
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/patch.rs
+++ b/src-tauri/src/commands/patch.rs
@@ -28,7 +28,21 @@ pub async fn create_patch(
             None
         };
 
-        let diff = repo.diff_tree_to_tree(parent.as_ref(), Some(&commit.tree()?), None)?;
+        // Enable binary patch output and full (40-char) blob ids so that
+        // patches touching binary files contain a real "GIT binary patch"
+        // section that `git am`/`git apply` can apply, rather than an
+        // unapplyable "Binary files ... differ" placeholder.
+        let mut diff_opts = git2::DiffOptions::new();
+        diff_opts.show_binary(true);
+        diff_opts.id_abbrev(40);
+        let mut diff =
+            repo.diff_tree_to_tree(parent.as_ref(), Some(&commit.tree()?), Some(&mut diff_opts))?;
+
+        // Detect renames/copies so a moved file is emitted as a compact
+        // "rename from/to" instead of a full delete + add (git's default).
+        let mut find_opts = git2::DiffFindOptions::new();
+        find_opts.renames(true);
+        diff.find_similar(Some(&mut find_opts))?;
 
         // Format patch
         let mut patch_content = String::new();
@@ -86,19 +100,20 @@ pub async fn create_patch(
         patch_content.push_str(stats_buf.as_str().unwrap_or(""));
         patch_content.push('\n');
 
-        // Actual diff
+        // Actual diff. Accumulate as raw bytes so that non-UTF8 content
+        // (Latin-1, Shift-JIS, binary literal data, ...) is written verbatim
+        // instead of being silently dropped, which would corrupt the patch.
+        let mut patch_bytes = patch_content.into_bytes();
         diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
             let origin = line.origin();
             if origin == '+' || origin == '-' || origin == ' ' {
-                patch_content.push(origin);
+                patch_bytes.push(origin as u8);
             }
-            if let Ok(content) = std::str::from_utf8(line.content()) {
-                patch_content.push_str(content);
-            }
+            patch_bytes.extend_from_slice(line.content());
             true
         })?;
 
-        patch_content.push_str("\n-- \n");
+        patch_bytes.extend_from_slice(b"\n-- \n");
 
         // Write patch file
         let short_id = &oid_str[..8.min(oid_str.len())];
@@ -118,7 +133,7 @@ pub async fn create_patch(
         if let Some(parent_dir) = patch_path.parent() {
             std::fs::create_dir_all(parent_dir)?;
         }
-        std::fs::write(&patch_path, &patch_content)?;
+        std::fs::write(&patch_path, &patch_bytes)?;
         patch_files.push(patch_path.to_string_lossy().to_string());
     }
 
@@ -134,8 +149,13 @@ pub async fn apply_patch(path: String, patch_path: String, check_only: Option<bo
     let diff = git2::Diff::from_buffer(&patch_content)?;
 
     if check_only.unwrap_or(false) {
-        // Dry run - just check if patch applies cleanly
-        repo.apply(&diff, git2::ApplyLocation::WorkDir, None)
+        // Dry run - just check if patch applies cleanly. Without
+        // ApplyOptions::check(true) libgit2 performs a REAL apply and writes
+        // the changes to the working tree (git apply --check must not modify
+        // anything).
+        let mut apply_opts = git2::ApplyOptions::new();
+        apply_opts.check(true);
+        repo.apply(&diff, git2::ApplyLocation::WorkDir, Some(&mut apply_opts))
             .map_err(|e| {
                 LeviathanError::OperationFailed(format!("Patch would not apply cleanly: {}", e))
             })?;
@@ -274,6 +294,141 @@ mod tests {
         .await;
 
         assert!(result.is_err());
+    }
+
+    /// Finding 58: `check_only` must NOT modify the working tree (git apply --check).
+    #[tokio::test]
+    async fn test_apply_patch_check_only_does_not_modify_worktree() {
+        let source = TestRepo::with_initial_commit();
+        source.create_commit("base", &[("f.txt", "base\n")]);
+        let oid = source.create_commit("change", &[("f.txt", "base\nadded line\n")]);
+
+        let output_dir = source.path.join("patches");
+        std::fs::create_dir_all(&output_dir).unwrap();
+        let files = create_patch(
+            source.path_str(),
+            vec![oid.to_string()],
+            output_dir.to_string_lossy().to_string(),
+        )
+        .await
+        .unwrap();
+
+        // Target repo whose working tree matches the patch's base ("base\n").
+        let target = TestRepo::with_initial_commit();
+        target.create_commit("base", &[("f.txt", "base\n")]);
+        let target_file = target.path.join("f.txt");
+        let before = std::fs::read_to_string(&target_file).unwrap();
+
+        let result = apply_patch(target.path_str(), files[0].clone(), Some(true)).await;
+        assert!(result.is_ok(), "check-only should report the patch applies");
+
+        let after = std::fs::read_to_string(&target_file).unwrap();
+        assert_eq!(
+            before, after,
+            "check_only=true must leave the working tree byte-identical"
+        );
+        assert_eq!(after, "base\n");
+    }
+
+    /// Finding 64: a patch touching a binary file must contain a real
+    /// "GIT binary patch" section, not an unapplyable placeholder.
+    #[tokio::test]
+    async fn test_create_patch_binary_file_produces_git_binary_patch() {
+        let source = TestRepo::with_initial_commit();
+
+        // Commit a binary blob (contains NUL / high bytes -> git treats as binary).
+        let binary: Vec<u8> = (0u16..256).map(|b| (b % 256) as u8).collect();
+        let bin_path = source.path.join("blob.bin");
+        std::fs::write(&bin_path, &binary).unwrap();
+        let repo = source.repo();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("blob.bin")).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let sig = repo.signature().unwrap();
+        let parent = repo.head().unwrap().peel_to_commit().unwrap();
+        let oid = repo
+            .commit(Some("HEAD"), &sig, &sig, "add binary", &tree, &[&parent])
+            .unwrap();
+
+        let output_dir = source.path.join("patches");
+        std::fs::create_dir_all(&output_dir).unwrap();
+        let files = create_patch(
+            source.path_str(),
+            vec![oid.to_string()],
+            output_dir.to_string_lossy().to_string(),
+        )
+        .await
+        .unwrap();
+
+        let contents = std::fs::read_to_string(&files[0]).unwrap();
+        assert!(
+            contents.contains("GIT binary patch"),
+            "binary patch section missing; got:\n{}",
+            contents
+        );
+        assert!(
+            !contents.contains("Binary files"),
+            "should not emit the unapplyable 'Binary files differ' placeholder"
+        );
+
+        // The exported patch must be applyable to a fresh repo.
+        let target = TestRepo::with_initial_commit();
+        let apply_result = apply_patch(target.path_str(), files[0].clone(), None).await;
+        assert!(
+            apply_result.is_ok(),
+            "binary patch should apply cleanly: {:?}",
+            apply_result.err()
+        );
+        let applied = std::fs::read(target.path.join("blob.bin")).unwrap();
+        assert_eq!(applied, binary, "applied binary content must round-trip");
+    }
+
+    /// Finding 65: non-UTF8 diff content must be written verbatim, not dropped.
+    #[tokio::test]
+    async fn test_create_patch_preserves_non_utf8_bytes() {
+        let source = TestRepo::with_initial_commit();
+
+        // A file containing a Latin-1 0xE9 byte ("café" in ISO-8859-1).
+        let latin1: Vec<u8> = vec![b'c', b'a', b'f', 0xE9, b'\n'];
+        let file_path = source.path.join("latin1.txt");
+        std::fs::write(&file_path, &latin1).unwrap();
+        let repo = source.repo();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("latin1.txt")).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let sig = repo.signature().unwrap();
+        let parent = repo.head().unwrap().peel_to_commit().unwrap();
+        let oid = repo
+            .commit(Some("HEAD"), &sig, &sig, "add latin1", &tree, &[&parent])
+            .unwrap();
+
+        let output_dir = source.path.join("patches");
+        std::fs::create_dir_all(&output_dir).unwrap();
+        let files = create_patch(
+            source.path_str(),
+            vec![oid.to_string()],
+            output_dir.to_string_lossy().to_string(),
+        )
+        .await
+        .unwrap();
+
+        let bytes = std::fs::read(&files[0]).unwrap();
+        // The raw 0xE9 byte must survive into the patch body.
+        assert!(
+            bytes.windows(1).any(|w| w == [0xE9]),
+            "non-UTF8 byte 0xE9 was dropped from the patch"
+        );
+        // And it must be preceded by the '+' add marker + "caf".
+        assert!(
+            bytes
+                .windows(5)
+                .any(|w| w == [b'+', b'c', b'a', b'f', 0xE9]),
+            "the '+' marker and content must stay glued to the byte"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/path_utils.rs
+++ b/src-tauri/src/commands/path_utils.rs
@@ -3,18 +3,22 @@
 //! Prevents directory traversal attacks (CWE-22) by ensuring
 //! user-provided file paths stay within the repository directory.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::error::{LeviathanError, Result};
 
 /// Validate that a file path stays within the repository directory.
 ///
-/// Rejects absolute paths and paths containing `..` components.
+/// Rejects absolute paths and paths containing a `..` (parent-directory)
+/// component. Note this is a *component* check, not a substring check: a
+/// filename such as `v1..v2.diff` or `...` is a legitimate pathname that git
+/// tracks normally, so it must be accepted — only a literal `..` path segment
+/// is rejected.
 /// Canonicalizes the deepest existing ancestor to detect symlink-based escapes.
 /// Works for both existing files and paths where the file may not exist yet.
 pub fn validate_path_within_repo(repo_path: &Path, file_path: &str) -> Result<PathBuf> {
     let rel = Path::new(file_path);
-    if rel.is_absolute() || file_path.contains("..") {
+    if rel.is_absolute() || rel.components().any(|c| matches!(c, Component::ParentDir)) {
         return Err(LeviathanError::InvalidPath(
             "File path must be relative and cannot contain '..'".to_string(),
         ));
@@ -49,4 +53,57 @@ pub fn validate_path_within_repo(repo_path: &Path, file_path: &str) -> Result<Pa
     }
 
     Ok(abs_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TestRepo;
+
+    #[test]
+    fn test_allows_filename_with_double_dot_substring() {
+        // `git add 'v1..v2.diff'` succeeds; the validator must not reject it.
+        let repo = TestRepo::new();
+        let result = validate_path_within_repo(&repo.path, "v1..v2.diff");
+        assert!(
+            result.is_ok(),
+            "filename containing '..' as a substring must be allowed"
+        );
+    }
+
+    #[test]
+    fn test_allows_double_dot_in_subdir_filename() {
+        let repo = TestRepo::new();
+        let result = validate_path_within_repo(&repo.path, "sub/a..b.txt");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_allows_triple_dot_filename() {
+        // `...` is a valid path component, not a parent-directory reference.
+        let repo = TestRepo::new();
+        let result = validate_path_within_repo(&repo.path, "...");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_rejects_parent_dir_component() {
+        let repo = TestRepo::new();
+        let result = validate_path_within_repo(&repo.path, "../escape.txt");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rejects_nested_parent_dir_component() {
+        let repo = TestRepo::new();
+        let result = validate_path_within_repo(&repo.path, "sub/../../escape.txt");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rejects_absolute_path() {
+        let repo = TestRepo::new();
+        let result = validate_path_within_repo(&repo.path, "/etc/passwd");
+        assert!(result.is_err());
+    }
 }

--- a/src-tauri/src/commands/reflog.rs
+++ b/src-tauri/src/commands/reflog.rs
@@ -5,6 +5,35 @@ use tauri::command;
 
 use crate::error::Result;
 
+/// Refuse to reset while a multi-step operation (rebase, bisect, or a
+/// cherry-pick/revert *sequence*) is in progress. Canonical `git reset` leaves
+/// `.git/rebase-merge`, `.git/rebase-apply`, `.git/BISECT_LOG` and the sequencer
+/// directory in place, but libgit2's reset unconditionally runs
+/// `git_repository_state_cleanup` for MIXED/HARD resets and deletes them,
+/// silently destroying the in-progress operation. Mirror git by refusing.
+/// (A plain single-op Merge / CherryPick / Revert is intentionally allowed:
+/// `git reset` is the documented way to abort those.)
+fn ensure_resettable(repo: &git2::Repository) -> Result<()> {
+    use git2::RepositoryState::*;
+    match repo.state() {
+        Rebase | RebaseInteractive | RebaseMerge | ApplyMailbox | ApplyMailboxOrRebase => {
+            Err(crate::error::LeviathanError::OperationFailed(
+                "Cannot reset while a rebase is in progress. Finish or abort the rebase (git rebase --continue or --abort) first.".to_string(),
+            ))
+        }
+        Bisect => Err(crate::error::LeviathanError::OperationFailed(
+            "Cannot reset while a bisect is in progress. Run 'git bisect reset' first.".to_string(),
+        )),
+        CherryPickSequence => Err(crate::error::LeviathanError::OperationFailed(
+            "Cannot reset while a cherry-pick sequence is in progress. Finish or abort it (git cherry-pick --continue or --abort) first.".to_string(),
+        )),
+        RevertSequence => Err(crate::error::LeviathanError::OperationFailed(
+            "Cannot reset while a revert sequence is in progress. Finish or abort it (git revert --continue or --abort) first.".to_string(),
+        )),
+        _ => Ok(()),
+    }
+}
+
 /// A reflog entry representing a recorded state change
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -107,6 +136,14 @@ pub async fn reset_to_reflog(
         "hard" => git2::ResetType::Hard,
         _ => git2::ResetType::Mixed,
     };
+
+    // A MIXED or HARD reset triggers libgit2's repository state cleanup, which
+    // would delete any in-progress rebase/bisect/sequencer state. Refuse in
+    // that case, mirroring what canonical git preserves. (SOFT resets do not
+    // trigger the cleanup, so they are left alone.)
+    if matches!(reset_type, git2::ResetType::Mixed | git2::ResetType::Hard) {
+        ensure_resettable(&repo)?;
+    }
 
     // Perform the reset
     repo.reset(target_commit.as_object(), reset_type, None)?;
@@ -395,6 +432,30 @@ mod tests {
         let result = get_reflog(repo.path_str(), Some(0)).await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_reset_to_reflog_refused_during_bisect() {
+        // A mixed/hard reset would erase .git/BISECT_LOG (libgit2 state cleanup);
+        // canonical git preserves it. The reset must be refused.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Second", &[("f2.txt", "2")]);
+        let second_oid = repo.head_oid();
+
+        std::fs::write(repo.path.join(".git").join("BISECT_LOG"), b"").unwrap();
+        assert_eq!(repo.repo().state(), git2::RepositoryState::Bisect);
+
+        // Hard reset must be refused.
+        let hard = reset_to_reflog(repo.path_str(), 1, "hard".to_string()).await;
+        assert!(hard.is_err(), "hard reset must refuse during a bisect");
+
+        // Mixed reset must be refused.
+        let mixed = reset_to_reflog(repo.path_str(), 1, "mixed".to_string()).await;
+        assert!(mixed.is_err(), "mixed reset must refuse during a bisect");
+
+        // HEAD and the bisect state are both preserved.
+        assert_eq!(repo.head_oid(), second_oid);
+        assert!(repo.path.join(".git").join("BISECT_LOG").exists());
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -475,6 +475,14 @@ pub async fn push(
                         token,
                     )?;
                 } else {
+                    // Run pre-push like canonical git — the git2 push path
+                    // otherwise bypasses it. A non-zero exit aborts the push.
+                    crate::commands::hooks::run_pre_push_branch(
+                        &repo,
+                        &remote_for_task,
+                        &branch_name,
+                    )?;
+
                     let mut git_remote = repo
                         .find_remote(&remote_for_task)
                         .map_err(|_| LeviathanError::RemoteNotFound(remote_for_task.clone()))?;
@@ -637,6 +645,10 @@ fn push_single_remote(
         .map_err(|e| e.to_string())
     } else {
         let repo = git2::Repository::open(Path::new(path)).map_err(|e| e.message().to_string())?;
+
+        // Run pre-push like canonical git; a non-zero exit aborts the push.
+        crate::commands::hooks::run_pre_push_branch(&repo, remote_name, branch_name)
+            .map_err(|e| e.to_string())?;
 
         let mut git_remote = repo
             .find_remote(remote_name)
@@ -983,6 +995,82 @@ pub async fn cancel_operation(
 mod tests {
     use super::*;
     use crate::test_utils::TestRepo;
+
+    // ---- pre-push hook parity (git2 push path) ----
+
+    #[cfg(unix)]
+    #[test]
+    fn test_push_single_remote_pre_push_hook_aborts() {
+        let repo = TestRepo::with_initial_commit();
+        let bare = tempfile::tempdir().unwrap();
+        git2::Repository::init_bare(bare.path()).unwrap();
+        repo.add_remote("origin", &bare.path().to_string_lossy());
+        let branch = repo.current_branch();
+
+        // Hook drains stdin then rejects the push.
+        repo.install_hook(
+            "pre-push",
+            "#!/bin/sh\ncat >/dev/null\necho prepush-denied 1>&2\nexit 1\n",
+        );
+
+        let result = push_single_remote(
+            &repo.path_str(),
+            "origin",
+            &branch,
+            false,
+            false,
+            false,
+            None,
+        );
+        assert!(result.is_err(), "pre-push exit 1 must abort the push");
+        assert!(result.unwrap_err().contains("prepush-denied"));
+
+        // The remote must not have received the ref.
+        let bare_repo = git2::Repository::open(bare.path()).unwrap();
+        assert!(bare_repo
+            .refname_to_id(&format!("refs/heads/{}", branch))
+            .is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_push_single_remote_pre_push_receives_ref_line() {
+        let repo = TestRepo::with_initial_commit();
+        let bare = tempfile::tempdir().unwrap();
+        git2::Repository::init_bare(bare.path()).unwrap();
+        repo.add_remote("origin", &bare.path().to_string_lossy());
+        let branch = repo.current_branch();
+        let local_oid = repo.head_oid();
+
+        let marker = repo.path.join("prepush-stdin.log");
+        repo.install_hook(
+            "pre-push",
+            &format!("#!/bin/sh\ncat > \"{}\"\n", marker.display()),
+        );
+
+        push_single_remote(
+            &repo.path_str(),
+            "origin",
+            &branch,
+            false,
+            false,
+            false,
+            None,
+        )
+        .unwrap();
+
+        let stdin = std::fs::read_to_string(&marker).expect("pre-push must run");
+        let zero = crate::commands::hooks::ZERO_OID;
+        assert_eq!(
+            stdin.trim(),
+            format!(
+                "refs/heads/{b} {oid} refs/heads/{b} {zero}",
+                b = branch,
+                oid = local_oid,
+                zero = zero
+            )
+        );
+    }
 
     #[tokio::test]
     async fn test_add_remote() {

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -384,6 +384,21 @@ pub async fn clone_repository(
             .map_err(|e| LeviathanError::Custom(format!("Clone task failed: {}", e)))?;
 
             let repo = result?;
+
+            // git runs post-checkout after a clone checks out the initial
+            // working tree (old-ref = all-zeros, flag = 1). The shallow/CLI
+            // clone path above runs it natively via `git clone`; the git2 path
+            // does not, so run it here. Non-blocking.
+            if !bare {
+                let new_head = crate::commands::hooks::head_oid_string(&repo);
+                crate::commands::hooks::run_post_checkout(
+                    &repo,
+                    crate::commands::hooks::ZERO_OID,
+                    &new_head,
+                    true,
+                );
+            }
+
             let path = Path::new(&path);
 
             let name = path

--- a/src-tauri/src/commands/rewrite.rs
+++ b/src-tauri/src/commands/rewrite.rs
@@ -688,7 +688,16 @@ pub async fn cherry_pick_range(path: String, commit_oids: Vec<String>) -> Result
 
     // Record the HEAD the sequence starts from so an abort mid-sequence can
     // rewind to it (matching git's return-to-pre-sequence-HEAD on --abort).
+    // Persist it up front: a mid-range pick can stop not only on a conflict but
+    // on an already-applied (empty) pick, which returns Err before the conflict
+    // branch runs — yet still leaves CHERRY_PICK_HEAD and earlier picks applied.
+    // Writing the sequence head now lets abort_cherry_pick rewind the whole
+    // range regardless of how the sequence stops.
     let pre_sequence_head = repo.head()?.peel_to_commit()?.id();
+    std::fs::write(
+        repo.path().join(CHERRY_PICK_SEQUENCE_HEAD),
+        pre_sequence_head.to_string(),
+    )?;
 
     let mut results = Vec::new();
 
@@ -1498,8 +1507,15 @@ pub async fn cherry_pick_from_branch(
     // Reverse so we apply oldest first
     commit_oids.reverse();
 
-    // Record the pre-sequence HEAD for abort rewind.
+    // Record the pre-sequence HEAD for abort rewind. Persist it up front so an
+    // abort can rewind the whole range even when the sequence stops on an
+    // already-applied (empty) pick, which returns Err before the conflict
+    // branch writes the sequencer state.
     let pre_sequence_head = repo.head()?.peel_to_commit()?.id();
+    std::fs::write(
+        repo.path().join(CHERRY_PICK_SEQUENCE_HEAD),
+        pre_sequence_head.to_string(),
+    )?;
 
     // Cherry-pick each commit
     let mut results = Vec::new();
@@ -3145,6 +3161,53 @@ mod tests {
         let git_dir = test_repo.repo().path().to_path_buf();
         assert!(!git_dir.join(CHERRY_PICK_SEQUENCE).exists());
         assert!(!git_dir.join(CHERRY_PICK_SEQUENCE_HEAD).exists());
+    }
+
+    #[tokio::test]
+    async fn test_cherry_pick_range_abort_rewinds_on_empty_mid_pick() {
+        // A mid-range pick that is already present in HEAD stops the sequence
+        // with an "empty" error (not a conflict). Abort must still rewind the
+        // whole range to the pre-sequence HEAD, removing earlier applied picks —
+        // this only works if the sequence head was persisted before the loop.
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_commit("Base", &[("shared.txt", "base")]);
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let a = test_repo.create_commit("A adds a.txt", &[("a.txt", "a")]);
+        let d = test_repo.create_commit("D adds d.txt", &[("d.txt", "d")]);
+        let e = test_repo.create_commit("E adds e.txt", &[("e.txt", "e")]);
+
+        // Pre-apply D onto main so the mid-range pick of D becomes empty.
+        test_repo.checkout_branch("main");
+        cherry_pick(test_repo.path_str(), d.to_string(), None, None)
+            .await
+            .unwrap();
+        let pre_seq = test_repo.head_oid();
+
+        // Range [A, D, E]: A applies, D is empty -> Err; repo left mid-sequence.
+        let result = cherry_pick_range(
+            test_repo.path_str(),
+            vec![a.to_string(), d.to_string(), e.to_string()],
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "an already-applied mid-range pick must error"
+        );
+        assert_ne!(test_repo.head_oid(), pre_seq, "A was applied");
+
+        // Abort must rewind to the pre-sequence HEAD, removing the applied A.
+        abort_cherry_pick(test_repo.path_str()).await.unwrap();
+        assert_eq!(
+            test_repo.head_oid(),
+            pre_seq,
+            "abort must rewind to pre-sequence HEAD even after an empty pick"
+        );
+        assert!(
+            !test_repo.path.join("a.txt").exists(),
+            "applied pick A must be removed on abort"
+        );
+        assert_eq!(test_repo.repo().state(), git2::RepositoryState::Clean);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/rewrite.rs
+++ b/src-tauri/src/commands/rewrite.rs
@@ -6,6 +6,179 @@ use tauri::command;
 use crate::error::{LeviathanError, Result};
 use crate::models::Commit;
 
+/// Message git prints when a cherry-pick becomes empty (its changes are already
+/// present). Canonical git stops and creates no commit rather than polluting
+/// history with an empty commit.
+const EMPTY_CHERRY_PICK_MSG: &str = "The cherry-pick is now empty because its changes are already present in HEAD; no commit was created. Skip or abort the cherry-pick to continue.";
+
+/// Message git prints when a revert becomes empty (there is nothing to undo).
+const EMPTY_REVERT_MSG: &str = "The revert is now empty because there is nothing to undo; no commit was created. Skip or abort the revert to continue.";
+
+/// Name of the sidecar file tracking the commits still to be applied during a
+/// multi-commit cherry-pick sequence (used so `continue` can resume the range).
+const CHERRY_PICK_SEQUENCE: &str = "CHERRY_PICK_SEQUENCE";
+
+/// Name of the sidecar file storing the pre-sequence HEAD oid so that aborting a
+/// multi-commit cherry-pick rewinds to the exact commit it started from
+/// (matching `git cherry-pick --abort`), rather than leaving already-applied
+/// picks on the branch.
+const CHERRY_PICK_SEQUENCE_HEAD: &str = "CHERRY_PICK_SEQUENCE_HEAD";
+
+/// Restore the working tree and index to HEAD when aborting a cherry-pick or
+/// revert, while preserving uncommitted changes to files the operation did not
+/// touch. This mirrors `git cherry-pick --abort` / `git revert --abort`, which
+/// use reset --merge semantics and do NOT force-reset the entire working tree.
+///
+/// A blanket `checkout_head().force()` (the previous behavior) destroys any
+/// unrelated uncommitted work, so we instead force-checkout ONLY the paths the
+/// aborted operation actually affected (its conflicted paths plus any path whose
+/// staged content differs from HEAD).
+fn restore_after_abort(repo: &git2::Repository) -> Result<()> {
+    let head_commit = repo.head()?.peel_to_commit()?;
+    let head_tree = head_commit.tree()?;
+    let mut index = repo.index()?;
+
+    // Collect exactly the paths the operation touched.
+    let mut affected: std::collections::BTreeSet<Vec<u8>> = std::collections::BTreeSet::new();
+
+    if let Ok(conflicts) = index.conflicts() {
+        for conflict in conflicts.flatten() {
+            if let Some(entry) = conflict.our.or(conflict.their).or(conflict.ancestor) {
+                affected.insert(entry.path);
+            }
+        }
+    }
+
+    let diff = repo.diff_tree_to_index(Some(&head_tree), Some(&index), None)?;
+    for delta in diff.deltas() {
+        if let Some(p) = delta.new_file().path_bytes() {
+            affected.insert(p.to_vec());
+        }
+        if let Some(p) = delta.old_file().path_bytes() {
+            affected.insert(p.to_vec());
+        }
+    }
+
+    // Reset the index to HEAD so conflict stages are cleared.
+    index.read_tree(&head_tree)?;
+    index.write()?;
+
+    if affected.is_empty() {
+        return Ok(());
+    }
+
+    // Files the operation ADDED are absent from HEAD, so a path-scoped checkout
+    // has nothing to write for them and would leave them behind. Delete them
+    // from the working tree explicitly (still scoped to operation paths, so
+    // unrelated untracked files are untouched).
+    if let Some(workdir) = repo.workdir() {
+        for path in &affected {
+            let rel = Path::new(std::str::from_utf8(path).unwrap_or(""));
+            if head_tree.get_path(rel).is_err() {
+                let _ = std::fs::remove_file(workdir.join(rel));
+            }
+        }
+    }
+
+    // Force-checkout only the affected paths; unrelated dirty files survive.
+    let mut checkout = git2::build::CheckoutBuilder::new();
+    checkout.force();
+    for path in &affected {
+        checkout.path(path.as_slice());
+    }
+    repo.checkout_head(Some(&mut checkout))?;
+
+    Ok(())
+}
+
+/// Apply a single non-merge commit as a cherry-pick onto the current HEAD and
+/// create the resulting commit, matching canonical git semantics:
+/// - refuses root commits and merge commits (a merge needs an explicit mainline);
+/// - stops (creates no commit) when the result would be empty;
+/// - runs the post-commit hook git's sequencer runs.
+///
+/// Returns `Ok(Some(commit))` on success, `Ok(None)` when the pick conflicts
+/// (the repository is left in cherry-pick state with CHERRY_PICK_HEAD written so
+/// the caller can persist sequencer state), and `Err` on any hard failure
+/// (including an empty pick, which git treats as a stop condition).
+fn cherry_pick_one(repo: &git2::Repository, commit: &git2::Commit) -> Result<Option<Commit>> {
+    if commit.parent_count() == 0 {
+        return Err(LeviathanError::OperationFailed(format!(
+            "Cannot cherry-pick root commit {}",
+            commit.id()
+        )));
+    }
+    if commit.parent_count() > 1 {
+        return Err(LeviathanError::OperationFailed(format!(
+            "Commit {} is a merge but no mainline parent was given; refusing to cherry-pick a merge commit without an explicit mainline.",
+            commit.id()
+        )));
+    }
+
+    let mut checkout_builder = git2::build::CheckoutBuilder::new();
+    checkout_builder
+        .allow_conflicts(true)
+        .conflict_style_merge(true);
+    let mut opts = git2::CherrypickOptions::new();
+    opts.checkout_builder(checkout_builder);
+
+    repo.cherrypick(commit, Some(&mut opts))?;
+
+    let mut index = repo.index()?;
+    if index.has_conflicts() {
+        return Ok(None);
+    }
+
+    let head = repo.head()?.peel_to_commit()?;
+    let tree_oid = index.write_tree()?;
+    if tree_oid == head.tree_id() {
+        return Err(LeviathanError::OperationFailed(
+            EMPTY_CHERRY_PICK_MSG.to_string(),
+        ));
+    }
+    let tree = repo.find_tree(tree_oid)?;
+    let signature = repo.signature()?;
+
+    let new_oid = repo.commit(
+        Some("HEAD"),
+        &signature,
+        &commit.author(),
+        commit.message().unwrap_or(""),
+        &tree,
+        &[&head],
+    )?;
+
+    repo.cleanup_state()?;
+    // The sequencer runs post-commit (but not pre-commit / commit-msg) for each
+    // cherry-picked commit. (prepare-commit-msg is not run here: this path never
+    // opens an editor, a documented deviation from githooks(5).)
+    crate::commands::hooks::run_hook_noblock(repo, "post-commit", &[]);
+
+    let new_commit = repo.find_commit(new_oid)?;
+    Ok(Some(Commit::from_git2(&new_commit)))
+}
+
+/// Persist multi-commit cherry-pick sequencer state on a conflict: the commits
+/// still to apply and the HEAD the sequence started from (for abort rewind).
+fn write_sequencer_state(
+    repo: &git2::Repository,
+    pre_sequence_head: git2::Oid,
+    remaining: &[String],
+) -> Result<()> {
+    std::fs::write(
+        repo.path().join(CHERRY_PICK_SEQUENCE_HEAD),
+        pre_sequence_head.to_string(),
+    )?;
+    std::fs::write(repo.path().join(CHERRY_PICK_SEQUENCE), remaining.join("\n"))?;
+    Ok(())
+}
+
+/// Remove the multi-commit cherry-pick sequencer sidecar files.
+fn clear_sequencer_state(repo: &git2::Repository) {
+    let _ = std::fs::remove_file(repo.path().join(CHERRY_PICK_SEQUENCE));
+    let _ = std::fs::remove_file(repo.path().join(CHERRY_PICK_SEQUENCE_HEAD));
+}
+
 /// Cherry-pick a commit onto the current branch
 ///
 /// Options:
@@ -15,6 +188,7 @@ pub async fn cherry_pick(
     path: String,
     commit_oid: String,
     no_commit: Option<bool>,
+    mainline: Option<u32>,
 ) -> Result<Commit> {
     let repo = git2::Repository::open(Path::new(&path))?;
     let no_commit = no_commit.unwrap_or(false);
@@ -64,9 +238,28 @@ pub async fn cherry_pick(
     let mut opts = git2::CherrypickOptions::new();
     opts.checkout_builder(checkout_builder);
 
-    // For merge commits, specify mainline parent (1 = the branch that was merged into)
+    // Merge commits are ambiguous: git refuses to cherry-pick one unless the
+    // caller picks which parent's diff to apply via an explicit mainline.
     if commit.parent_count() > 1 {
-        opts.mainline(1);
+        match mainline {
+            Some(m) if m >= 1 && m <= commit.parent_count() as u32 => {
+                opts.mainline(m);
+            }
+            Some(m) => {
+                return Err(LeviathanError::OperationFailed(format!(
+                    "Mainline {} is out of range: commit {} has {} parents.",
+                    m,
+                    commit_oid,
+                    commit.parent_count()
+                )));
+            }
+            None => {
+                return Err(LeviathanError::OperationFailed(format!(
+                    "Commit {} is a merge but no mainline parent was given; choose which parent to cherry-pick relative to.",
+                    commit_oid
+                )));
+            }
+        }
     }
 
     repo.cherrypick(&commit, Some(&mut opts))?;
@@ -97,6 +290,15 @@ pub async fn cherry_pick(
     // No conflicts - the working directory and index are updated, now create the commit
     let head = repo.head()?.peel_to_commit()?;
     let tree_oid = index.write_tree()?;
+
+    // If the pick is already applied the result is empty; git stops here (leaving
+    // CHERRY_PICK_HEAD in place) instead of creating an empty commit.
+    if tree_oid == head.tree_id() {
+        return Err(LeviathanError::OperationFailed(
+            EMPTY_CHERRY_PICK_MSG.to_string(),
+        ));
+    }
+
     let tree = repo.find_tree(tree_oid)?;
     let signature = repo.signature()?;
 
@@ -111,6 +313,8 @@ pub async fn cherry_pick(
 
     // Clean up cherry-pick state
     repo.cleanup_state()?;
+    // The sequencer runs post-commit for the cherry-picked commit.
+    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
 
     let new_commit = repo.find_commit(new_oid)?;
     Ok(Commit::from_git2(&new_commit))
@@ -121,8 +325,9 @@ pub async fn cherry_pick(
 pub async fn continue_cherry_pick(path: String) -> Result<Commit> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
-    // Check if we're actually in a cherry-pick state
-    let cherry_pick_head_path = Path::new(&path).join(".git/CHERRY_PICK_HEAD");
+    // Check if we're actually in a cherry-pick state. Resolve the state file via
+    // repo.path() so this works in linked worktrees (where <wt>/.git is a file).
+    let cherry_pick_head_path = repo.path().join("CHERRY_PICK_HEAD");
     if !cherry_pick_head_path.exists() {
         return Err(LeviathanError::OperationFailed(
             "No cherry-pick in progress".to_string(),
@@ -148,6 +353,15 @@ pub async fn continue_cherry_pick(path: String) -> Result<Commit> {
 
     // Create the commit
     let tree_oid = index.write_tree()?;
+
+    // A conflict resolution that leaves nothing to apply is empty; git stops
+    // rather than recording an empty commit.
+    if tree_oid == head.tree_id() {
+        return Err(LeviathanError::OperationFailed(
+            EMPTY_CHERRY_PICK_MSG.to_string(),
+        ));
+    }
+
     let tree = repo.find_tree(tree_oid)?;
     let signature = repo.signature()?;
 
@@ -160,12 +374,48 @@ pub async fn continue_cherry_pick(path: String) -> Result<Commit> {
         &[&head],
     )?;
 
-    // Clean up cherry-pick state
-    std::fs::remove_file(&cherry_pick_head_path)?;
+    // Clean up cherry-pick state for the resolved commit.
+    let _ = std::fs::remove_file(&cherry_pick_head_path);
     repo.cleanup_state()?;
+    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
 
-    let new_commit = repo.find_commit(new_oid)?;
-    Ok(Commit::from_git2(&new_commit))
+    let mut last = {
+        let new_commit = repo.find_commit(new_oid)?;
+        Commit::from_git2(&new_commit)
+    };
+
+    // If this cherry-pick was part of a multi-commit sequence, apply the
+    // remaining commits now (the real sequencer resumes automatically).
+    let seq_path = repo.path().join(CHERRY_PICK_SEQUENCE);
+    if let Ok(contents) = std::fs::read_to_string(&seq_path) {
+        let remaining: Vec<String> = contents
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect();
+
+        for (i, oid_str) in remaining.iter().enumerate() {
+            let oid = git2::Oid::from_str(oid_str)
+                .map_err(|_| LeviathanError::CommitNotFound(oid_str.clone()))?;
+            let commit = repo
+                .find_commit(oid)
+                .map_err(|_| LeviathanError::CommitNotFound(oid_str.clone()))?;
+
+            match cherry_pick_one(&repo, &commit)? {
+                Some(c) => last = c,
+                None => {
+                    // Conflict again: persist the not-yet-applied remainder so
+                    // the next continue resumes from here.
+                    let still: Vec<String> = remaining.iter().skip(i + 1).cloned().collect();
+                    std::fs::write(&seq_path, still.join("\n"))?;
+                    return Err(LeviathanError::CherryPickConflict);
+                }
+            }
+        }
+    }
+
+    clear_sequencer_state(&repo);
+    Ok(last)
 }
 
 /// Abort a cherry-pick in progress
@@ -173,22 +423,44 @@ pub async fn continue_cherry_pick(path: String) -> Result<Commit> {
 pub async fn abort_cherry_pick(path: String) -> Result<()> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
-    // Remove cherry-pick state file if it exists
-    let cherry_pick_head_path = Path::new(&path).join(".git/CHERRY_PICK_HEAD");
-    if cherry_pick_head_path.exists() {
-        std::fs::remove_file(&cherry_pick_head_path)?;
+    // git refuses to abort when no cherry-pick is in progress and leaves the
+    // working tree untouched; blindly force-resetting here would destroy
+    // uncommitted work. Resolve the state file via repo.path() (worktree-safe).
+    let cherry_pick_head_path = repo.path().join("CHERRY_PICK_HEAD");
+    if !cherry_pick_head_path.exists() {
+        return Err(LeviathanError::OperationFailed(
+            "There is no cherry-pick in progress to abort.".to_string(),
+        ));
     }
 
-    // Reset to HEAD
+    // If this was a multi-commit sequence, rewind HEAD to the commit the
+    // sequence started from so already-applied picks are removed too.
+    if let Ok(head_str) = std::fs::read_to_string(repo.path().join(CHERRY_PICK_SEQUENCE_HEAD)) {
+        if let Ok(pre_seq_oid) = git2::Oid::from_str(head_str.trim()) {
+            let head_ref = repo.head()?;
+            if head_ref.is_branch() {
+                let branch_name = head_ref.shorthand().unwrap_or("HEAD");
+                let refname = format!("refs/heads/{}", branch_name);
+                repo.reference(&refname, pre_seq_oid, true, "cherry-pick: abort")?;
+            } else {
+                repo.set_head_detached(pre_seq_oid)?;
+            }
+        }
+    }
+
+    // Restore the working tree to (the possibly rewound) HEAD, preserving
+    // unrelated uncommitted changes.
+    restore_after_abort(&repo)?;
+
     repo.cleanup_state()?;
-    repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
+    clear_sequencer_state(&repo);
 
     Ok(())
 }
 
 /// Revert a commit (create a new commit that undoes the changes)
 #[command]
-pub async fn revert(path: String, commit_oid: String) -> Result<Commit> {
+pub async fn revert(path: String, commit_oid: String, mainline: Option<u32>) -> Result<Commit> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
     // Check for existing operations in progress
@@ -221,9 +493,28 @@ pub async fn revert(path: String, commit_oid: String) -> Result<Commit> {
     let mut opts = git2::RevertOptions::new();
     opts.checkout_builder(checkout_builder);
 
-    // For merge commits, specify mainline parent (1 = the branch that was merged into)
+    // Merge commits are ambiguous: git refuses to revert one unless the caller
+    // picks which parent's change to undo via an explicit mainline.
     if commit.parent_count() > 1 {
-        opts.mainline(1);
+        match mainline {
+            Some(m) if m >= 1 && m <= commit.parent_count() as u32 => {
+                opts.mainline(m);
+            }
+            Some(m) => {
+                return Err(LeviathanError::OperationFailed(format!(
+                    "Mainline {} is out of range: commit {} has {} parents.",
+                    m,
+                    commit_oid,
+                    commit.parent_count()
+                )));
+            }
+            None => {
+                return Err(LeviathanError::OperationFailed(format!(
+                    "Commit {} is a merge but no mainline parent was given; choose which parent to revert relative to.",
+                    commit_oid
+                )));
+            }
+        }
     }
 
     repo.revert(&commit, Some(&mut opts))?;
@@ -237,14 +528,36 @@ pub async fn revert(path: String, commit_oid: String) -> Result<Commit> {
     // No conflicts - the working directory and index are updated, now create the commit
     let head = repo.head()?.peel_to_commit()?;
     let tree_oid = index.write_tree()?;
+
+    // A revert that changes nothing is empty; git stops rather than recording an
+    // empty commit (leaving REVERT_HEAD in place).
+    if tree_oid == head.tree_id() {
+        return Err(LeviathanError::OperationFailed(
+            EMPTY_REVERT_MSG.to_string(),
+        ));
+    }
+
     let tree = repo.find_tree(tree_oid)?;
     let signature = repo.signature()?;
 
-    let revert_message = format!(
-        "Revert \"{}\"\n\nThis reverts commit {}.",
-        commit.summary().ok().flatten().unwrap_or(""),
-        commit_oid
-    );
+    let summary = commit.summary().ok().flatten().unwrap_or("").to_string();
+    let revert_message = if commit.parent_count() > 1 {
+        // Reverting a merge: git records which parent the changes were made to.
+        let m = mainline.unwrap_or(1);
+        let parent_oid = commit
+            .parent((m - 1) as usize)
+            .map(|p| p.id().to_string())
+            .unwrap_or_default();
+        format!(
+            "Revert \"{}\"\n\nThis reverts commit {}, reversing\nchanges made to {}.",
+            summary, commit_oid, parent_oid
+        )
+    } else {
+        format!(
+            "Revert \"{}\"\n\nThis reverts commit {}.",
+            summary, commit_oid
+        )
+    };
 
     let new_oid = repo.commit(
         Some("HEAD"),
@@ -257,6 +570,7 @@ pub async fn revert(path: String, commit_oid: String) -> Result<Commit> {
 
     // Clean up revert state
     repo.cleanup_state()?;
+    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
 
     let new_commit = repo.find_commit(new_oid)?;
     Ok(Commit::from_git2(&new_commit))
@@ -267,8 +581,9 @@ pub async fn revert(path: String, commit_oid: String) -> Result<Commit> {
 pub async fn continue_revert(path: String) -> Result<Commit> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
-    // Check if we're actually in a revert state
-    let revert_head_path = Path::new(&path).join(".git/REVERT_HEAD");
+    // Check if we're actually in a revert state. Resolve via repo.path() so this
+    // works in linked worktrees (where <wt>/.git is a file, not a directory).
+    let revert_head_path = repo.path().join("REVERT_HEAD");
     if !revert_head_path.exists() {
         return Err(LeviathanError::OperationFailed(
             "No revert in progress".to_string(),
@@ -294,6 +609,15 @@ pub async fn continue_revert(path: String) -> Result<Commit> {
 
     // Create the revert commit
     let tree_oid = index.write_tree()?;
+
+    // A conflict resolution that undoes nothing is empty; git stops rather than
+    // recording an empty commit.
+    if tree_oid == head.tree_id() {
+        return Err(LeviathanError::OperationFailed(
+            EMPTY_REVERT_MSG.to_string(),
+        ));
+    }
+
     let tree = repo.find_tree(tree_oid)?;
     let signature = repo.signature()?;
 
@@ -313,8 +637,9 @@ pub async fn continue_revert(path: String) -> Result<Commit> {
     )?;
 
     // Clean up revert state
-    std::fs::remove_file(&revert_head_path)?;
+    let _ = std::fs::remove_file(&revert_head_path);
     repo.cleanup_state()?;
+    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
 
     let new_commit = repo.find_commit(new_oid)?;
     Ok(Commit::from_git2(&new_commit))
@@ -325,15 +650,20 @@ pub async fn continue_revert(path: String) -> Result<Commit> {
 pub async fn abort_revert(path: String) -> Result<()> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
-    // Remove revert state file if it exists
-    let revert_head_path = Path::new(&path).join(".git/REVERT_HEAD");
-    if revert_head_path.exists() {
-        std::fs::remove_file(&revert_head_path)?;
+    // git refuses to abort when no revert is in progress and leaves the working
+    // tree untouched; blindly force-resetting here would destroy uncommitted
+    // work. Resolve the state file via repo.path() (worktree-safe).
+    let revert_head_path = repo.path().join("REVERT_HEAD");
+    if !revert_head_path.exists() {
+        return Err(LeviathanError::OperationFailed(
+            "There is no revert in progress to abort.".to_string(),
+        ));
     }
 
-    // Reset to HEAD
+    // Restore the working tree to HEAD, preserving unrelated uncommitted changes.
+    restore_after_abort(&repo)?;
+
     repo.cleanup_state()?;
-    repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
 
     Ok(())
 }
@@ -356,77 +686,33 @@ pub async fn cherry_pick_range(path: String, commit_oids: Vec<String>) -> Result
         ));
     }
 
+    // Record the HEAD the sequence starts from so an abort mid-sequence can
+    // rewind to it (matching git's return-to-pre-sequence-HEAD on --abort).
+    let pre_sequence_head = repo.head()?.peel_to_commit()?.id();
+
     let mut results = Vec::new();
 
-    for commit_oid in &commit_oids {
+    for (i, commit_oid) in commit_oids.iter().enumerate() {
         let oid = git2::Oid::from_str(commit_oid)
             .map_err(|_| LeviathanError::CommitNotFound(commit_oid.clone()))?;
         let commit = repo
             .find_commit(oid)
             .map_err(|_| LeviathanError::CommitNotFound(commit_oid.clone()))?;
 
-        if commit.parent_count() == 0 {
-            return Err(LeviathanError::OperationFailed(format!(
-                "Cannot cherry-pick root commit {}",
-                commit_oid
-            )));
-        }
-
-        let mut checkout_builder = git2::build::CheckoutBuilder::new();
-        checkout_builder
-            .allow_conflicts(true)
-            .conflict_style_merge(true);
-
-        let mut opts = git2::CherrypickOptions::new();
-        opts.checkout_builder(checkout_builder);
-
-        if commit.parent_count() > 1 {
-            opts.mainline(1);
-        }
-
-        repo.cherrypick(&commit, Some(&mut opts))?;
-
-        let mut index = repo.index()?;
-        if index.has_conflicts() {
-            // Write the remaining commits to a sequence file so the user can continue
-            let remaining: Vec<String> = commit_oids
-                .iter()
-                .skip(results.len() + 1)
-                .cloned()
-                .collect();
-            if !remaining.is_empty() {
-                let seq_path = Path::new(&path).join(".git/CHERRY_PICK_SEQUENCE");
-                std::fs::write(&seq_path, remaining.join("\n"))?;
+        match cherry_pick_one(&repo, &commit)? {
+            Some(new_commit) => results.push(new_commit),
+            None => {
+                // Conflict: persist the not-yet-applied commits and the
+                // pre-sequence HEAD so continue/abort behave like git's
+                // sequencer.
+                let remaining: Vec<String> = commit_oids.iter().skip(i + 1).cloned().collect();
+                write_sequencer_state(&repo, pre_sequence_head, &remaining)?;
+                return Err(LeviathanError::CherryPickConflict);
             }
-            return Err(LeviathanError::CherryPickConflict);
         }
-
-        // Create the commit
-        let head = repo.head()?.peel_to_commit()?;
-        let tree_oid = index.write_tree()?;
-        let tree = repo.find_tree(tree_oid)?;
-        let signature = repo.signature()?;
-
-        let new_oid = repo.commit(
-            Some("HEAD"),
-            &signature,
-            &commit.author(),
-            commit.message().unwrap_or(""),
-            &tree,
-            &[&head],
-        )?;
-
-        repo.cleanup_state()?;
-
-        let new_commit = repo.find_commit(new_oid)?;
-        results.push(Commit::from_git2(&new_commit));
     }
 
-    // Clean up sequence file if it exists
-    let seq_path = Path::new(&path).join(".git/CHERRY_PICK_SEQUENCE");
-    if seq_path.exists() {
-        let _ = std::fs::remove_file(&seq_path);
-    }
+    clear_sequencer_state(&repo);
 
     Ok(results)
 }
@@ -487,7 +773,9 @@ pub async fn get_rebase_state(path: String) -> Result<RebaseState> {
         });
     }
 
-    let git_dir = Path::new(&path).join(".git");
+    // Resolve via repo.path() so per-worktree rebase state is found in linked
+    // worktrees (where <wt>/.git is a gitdir-pointer file, not a directory).
+    let git_dir = repo.path();
     let rebase_merge_dir = git_dir.join("rebase-merge");
     let rebase_apply_dir = git_dir.join("rebase-apply");
 
@@ -610,7 +898,9 @@ pub async fn get_rebase_todo(path: String) -> Result<RebaseTodo> {
         ));
     }
 
-    let git_dir = Path::new(&path).join(".git");
+    // Resolve via repo.path() so per-worktree rebase state is found in linked
+    // worktrees (where <wt>/.git is a gitdir-pointer file, not a directory).
+    let git_dir = repo.path();
     let rebase_merge_dir = git_dir.join("rebase-merge");
     let rebase_apply_dir = git_dir.join("rebase-apply");
 
@@ -659,7 +949,9 @@ pub async fn update_rebase_todo(path: String, entries: Vec<RebaseTodoEntry>) -> 
         ));
     }
 
-    let git_dir = Path::new(&path).join(".git");
+    // Resolve via repo.path() so per-worktree rebase state is found in linked
+    // worktrees (where <wt>/.git is a gitdir-pointer file, not a directory).
+    let git_dir = repo.path();
     let rebase_merge_dir = git_dir.join("rebase-merge");
     let rebase_apply_dir = git_dir.join("rebase-apply");
 
@@ -1192,74 +1484,30 @@ pub async fn cherry_pick_from_branch(
     // Reverse so we apply oldest first
     commit_oids.reverse();
 
+    // Record the pre-sequence HEAD for abort rewind.
+    let pre_sequence_head = repo.head()?.peel_to_commit()?.id();
+
     // Cherry-pick each commit
     let mut results = Vec::new();
 
-    for oid in &commit_oids {
+    for (i, oid) in commit_oids.iter().enumerate() {
         let commit = repo.find_commit(*oid)?;
 
-        if commit.parent_count() == 0 {
-            return Err(LeviathanError::OperationFailed(format!(
-                "Cannot cherry-pick root commit {}",
-                oid
-            )));
-        }
-
-        let mut checkout_builder = git2::build::CheckoutBuilder::new();
-        checkout_builder
-            .allow_conflicts(true)
-            .conflict_style_merge(true);
-
-        let mut opts = git2::CherrypickOptions::new();
-        opts.checkout_builder(checkout_builder);
-
-        if commit.parent_count() > 1 {
-            opts.mainline(1);
-        }
-
-        repo.cherrypick(&commit, Some(&mut opts))?;
-
-        let mut index = repo.index()?;
-        if index.has_conflicts() {
-            // Write remaining commits to sequence file for continuation
-            let remaining: Vec<String> = commit_oids
-                .iter()
-                .skip(results.len() + 1)
-                .map(|o| o.to_string())
-                .collect();
-            if !remaining.is_empty() {
-                let seq_path = Path::new(&path).join(".git/CHERRY_PICK_SEQUENCE");
-                std::fs::write(&seq_path, remaining.join("\n"))?;
+        match cherry_pick_one(&repo, &commit)? {
+            Some(new_commit) => results.push(new_commit),
+            None => {
+                let remaining: Vec<String> = commit_oids
+                    .iter()
+                    .skip(i + 1)
+                    .map(|o| o.to_string())
+                    .collect();
+                write_sequencer_state(&repo, pre_sequence_head, &remaining)?;
+                return Err(LeviathanError::CherryPickConflict);
             }
-            return Err(LeviathanError::CherryPickConflict);
         }
-
-        // Create the commit
-        let head = repo.head()?.peel_to_commit()?;
-        let tree_oid = index.write_tree()?;
-        let tree = repo.find_tree(tree_oid)?;
-        let signature = repo.signature()?;
-
-        let new_oid = repo.commit(
-            Some("HEAD"),
-            &signature,
-            &commit.author(),
-            commit.message().unwrap_or(""),
-            &tree,
-            &[&head],
-        )?;
-
-        repo.cleanup_state()?;
-
-        let new_commit = repo.find_commit(new_oid)?;
-        results.push(Commit::from_git2(&new_commit));
     }
 
-    // Clean up sequence file if it exists
-    let seq_path = Path::new(&path).join(".git/CHERRY_PICK_SEQUENCE");
-    if seq_path.exists() {
-        let _ = std::fs::remove_file(&seq_path);
-    }
+    clear_sequencer_state(&repo);
 
     Ok(results)
 }
@@ -1294,7 +1542,13 @@ mod tests {
         assert!(!test_repo.path.join("feature.txt").exists());
 
         // Cherry-pick the feature commit
-        let result = cherry_pick(test_repo.path_str(), feature_commit_oid.to_string(), None).await;
+        let result = cherry_pick(
+            test_repo.path_str(),
+            feature_commit_oid.to_string(),
+            None,
+            None,
+        )
+        .await;
 
         assert!(result.is_ok(), "Cherry-pick should succeed");
         let new_commit = result.unwrap();
@@ -1337,6 +1591,7 @@ mod tests {
             test_repo.path_str(),
             feature_commit_oid.to_string(),
             Some(true),
+            None,
         )
         .await;
 
@@ -1385,7 +1640,13 @@ mod tests {
         test_repo.checkout_branch("main");
 
         // Cherry-pick should result in conflict
-        let result = cherry_pick(test_repo.path_str(), feature_commit_oid.to_string(), None).await;
+        let result = cherry_pick(
+            test_repo.path_str(),
+            feature_commit_oid.to_string(),
+            None,
+            None,
+        )
+        .await;
 
         assert!(result.is_err(), "Cherry-pick should fail with conflict");
         let err = result.unwrap_err();
@@ -1424,7 +1685,13 @@ mod tests {
         test_repo.checkout_branch("main");
 
         // Cherry-pick to create conflict
-        let _ = cherry_pick(test_repo.path_str(), feature_commit_oid.to_string(), None).await;
+        let _ = cherry_pick(
+            test_repo.path_str(),
+            feature_commit_oid.to_string(),
+            None,
+            None,
+        )
+        .await;
 
         // Verify we're in cherry-pick state
         assert_eq!(test_repo.repo().state(), git2::RepositoryState::CherryPick);
@@ -1470,7 +1737,13 @@ mod tests {
         let main_head_before = test_repo.head_oid();
 
         // Cherry-pick to create conflict
-        let _ = cherry_pick(test_repo.path_str(), feature_commit_oid.to_string(), None).await;
+        let _ = cherry_pick(
+            test_repo.path_str(),
+            feature_commit_oid.to_string(),
+            None,
+            None,
+        )
+        .await;
 
         // Manually resolve the conflict by writing resolved content
         std::fs::write(test_repo.path.join("conflict.txt"), "resolved content").unwrap();
@@ -1514,7 +1787,7 @@ mod tests {
         let root_oid = test_repo.create_commit("Root commit", &[("file.txt", "content")]);
 
         // Try to cherry-pick the root commit
-        let result = cherry_pick(test_repo.path_str(), root_oid.to_string(), None).await;
+        let result = cherry_pick(test_repo.path_str(), root_oid.to_string(), None, None).await;
 
         assert!(
             result.is_err(),
@@ -1549,13 +1822,25 @@ mod tests {
         test_repo.checkout_branch("main");
 
         // First cherry-pick creates conflict
-        let _ = cherry_pick(test_repo.path_str(), feature_commit_oid.to_string(), None).await;
+        let _ = cherry_pick(
+            test_repo.path_str(),
+            feature_commit_oid.to_string(),
+            None,
+            None,
+        )
+        .await;
 
         // Verify we're in cherry-pick state
         assert_eq!(test_repo.repo().state(), git2::RepositoryState::CherryPick);
 
         // Second cherry-pick should fail
-        let result = cherry_pick(test_repo.path_str(), another_commit_oid.to_string(), None).await;
+        let result = cherry_pick(
+            test_repo.path_str(),
+            another_commit_oid.to_string(),
+            None,
+            None,
+        )
+        .await;
 
         assert!(
             result.is_err(),
@@ -1583,9 +1868,14 @@ mod tests {
 
         // Switch back to main and cherry-pick
         test_repo.checkout_branch("main");
-        let result = cherry_pick(test_repo.path_str(), feature_commit_oid.to_string(), None)
-            .await
-            .unwrap();
+        let result = cherry_pick(
+            test_repo.path_str(),
+            feature_commit_oid.to_string(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
 
         // Verify author is preserved
         assert_eq!(result.author.name, original_author.name().unwrap());
@@ -1633,10 +1923,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_abort_cherry_pick_no_operation() {
+        // Canonical git: `git cherry-pick --abort` with no cherry-pick in
+        // progress fails ("no cherry-pick or revert in progress") and touches
+        // nothing. A blanket force-reset here would destroy uncommitted work.
         let repo = TestRepo::with_initial_commit();
-        // Aborting when no cherry-pick in progress should still succeed
+
+        // Make an uncommitted edit to a tracked file.
+        std::fs::write(repo.path.join("README.md"), "uncommitted precious work").unwrap();
+
         let result = abort_cherry_pick(repo.path_str()).await;
-        assert!(result.is_ok());
+        assert!(
+            result.is_err(),
+            "Abort with no cherry-pick in progress must fail like git"
+        );
+
+        // The uncommitted edit must survive (nothing was force-reset).
+        let content = std::fs::read_to_string(repo.path.join("README.md")).unwrap();
+        assert_eq!(content, "uncommitted precious work");
     }
 
     #[tokio::test]
@@ -1669,7 +1972,7 @@ mod tests {
         assert!(test_repo.path.join("revert-me.txt").exists());
 
         // Revert the commit
-        let result = revert(test_repo.path_str(), commit_to_revert.to_string()).await;
+        let result = revert(test_repo.path_str(), commit_to_revert.to_string(), None).await;
         assert!(result.is_ok(), "Revert should succeed");
 
         let revert_commit = result.unwrap();
@@ -1694,7 +1997,7 @@ mod tests {
         test_repo.create_commit("Modify file", &[("file.txt", "modified content")]);
 
         // Revert the original commit - this should conflict
-        let result = revert(test_repo.path_str(), commit_to_revert.to_string()).await;
+        let result = revert(test_repo.path_str(), commit_to_revert.to_string(), None).await;
 
         assert!(result.is_err(), "Revert should fail with conflict");
         let err = result.unwrap_err();
@@ -1711,7 +2014,7 @@ mod tests {
         test_repo.create_commit("Modify file", &[("file.txt", "modified content")]);
 
         // Revert to create conflict
-        let _ = revert(test_repo.path_str(), commit_to_revert.to_string()).await;
+        let _ = revert(test_repo.path_str(), commit_to_revert.to_string(), None).await;
 
         // Abort
         let abort_result = abort_revert(test_repo.path_str()).await;
@@ -1727,6 +2030,7 @@ mod tests {
         let result = revert(
             repo.path_str(),
             "0000000000000000000000000000000000000000".to_string(),
+            None,
         )
         .await;
         assert!(result.is_err());
@@ -1734,10 +2038,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_abort_revert_no_operation() {
+        // Canonical git: `git revert --abort` with no revert in progress fails
+        // and touches nothing.
         let repo = TestRepo::with_initial_commit();
-        // Aborting when no revert in progress should still succeed
+
+        std::fs::write(repo.path.join("README.md"), "uncommitted precious work").unwrap();
+
         let result = abort_revert(repo.path_str()).await;
-        assert!(result.is_ok());
+        assert!(
+            result.is_err(),
+            "Abort with no revert in progress must fail like git"
+        );
+
+        let content = std::fs::read_to_string(repo.path.join("README.md")).unwrap();
+        assert_eq!(content, "uncommitted precious work");
     }
 
     #[tokio::test]
@@ -1746,7 +2060,7 @@ mod tests {
 
         let commit_oid = repo.create_commit("Original message", &[("file.txt", "content")]);
 
-        let result = revert(repo.path_str(), commit_oid.to_string()).await;
+        let result = revert(repo.path_str(), commit_oid.to_string(), None).await;
         assert!(result.is_ok());
         let revert_commit = result.unwrap();
 
@@ -2515,5 +2829,406 @@ mod tests {
         // The initial commit is a root commit so it will fail on root commit check
         // Actually, it will try to cherry-pick root commit which should fail
         assert!(result.is_err());
+    }
+
+    // ==================== Regression tests: canonical git parity ====================
+
+    /// Build a merge commit on the current HEAD merging in `other`, returning its
+    /// oid. The merge's tree is just HEAD's tree (content is irrelevant for these
+    /// tests, which only exercise the merge-parent handling).
+    fn make_merge_commit(repo: &TestRepo, other: git2::Oid) -> git2::Oid {
+        let git_repo = repo.repo();
+        let sig = git_repo.signature().unwrap();
+        let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+        let other_commit = git_repo.find_commit(other).unwrap();
+        let tree = head.tree().unwrap();
+        git_repo
+            .commit(
+                Some("HEAD"),
+                &sig,
+                &sig,
+                "Merge commit",
+                &tree,
+                &[&head, &other_commit],
+            )
+            .unwrap()
+    }
+
+    // ---- Finding 42: empty cherry-pick / revert must stop, not commit ----
+
+    #[tokio::test]
+    async fn test_cherry_pick_already_applied_stops() {
+        let test_repo = TestRepo::with_initial_commit();
+
+        // Commit a change on feature, then make the identical change on main.
+        test_repo.create_commit("Base", &[("f.txt", "x")]);
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let feature_oid = test_repo.create_commit("Change to y", &[("f.txt", "y")]);
+
+        test_repo.checkout_branch("main");
+        test_repo.create_commit("Same change to y", &[("f.txt", "y")]);
+        let head_before = test_repo.head_oid();
+
+        // Cherry-picking the already-applied change must stop with an empty error
+        // and create NO commit (matching `git cherry-pick`'s default --empty=stop).
+        let result = cherry_pick(test_repo.path_str(), feature_oid.to_string(), None, None).await;
+        assert!(result.is_err(), "empty cherry-pick must not succeed");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .to_lowercase()
+                .contains("empty"),
+            "error should explain the pick is empty"
+        );
+
+        // HEAD must not have advanced (no empty commit was created).
+        assert_eq!(test_repo.head_oid(), head_before);
+        // git leaves CHERRY_PICK_HEAD in place so the user can skip/abort.
+        assert_eq!(test_repo.repo().state(), git2::RepositoryState::CherryPick);
+    }
+
+    #[tokio::test]
+    async fn test_revert_already_undone_stops() {
+        let test_repo = TestRepo::with_initial_commit();
+
+        // f.txt starts at x, A changes it to y, B changes it back to x (the exact
+        // inverse). Reverting A is then a no-op → empty.
+        test_repo.create_commit("Setup", &[("f.txt", "x")]);
+        let add_oid = test_repo.create_commit("A: x->y", &[("f.txt", "y")]);
+        test_repo.create_commit("B: y->x", &[("f.txt", "x")]);
+        let head_before = test_repo.head_oid();
+
+        // Reverting the already-undone commit is empty; git stops.
+        let result = revert(test_repo.path_str(), add_oid.to_string(), None).await;
+        assert!(result.is_err(), "empty revert must not succeed");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .to_lowercase()
+                .contains("empty"),
+            "error should explain the revert is empty"
+        );
+        assert_eq!(test_repo.head_oid(), head_before);
+    }
+
+    // ---- Finding 43: merge commits require an explicit mainline ----
+
+    #[tokio::test]
+    async fn test_cherry_pick_merge_without_mainline_refuses() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let feat = test_repo.create_commit("Feature", &[("feat.txt", "f")]);
+        test_repo.checkout_branch("main");
+        test_repo.create_commit("Main", &[("main.txt", "m")]);
+        let merge_oid = make_merge_commit(&test_repo, feat);
+
+        // Without a mainline, git refuses to cherry-pick a merge commit.
+        let result = cherry_pick(test_repo.path_str(), merge_oid.to_string(), None, None).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .to_lowercase()
+                .contains("mainline"),
+            "error should mention the missing mainline"
+        );
+
+        // An out-of-range mainline is rejected too.
+        let result = cherry_pick(test_repo.path_str(), merge_oid.to_string(), None, Some(5)).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .to_lowercase()
+            .contains("out of range"));
+    }
+
+    #[tokio::test]
+    async fn test_revert_merge_without_mainline_refuses() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let feat = test_repo.create_commit("Feature", &[("feat.txt", "f")]);
+        test_repo.checkout_branch("main");
+        test_repo.create_commit("Main", &[("main.txt", "m")]);
+        let merge_oid = make_merge_commit(&test_repo, feat);
+
+        let result = revert(test_repo.path_str(), merge_oid.to_string(), None).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .to_lowercase()
+                .contains("mainline"),
+            "error should mention the missing mainline"
+        );
+    }
+
+    // ---- Finding 40: aborting must preserve unrelated uncommitted work ----
+
+    #[tokio::test]
+    async fn test_abort_cherry_pick_preserves_unrelated_changes() {
+        let test_repo = TestRepo::with_initial_commit();
+
+        // Commit conflict.txt and unrelated.txt on main.
+        test_repo.create_commit(
+            "Add files",
+            &[("conflict.txt", "base"), ("unrelated.txt", "orig")],
+        );
+        let repo = test_repo.repo();
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        let parent = head_commit.parent(0).unwrap();
+        repo.branch("feature", &parent, false).unwrap();
+        test_repo.checkout_branch("feature");
+        let feature_oid =
+            test_repo.create_commit("Feature conflict", &[("conflict.txt", "feature")]);
+        test_repo.checkout_branch("main");
+        // Re-add conflict.txt on main so the pick conflicts.
+        test_repo.create_commit("Main conflict", &[("conflict.txt", "main")]);
+
+        // Uncommitted edit to an unrelated tracked file.
+        std::fs::write(test_repo.path.join("unrelated.txt"), "PRECIOUS WORK").unwrap();
+
+        // Cherry-pick conflicts on conflict.txt.
+        let result = cherry_pick(test_repo.path_str(), feature_oid.to_string(), None, None).await;
+        assert!(matches!(result, Err(LeviathanError::CherryPickConflict)));
+
+        // Abort must restore conflict.txt but preserve the unrelated edit.
+        abort_cherry_pick(test_repo.path_str()).await.unwrap();
+
+        assert_eq!(test_repo.repo().state(), git2::RepositoryState::Clean);
+        let unrelated = std::fs::read_to_string(test_repo.path.join("unrelated.txt")).unwrap();
+        assert_eq!(
+            unrelated, "PRECIOUS WORK",
+            "unrelated uncommitted work must survive the abort"
+        );
+        let conflict = std::fs::read_to_string(test_repo.path.join("conflict.txt")).unwrap();
+        assert_eq!(conflict, "main", "conflicted file restored to HEAD");
+    }
+
+    #[tokio::test]
+    async fn test_abort_revert_preserves_unrelated_changes() {
+        let test_repo = TestRepo::with_initial_commit();
+
+        test_repo.create_commit("Add unrelated", &[("unrelated.txt", "orig")]);
+        let add_oid = test_repo.create_commit("Add file", &[("file.txt", "original")]);
+        test_repo.create_commit("Modify file", &[("file.txt", "modified")]);
+
+        std::fs::write(test_repo.path.join("unrelated.txt"), "PRECIOUS WORK").unwrap();
+
+        // Reverting the add conflicts on file.txt (later modified).
+        let result = revert(test_repo.path_str(), add_oid.to_string(), None).await;
+        assert!(matches!(result, Err(LeviathanError::RevertConflict)));
+
+        abort_revert(test_repo.path_str()).await.unwrap();
+
+        assert_eq!(test_repo.repo().state(), git2::RepositoryState::Clean);
+        let unrelated = std::fs::read_to_string(test_repo.path.join("unrelated.txt")).unwrap();
+        assert_eq!(unrelated, "PRECIOUS WORK");
+    }
+
+    // ---- Finding 44: multi-commit sequencer abort rewinds & continue resumes ----
+
+    /// Set up main at M with a feature branch [A (clean), B (conflicts), C (clean)]
+    /// branched before M. Returns (pre_sequence_head = M, [A, B, C]).
+    fn setup_range(test_repo: &TestRepo) -> (git2::Oid, git2::Oid, git2::Oid, git2::Oid) {
+        // Base commit adds shared.txt.
+        test_repo.create_commit("Base", &[("shared.txt", "base")]);
+        // Feature branch from base.
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let a = test_repo.create_commit("A adds a.txt", &[("a.txt", "a")]);
+        let b = test_repo.create_commit("B edits shared", &[("shared.txt", "feature")]);
+        let c = test_repo.create_commit("C adds c.txt", &[("c.txt", "c")]);
+        // Main diverges: edit shared.txt so B will conflict.
+        test_repo.checkout_branch("main");
+        test_repo.create_commit("Main edits shared", &[("shared.txt", "main")]);
+        let m = test_repo.head_oid();
+        (m, a, b, c)
+    }
+
+    #[tokio::test]
+    async fn test_cherry_pick_range_abort_rewinds_applied_picks() {
+        let test_repo = TestRepo::with_initial_commit();
+        let (m, a, b, _c) = setup_range(&test_repo);
+
+        // Range [A, B]: A applies cleanly, B conflicts.
+        let result =
+            cherry_pick_range(test_repo.path_str(), vec![a.to_string(), b.to_string()]).await;
+        assert!(matches!(result, Err(LeviathanError::CherryPickConflict)));
+
+        // A was applied on top of M, so HEAD advanced and a.txt exists.
+        assert_ne!(test_repo.head_oid(), m);
+        assert!(test_repo.path.join("a.txt").exists());
+
+        // Abort must rewind HEAD all the way back to the pre-sequence commit M,
+        // removing the already-applied A (git's return-to-pre-sequence-HEAD).
+        abort_cherry_pick(test_repo.path_str()).await.unwrap();
+
+        assert_eq!(test_repo.repo().state(), git2::RepositoryState::Clean);
+        assert_eq!(
+            test_repo.head_oid(),
+            m,
+            "abort must rewind to pre-sequence HEAD"
+        );
+        assert!(
+            !test_repo.path.join("a.txt").exists(),
+            "applied pick removed"
+        );
+        // Sequencer sidecar files must be cleaned up.
+        let git_dir = test_repo.repo().path().to_path_buf();
+        assert!(!git_dir.join(CHERRY_PICK_SEQUENCE).exists());
+        assert!(!git_dir.join(CHERRY_PICK_SEQUENCE_HEAD).exists());
+    }
+
+    #[tokio::test]
+    async fn test_cherry_pick_range_continue_resumes_remaining() {
+        let test_repo = TestRepo::with_initial_commit();
+        let (_m, a, b, c) = setup_range(&test_repo);
+
+        // Range [A, B, C]: A clean, B conflicts, C still pending.
+        let result = cherry_pick_range(
+            test_repo.path_str(),
+            vec![a.to_string(), b.to_string(), c.to_string()],
+        )
+        .await;
+        assert!(matches!(result, Err(LeviathanError::CherryPickConflict)));
+
+        // Resolve B's conflict and stage it.
+        std::fs::write(test_repo.path.join("shared.txt"), "resolved").unwrap();
+        let repo = test_repo.repo();
+        let mut index = repo.index().unwrap();
+        index.add_path(std::path::Path::new("shared.txt")).unwrap();
+        index.write().unwrap();
+
+        // Continue must commit B AND resume the remaining pick C.
+        let last = continue_cherry_pick(test_repo.path_str()).await.unwrap();
+        assert_eq!(last.summary, "C adds c.txt", "the last resumed pick is C");
+
+        assert_eq!(test_repo.repo().state(), git2::RepositoryState::Clean);
+        assert!(test_repo.path.join("a.txt").exists());
+        assert!(test_repo.path.join("c.txt").exists());
+        assert_eq!(
+            std::fs::read_to_string(test_repo.path.join("shared.txt")).unwrap(),
+            "resolved"
+        );
+        // Sequencer sidecar files must be gone.
+        let git_dir = test_repo.repo().path().to_path_buf();
+        assert!(!git_dir.join(CHERRY_PICK_SEQUENCE).exists());
+        assert!(!git_dir.join(CHERRY_PICK_SEQUENCE_HEAD).exists());
+    }
+
+    // ---- Finding 45: state files resolved via repo.path() for linked worktrees ----
+
+    #[tokio::test]
+    async fn test_continue_cherry_pick_in_linked_worktree() {
+        let test_repo = TestRepo::with_initial_commit();
+
+        // Build a conflict scenario on main.
+        test_repo.create_commit("Add", &[("conflict.txt", "base")]);
+        let repo = test_repo.repo();
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        let parent = head_commit.parent(0).unwrap();
+        repo.branch("feature", &parent, false).unwrap();
+        test_repo.checkout_branch("feature");
+        let feature_oid = test_repo.create_commit("Feature", &[("conflict.txt", "feature")]);
+        test_repo.checkout_branch("main");
+        test_repo.create_commit("Main", &[("conflict.txt", "main")]);
+
+        // Create a linked worktree (checked out on a new branch "wt").
+        let wt_path = test_repo
+            .path
+            .parent()
+            .unwrap()
+            .join(format!("wt-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&wt_path);
+        {
+            let git_repo = test_repo.repo();
+            git_repo.worktree("wt", &wt_path, None).unwrap();
+        }
+        let wt_path_str = wt_path.to_string_lossy().to_string();
+
+        // Cherry-pick in the worktree conflicts.
+        let result = cherry_pick(wt_path_str.clone(), feature_oid.to_string(), None, None).await;
+        assert!(matches!(result, Err(LeviathanError::CherryPickConflict)));
+
+        // Resolve the conflict inside the worktree and stage it.
+        std::fs::write(wt_path.join("conflict.txt"), "resolved in wt").unwrap();
+        {
+            let wt_repo = git2::Repository::open(&wt_path).unwrap();
+            let mut index = wt_repo.index().unwrap();
+            index
+                .add_path(std::path::Path::new("conflict.txt"))
+                .unwrap();
+            index.write().unwrap();
+        }
+
+        // Continue must find CHERRY_PICK_HEAD via repo.path() (the per-worktree
+        // gitdir) rather than <wt>/.git/CHERRY_PICK_HEAD, which does not exist.
+        let cont = continue_cherry_pick(wt_path_str.clone()).await;
+        assert!(
+            cont.is_ok(),
+            "continue must succeed in a linked worktree, got: {:?}",
+            cont.err()
+        );
+
+        let _ = std::fs::remove_dir_all(&wt_path);
+    }
+
+    // ---- Finding 46: post-commit hook runs for cherry-pick / revert ----
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_cherry_pick_runs_post_commit_hook() {
+        let test_repo = TestRepo::with_initial_commit();
+
+        let marker = test_repo.path.join("post-commit-ran");
+        test_repo.install_hook(
+            "post-commit",
+            &format!("#!/bin/sh\ntouch \"{}\"\n", marker.display()),
+        );
+
+        // A clean cherry-pick.
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let feature_oid = test_repo.create_commit("Feature", &[("feature.txt", "content")]);
+        test_repo.checkout_branch("main");
+
+        cherry_pick(test_repo.path_str(), feature_oid.to_string(), None, None)
+            .await
+            .unwrap();
+
+        assert!(
+            marker.exists(),
+            "post-commit hook must run for a cherry-pick commit"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_revert_runs_post_commit_hook() {
+        let test_repo = TestRepo::with_initial_commit();
+
+        let marker = test_repo.path.join("post-commit-ran");
+        test_repo.install_hook(
+            "post-commit",
+            &format!("#!/bin/sh\ntouch \"{}\"\n", marker.display()),
+        );
+
+        let commit = test_repo.create_commit("Add file", &[("f.txt", "content")]);
+        revert(test_repo.path_str(), commit.to_string(), None)
+            .await
+            .unwrap();
+
+        assert!(
+            marker.exists(),
+            "post-commit hook must run for a revert commit"
+        );
     }
 }

--- a/src-tauri/src/commands/rewrite.rs
+++ b/src-tauri/src/commands/rewrite.rs
@@ -1228,6 +1228,13 @@ pub async fn drop_commit(path: String, commit_oid: String) -> Result<DropCommitR
     // Checkout to update working directory
     repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
 
+    // git's rebase sequencer runs post-commit for each replayed commit; we
+    // replay them as a batch and move the ref once, so fire the hook the same
+    // number of times now that HEAD is at the final commit.
+    for _ in 0..commits_after_drop.len() {
+        crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
+    }
+
     Ok(DropCommitResult {
         success: true,
         new_tip: current_base_oid.to_string(),
@@ -1394,6 +1401,13 @@ pub async fn reorder_commits(
 
     // Checkout the new commit to update working directory
     repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
+
+    // git's rebase sequencer runs post-commit for each replayed commit; we
+    // replay them as a batch and move the ref once, so fire the hook the same
+    // number of times now that HEAD is at the final commit.
+    for _ in 0..commits_in_order.len() {
+        crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
+    }
 
     Ok(ReorderResult {
         success: true,

--- a/src-tauri/src/commands/rewrite.rs
+++ b/src-tauri/src/commands/rewrite.rs
@@ -2970,6 +2970,52 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_cherry_pick_merge_with_mainline_is_accepted() {
+        // With an explicit, in-range mainline the merge-commit guard must NOT
+        // block the operation — the frontend now always supplies one for merge
+        // commits, so this contract must hold (any later empty/conflict outcome
+        // is fine; what must not happen is the "no mainline" refusal).
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let feat = test_repo.create_commit("Feature", &[("feat.txt", "f")]);
+        test_repo.checkout_branch("main");
+        test_repo.create_commit("Main", &[("main.txt", "m")]);
+        let merge_oid = make_merge_commit(&test_repo, feat);
+
+        let result = cherry_pick(test_repo.path_str(), merge_oid.to_string(), None, Some(1)).await;
+        if let Err(e) = &result {
+            assert!(
+                !e.to_string()
+                    .to_lowercase()
+                    .contains("no mainline parent was given"),
+                "an explicit mainline must satisfy the merge-commit guard, got: {e}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_revert_merge_with_mainline_is_accepted() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let feat = test_repo.create_commit("Feature", &[("feat.txt", "f")]);
+        test_repo.checkout_branch("main");
+        test_repo.create_commit("Main", &[("main.txt", "m")]);
+        let merge_oid = make_merge_commit(&test_repo, feat);
+
+        let result = revert(test_repo.path_str(), merge_oid.to_string(), Some(1)).await;
+        if let Err(e) = &result {
+            assert!(
+                !e.to_string()
+                    .to_lowercase()
+                    .contains("no mainline parent was given"),
+                "an explicit mainline must satisfy the merge-commit guard, got: {e}"
+            );
+        }
+    }
+
     // ---- Finding 40: aborting must preserve unrelated uncommitted work ----
 
     #[tokio::test]

--- a/src-tauri/src/commands/rewrite.rs
+++ b/src-tauri/src/commands/rewrite.rs
@@ -1237,10 +1237,11 @@ pub async fn drop_commit(path: String, commit_oid: String) -> Result<DropCommitR
     // Checkout to update working directory
     repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
 
-    // git's rebase sequencer runs post-commit for each replayed commit; we
-    // replay them as a batch and move the ref once, so fire the hook the same
-    // number of times now that HEAD is at the final commit.
-    for _ in 0..commits_after_drop.len() {
+    // git's rebase sequencer fires post-commit per replayed commit as HEAD
+    // advances; we replay atomically (nothing moved until success) and move the
+    // ref once, so fire post-commit a single time for the final rewritten HEAD
+    // when the drop actually rewrote commits (dropping the tip rewrites none).
+    if !commits_after_drop.is_empty() {
         crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
     }
 
@@ -1411,10 +1412,10 @@ pub async fn reorder_commits(
     // Checkout the new commit to update working directory
     repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
 
-    // git's rebase sequencer runs post-commit for each replayed commit; we
-    // replay them as a batch and move the ref once, so fire the hook the same
-    // number of times now that HEAD is at the final commit.
-    for _ in 0..commits_in_order.len() {
+    // git's rebase sequencer fires post-commit per replayed commit as HEAD
+    // advances; we replay atomically (nothing moved until success) and move the
+    // ref once, so fire post-commit a single time for the final rewritten HEAD.
+    if !commits_in_order.is_empty() {
         crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
     }
 

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -81,6 +81,12 @@ pub async fn search_in_files(
 
     if use_regex {
         cmd.arg("-E");
+    } else {
+        // Non-regex ("plain text") search must match the query literally, exactly
+        // like `git grep -F`. Without -F, git grep treats the pattern as a basic
+        // regular expression: literal queries like "a.c" over-match ("abc") and
+        // queries containing regex metacharacters like "a[" fatally error.
+        cmd.arg("-F");
     }
 
     cmd.arg("--").arg(&query);
@@ -187,52 +193,87 @@ pub async fn search_in_diff(
     let query_lower = query.to_lowercase();
     let mut results: Vec<SearchResult> = Vec::new();
     let mut current_file = String::new();
-    let mut current_line_number: u32 = 0;
+    // The old-side path parsed from the "--- a/<path>" header. Needed for deleted
+    // files, whose new-side header is "+++ /dev/null" and thus carries no path.
+    let mut old_file = String::new();
+    // Separate counters for the two sides of the hunk: added lines advance the
+    // new-side counter, removed lines advance the old-side counter.
+    let mut current_new_line: u32 = 0;
+    let mut current_old_line: u32 = 0;
 
     for line in stdout.lines() {
-        // Track the current file from diff headers
-        if let Some(file) = line.strip_prefix("+++ b/") {
-            current_file = file.to_string();
+        // Track the old-side path from the "--- a/<path>" header (or /dev/null
+        // for added files). Must be checked before the generic "-" line handling.
+        if let Some(rest) = line.strip_prefix("--- ") {
+            old_file = rest.strip_prefix("a/").unwrap_or(rest).to_string();
             continue;
         }
-        if line.starts_with("+++ ") || line.starts_with("--- ") {
+        // Track the current file from the new-side header. Deleted files report
+        // "+++ /dev/null", so fall back to the old-side path parsed above.
+        if let Some(rest) = line.strip_prefix("+++ ") {
+            current_file = match rest.strip_prefix("b/") {
+                Some(path) => path.to_string(),
+                None => old_file.clone(),
+            };
             continue;
         }
 
-        // Parse hunk header for line numbers: @@ -old,count +new,count @@
+        // Parse hunk header for line numbers: @@ -oldStart,count +newStart,count @@
         if line.starts_with("@@") {
-            if let Some(plus_part) = line.split('+').nth(1) {
-                if let Some(num_str) = plus_part.split(',').next() {
-                    if let Some(num_str) = num_str.split(' ').next() {
-                        current_line_number = num_str.parse().unwrap_or(0);
-                    }
-                }
+            let mut tokens = line.split(' ');
+            let _ = tokens.next(); // "@@"
+            if let Some(old_tok) = tokens.next() {
+                current_old_line = old_tok
+                    .trim_start_matches('-')
+                    .split(',')
+                    .next()
+                    .and_then(|n| n.parse().ok())
+                    .unwrap_or(0);
+            }
+            if let Some(new_tok) = tokens.next() {
+                current_new_line = new_tok
+                    .trim_start_matches('+')
+                    .split(',')
+                    .next()
+                    .and_then(|n| n.parse().ok())
+                    .unwrap_or(0);
             }
             continue;
         }
 
-        // Check added or removed lines for the query
-        if (line.starts_with('+') || line.starts_with('-'))
-            && !line.starts_with("+++")
-            && !line.starts_with("---")
-        {
-            let content = &line[1..]; // Strip the +/- prefix
+        // Check added lines for the query (new-side numbering).
+        if line.starts_with('+') && !line.starts_with("+++") {
+            let content = &line[1..]; // Strip the '+' prefix
 
             if content.to_lowercase().contains(&query_lower) {
                 let (match_start, match_end) = find_match_position(content, &query, false);
 
                 results.push(SearchResult {
                     file_path: current_file.clone(),
-                    line_number: current_line_number,
+                    line_number: current_new_line,
                     line_content: content.to_string(),
                     match_start,
                     match_end,
                 });
             }
 
-            if line.starts_with('+') {
-                current_line_number += 1;
+            current_new_line += 1;
+        } else if line.starts_with('-') && !line.starts_with("---") {
+            let content = &line[1..]; // Strip the '-' prefix
+
+            if content.to_lowercase().contains(&query_lower) {
+                let (match_start, match_end) = find_match_position(content, &query, false);
+
+                results.push(SearchResult {
+                    file_path: current_file.clone(),
+                    line_number: current_old_line,
+                    line_content: content.to_string(),
+                    match_start,
+                    match_end,
+                });
             }
+
+            current_old_line += 1;
         }
     }
 
@@ -325,6 +366,10 @@ pub async fn search_in_commit_messages(
         .arg("log")
         .arg(format!("--grep={}", query))
         .arg("-i")
+        // Match the query literally (like `git log --grep=… -F`). Without -F the
+        // query is treated as a regex, so "v1.2" would spuriously match "v1x2"
+        // and invalid patterns like "fix a[" would make git log exit non-zero.
+        .arg("--fixed-strings")
         .arg("--format=%H|%an|%at|%s")
         .arg(format!("-{}", max_commits));
 
@@ -407,7 +452,11 @@ pub async fn search_commits_by_content(
     cmd.arg("-C")
         .arg(&path)
         .arg("log")
-        .arg("--format=%H|%h|%s|%an|%at")
+        // Use NUL (%x00) as the field separator so that a commit subject (%s) or
+        // author name (%an) containing '|' cannot be misparsed into the wrong
+        // field. File names from --name-only never contain NUL, so they remain
+        // unambiguously distinguishable from header lines.
+        .arg("--format=%H%x00%h%x00%s%x00%an%x00%at")
         .arg("--name-only")
         .arg(format!("-{}", max_count));
 
@@ -454,14 +503,14 @@ pub async fn search_commits_by_content(
             continue;
         }
 
-        // Check if this is a commit header line (contains | separators)
-        if line.contains('|') && line.split('|').count() >= 5 {
+        // Header lines contain NUL field separators; file names never do.
+        if line.contains('\0') {
             // Save previous commit if exists
             if let Some(commit) = current_commit.take() {
                 results.push(commit);
             }
 
-            let parts: Vec<&str> = line.splitn(5, '|').collect();
+            let parts: Vec<&str> = line.splitn(5, '\0').collect();
             if parts.len() == 5 {
                 current_commit = Some(SearchCommit {
                     oid: parts[0].to_string(),
@@ -505,7 +554,9 @@ pub async fn search_commits_by_file(
     cmd.arg("-C")
         .arg(&path)
         .arg("log")
-        .arg("--format=%H|%h|%s|%an|%at")
+        // NUL-separated fields so a '|' in the subject/author cannot corrupt
+        // field parsing (see search_commits_by_content for details).
+        .arg("--format=%H%x00%h%x00%s%x00%an%x00%at")
         .arg("--name-only")
         .arg(format!("-{}", max_count))
         .arg("--")
@@ -541,14 +592,14 @@ pub async fn search_commits_by_file(
             continue;
         }
 
-        // Check if this is a commit header line (contains | separators)
-        if line.contains('|') && line.split('|').count() >= 5 {
+        // Header lines contain NUL field separators; file names never do.
+        if line.contains('\0') {
             // Save previous commit if exists
             if let Some(commit) = current_commit.take() {
                 results.push(commit);
             }
 
-            let parts: Vec<&str> = line.splitn(5, '|').collect();
+            let parts: Vec<&str> = line.splitn(5, '\0').collect();
             if parts.len() == 5 {
                 current_commit = Some(SearchCommit {
                     oid: parts[0].to_string(),
@@ -681,6 +732,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_search_in_files_literal_non_regex() {
+        // Regression (finding 107): a non-regex search must match literally
+        // (like `git grep -F`). "a.c" must match only the literal "a.c literal"
+        // line, not "abc" (where '.' would match 'b' under BRE semantics).
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add literal test", &[("lit.txt", "abc\na.c literal\n")]);
+
+        let result = search_in_files(
+            repo.path_str(),
+            "a.c".to_string(),
+            Some(false), // case-insensitive
+            Some(false), // NOT regex → literal
+            None,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let files = result.unwrap();
+        let total: u32 = files.iter().map(|f| f.match_count).sum();
+        assert_eq!(total, 1, "literal 'a.c' should match exactly one line");
+        assert!(files
+            .iter()
+            .flat_map(|f| &f.matches)
+            .all(|m| m.line_content.contains("a.c literal")));
+    }
+
+    #[tokio::test]
+    async fn test_search_in_files_literal_regex_metacharacters_no_error() {
+        // Regression (finding 107): a literal query containing regex
+        // metacharacters (e.g. an unbalanced "[") must NOT error out; under -F it
+        // is matched verbatim rather than compiled as an invalid regex.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add bracket", &[("br.txt", "value a[ here\n")]);
+
+        let result = search_in_files(
+            repo.path_str(),
+            "a[".to_string(),
+            Some(false),
+            Some(false),
+            None,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok(), "literal 'a[' must not error");
+        let files = result.unwrap();
+        let total: u32 = files.iter().map(|f| f.match_count).sum();
+        assert_eq!(total, 1);
+    }
+
+    #[tokio::test]
     async fn test_search_in_diff_unstaged() {
         let repo = TestRepo::with_initial_commit();
         repo.create_commit("Add base file", &[("diff_test.txt", "original content")]);
@@ -724,6 +827,44 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_search_in_diff_deleted_file_attribution() {
+        // Regression (finding 109): content removed by deleting a file must be
+        // attributed to that deleted file (whose new-side header is
+        // "+++ /dev/null"), not to the previous file in the diff, and removed
+        // lines must carry old-side (not new-side) line numbers.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit(
+            "Add base files",
+            &[
+                ("alive.txt", "alive line 1\n"),
+                ("doomed.txt", "secret_token here\nsecond line\n"),
+            ],
+        );
+
+        // Modify alive.txt and delete doomed.txt in the working tree.
+        repo.create_file("alive.txt", "alive line 1\nalive line 2\n");
+        std::fs::remove_file(format!("{}/doomed.txt", repo.path_str()))
+            .expect("failed to delete doomed.txt");
+
+        let result = search_in_diff(repo.path_str(), "secret_token".to_string(), Some(false)).await;
+
+        assert!(result.is_ok());
+        let matches = result.unwrap();
+        let m = matches
+            .iter()
+            .find(|m| m.line_content.contains("secret_token"))
+            .expect("secret_token match should be present");
+        assert_eq!(
+            m.file_path, "doomed.txt",
+            "removed content must be attributed to the deleted file"
+        );
+        assert_eq!(
+            m.line_number, 1,
+            "removed line must use its old-side line number, not 0"
+        );
     }
 
     #[tokio::test]
@@ -811,6 +952,22 @@ mod tests {
         assert!(!commits.is_empty());
     }
 
+    #[tokio::test]
+    async fn test_search_in_commit_messages_literal_not_regex() {
+        // Regression (finding 108): the message query must be matched literally,
+        // so "v1.2" must NOT match a commit message of "release v1x2".
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("release v1x2", &[("rel.txt", "content")]);
+
+        let result = search_in_commit_messages(repo.path_str(), "v1.2".to_string(), Some(50)).await;
+
+        assert!(result.is_ok());
+        assert!(
+            result.unwrap().is_empty(),
+            "literal 'v1.2' must not match 'v1x2'"
+        );
+    }
+
     #[test]
     fn test_find_match_position_case_sensitive() {
         let (start, end) = find_match_position("hello world", "world", true);
@@ -861,6 +1018,69 @@ mod tests {
             .matches
             .iter()
             .any(|m| m.file_path.contains("content_test.txt"))));
+    }
+
+    #[tokio::test]
+    async fn test_search_commits_by_content_subject_with_pipe() {
+        // Regression (finding 106): a commit subject containing '|' must not
+        // corrupt the author/date fields of the parsed SearchCommit.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit(
+            "feat: support a|b unique_pipe_token in parser",
+            &[("pipe_content.txt", "unique_pipe_token_body")],
+        );
+
+        let result = search_commits_by_content(
+            repo.path_str(),
+            "unique_pipe_token_body".to_string(),
+            Some(false),
+            Some(false),
+            Some(50),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let commits = result.unwrap();
+        let commit = commits
+            .iter()
+            .find(|c| c.message.starts_with("feat: support a|b"))
+            .expect("commit with pipe subject should be present");
+        assert_eq!(
+            commit.message,
+            "feat: support a|b unique_pipe_token in parser"
+        );
+        assert_eq!(commit.author_name, "Test User");
+        assert!(
+            commit.author_date > 0,
+            "author date must parse (not fall back to 0)"
+        );
+        assert!(commit
+            .matches
+            .iter()
+            .any(|m| m.file_path.contains("pipe_content.txt")));
+    }
+
+    #[tokio::test]
+    async fn test_search_commits_by_file_subject_with_pipe() {
+        // Regression (finding 106): search_commits_by_file shares the same
+        // parsing; a '|' in the subject must not corrupt fields.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit(
+            "chore: rename a|b in config",
+            &[("piped_config.json", "{}")],
+        );
+
+        let result = search_commits_by_file(repo.path_str(), "*.json".to_string(), Some(50)).await;
+
+        assert!(result.is_ok());
+        let commits = result.unwrap();
+        let commit = commits
+            .iter()
+            .find(|c| c.message.starts_with("chore: rename a|b"))
+            .expect("commit with pipe subject should be present");
+        assert_eq!(commit.message, "chore: rename a|b in config");
+        assert_eq!(commit.author_name, "Test User");
+        assert!(commit.author_date > 0);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/shortlog.rs
+++ b/src-tauri/src/commands/shortlog.rs
@@ -58,7 +58,30 @@ pub async fn shortlog(
 
     // Handle revision range
     if let Some(ref range_spec) = range {
-        if range_spec.contains("..") {
+        if range_spec.contains("...") {
+            // Symmetric-difference range like "v1...HEAD": commits reachable
+            // from either endpoint but not from both. Mirror git by walking
+            // both tips and hiding every merge base.
+            let parts: Vec<&str> = range_spec.splitn(2, "...").collect();
+            let from_spec = if parts[0].is_empty() {
+                "HEAD"
+            } else {
+                parts[0]
+            };
+            let to_spec = match parts.get(1) {
+                Some(s) if !s.is_empty() => *s,
+                _ => "HEAD",
+            };
+
+            let from_id = repo.revparse_single(from_spec)?.peel_to_commit()?.id();
+            let to_id = repo.revparse_single(to_spec)?.peel_to_commit()?.id();
+
+            revwalk.push(from_id)?;
+            revwalk.push(to_id)?;
+            for base in repo.merge_bases(from_id, to_id)?.iter() {
+                revwalk.hide(*base)?;
+            }
+        } else if range_spec.contains("..") {
             // Range specification like "v1.0..HEAD"
             let parts: Vec<&str> = range_spec.split("..").collect();
             if parts.len() == 2 {
@@ -107,6 +130,10 @@ pub async fn shortlog(
         }
     }
 
+    // Load the repository's .mailmap so coalesced identities match git's
+    // default behaviour. Absent or unreadable mailmaps are simply ignored.
+    let mailmap = repo.mailmap().ok();
+
     // Group commits by author/committer
     // Tuple: (name, email, commit_count, commit_messages)
     let mut contributors_map: HashMap<String, (String, Option<String>, u32, Vec<String>)> =
@@ -125,15 +152,26 @@ pub async fn shortlog(
             commit.author()
         };
 
-        let person_name = person.name().ok().unwrap_or("Unknown").to_string();
-        let person_email = person.email().ok().map(|s| s.to_string());
+        // Canonicalize the identity through the mailmap, falling back to the
+        // raw signature when no mapping applies.
+        let resolved = mailmap
+            .as_ref()
+            .and_then(|mm| mm.resolve_signature(&person).ok());
+        let effective = resolved.as_ref().unwrap_or(&person);
 
-        // Use email as key if showing email, otherwise use name
+        let person_name = effective.name().unwrap_or("Unknown").to_string();
+        let person_email = effective.email().ok().map(|s| s.to_string());
+
+        // git shortlog groups by author NAME by default; only with --email
+        // does the (name, email) pair become the grouping identity.
         let key = if show_email {
-            person_email.clone().unwrap_or_else(|| person_name.clone())
+            format!(
+                "{}\u{0}{}",
+                person_name,
+                person_email.clone().unwrap_or_default()
+            )
         } else {
-            // Use email as unique key but display name
-            person_email.clone().unwrap_or_else(|| person_name.clone())
+            person_name.clone()
         };
 
         let commit_summary = commit.summary().ok().flatten().unwrap_or("").to_string();
@@ -432,6 +470,180 @@ mod tests {
         assert_eq!(entry.email.as_ref().unwrap(), "test@example.com");
         assert_eq!(entry.count, 1);
         assert_eq!(entry.commits.len(), 1);
+    }
+
+    /// Commit `file`=`content` authored (and committed) by the given identity.
+    fn commit_as(repo: &TestRepo, name: &str, email: &str, file: &str, content: &str, msg: &str) {
+        repo.create_file(file, content);
+        repo.stage_file(file);
+        let git = repo.repo();
+        let mut index = git.index().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = git.find_tree(tree_oid).unwrap();
+        let sig = git2::Signature::now(name, email).unwrap();
+        let parent = git.head().ok().and_then(|h| h.peel_to_commit().ok());
+        let parents: Vec<&git2::Commit> = parent.as_ref().into_iter().collect();
+        git.commit(Some("HEAD"), &sig, &sig, msg, &tree, &parents)
+            .unwrap();
+    }
+
+    // Finding 72: default grouping is by author NAME, so Alice's two emails
+    // collapse into one entry while Bob and Carol (who share an email) stay
+    // distinct.
+    #[tokio::test]
+    async fn test_shortlog_groups_by_name_not_email() {
+        let repo = TestRepo::new();
+        commit_as(&repo, "Alice", "a@x", "1.txt", "1", "c1");
+        commit_as(&repo, "Alice", "b@x", "2.txt", "2", "c2");
+        commit_as(&repo, "Bob", "shared@corp", "3.txt", "3", "c3");
+        commit_as(&repo, "Carol", "shared@corp", "4.txt", "4", "c4");
+
+        let result = shortlog(
+            repo.path_str(),
+            None,
+            None,
+            Some(true),
+            Some(true),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.total_contributors, 3,
+            "entries: {:?}",
+            result.entries
+        );
+        let alice = result.entries.iter().find(|e| e.name == "Alice").unwrap();
+        assert_eq!(alice.count, 2);
+        let bob = result.entries.iter().find(|e| e.name == "Bob").unwrap();
+        assert_eq!(bob.count, 1);
+        let carol = result.entries.iter().find(|e| e.name == "Carol").unwrap();
+        assert_eq!(carol.count, 1);
+    }
+
+    // Finding 72: with --email the (name, email) pair is the identity, so the
+    // two Alice emails and the two shared-email people are all distinct.
+    #[tokio::test]
+    async fn test_shortlog_email_mode_groups_by_name_and_email() {
+        let repo = TestRepo::new();
+        commit_as(&repo, "Alice", "a@x", "1.txt", "1", "c1");
+        commit_as(&repo, "Alice", "b@x", "2.txt", "2", "c2");
+        commit_as(&repo, "Bob", "shared@corp", "3.txt", "3", "c3");
+        commit_as(&repo, "Carol", "shared@corp", "4.txt", "4", "c4");
+
+        let result = shortlog(
+            repo.path_str(),
+            None,
+            None,
+            Some(true),
+            Some(true),
+            Some(true), // --email
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.total_contributors, 4,
+            "entries: {:?}",
+            result.entries
+        );
+        assert!(result.entries.iter().all(|e| e.count == 1));
+    }
+
+    // Finding 72: a .mailmap canonicalizes identities before grouping.
+    #[tokio::test]
+    async fn test_shortlog_honors_mailmap() {
+        let repo = TestRepo::new();
+        commit_as(&repo, "Alice", "a@x", "1.txt", "1", "c1");
+        commit_as(&repo, "Alice", "b@x", "2.txt", "2", "c2");
+        // Map both of Alice's emails to the canonical name "Alicia".
+        repo.create_file(".mailmap", "Alicia <a@x>\nAlicia <b@x>\n");
+
+        let result = shortlog(
+            repo.path_str(),
+            None,
+            None,
+            Some(true),
+            Some(true),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.entries.iter().all(|e| e.name != "Alice"),
+            "Alice should be remapped to Alicia: {:?}",
+            result.entries
+        );
+        let alicia = result
+            .entries
+            .iter()
+            .find(|e| e.name == "Alicia")
+            .expect("Alicia entry");
+        assert_eq!(alicia.count, 2);
+    }
+
+    // Finding 73: three-dot symmetric-difference ranges are valid and must not
+    // error. On linear history v1...HEAD == v1..HEAD.
+    #[tokio::test]
+    async fn test_shortlog_three_dot_range_linear() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_tag("v1");
+        repo.create_commit("Second commit", &[("file.txt", "content")]);
+        repo.create_commit("Third commit", &[("file2.txt", "content2")]);
+
+        let result = shortlog(
+            repo.path_str(),
+            Some("v1...HEAD".to_string()),
+            None,
+            None,
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "three-dot range errored: {:?}",
+            result.err()
+        );
+        assert_eq!(result.unwrap().total_commits, 2);
+    }
+
+    // Finding 73: on divergent history v1...HEAD is the symmetric difference,
+    // excluding the common merge base.
+    #[tokio::test]
+    async fn test_shortlog_three_dot_range_divergent() {
+        let repo = TestRepo::with_initial_commit();
+        // feature branch diverges from main after the base commit.
+        repo.create_branch("feature");
+        repo.create_commit("Main work", &[("m.txt", "m")]);
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature work", &[("f.txt", "f")]);
+
+        let result = shortlog(
+            repo.path_str(),
+            Some("main...feature".to_string()),
+            None,
+            None,
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "three-dot range errored: {:?}",
+            result.err()
+        );
+        // Symmetric difference = {Main work, Feature work}, base excluded.
+        assert_eq!(result.unwrap().total_commits, 2);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/sparse_checkout.rs
+++ b/src-tauri/src/commands/sparse_checkout.rs
@@ -84,9 +84,16 @@ pub async fn get_sparse_checkout_config(path: String) -> Result<SparseCheckoutCo
 /// Enable sparse checkout
 #[command]
 pub async fn enable_sparse_checkout(path: String, cone_mode: bool) -> Result<SparseCheckoutConfig> {
+    // git >= 2.37 enables cone mode by default for `sparse-checkout init`.
+    // To honor a caller's request for non-cone (glob/pattern) mode we must
+    // pass `--no-cone` explicitly; otherwise git silently enables cone mode
+    // and later glob patterns are rejected with "specify directories rather
+    // than patterns".
     let mut args = vec!["sparse-checkout", "init"];
     if cone_mode {
         args.push("--cone");
+    } else {
+        args.push("--no-cone");
     }
     run_git(&path, &args)?;
     Ok(build_config(&path))
@@ -144,14 +151,22 @@ mod tests {
     use super::*;
     use crate::test_utils::TestRepo;
 
-    /// Check if git supports sparse-checkout (requires git >= 2.25)
+    /// Check if git supports sparse-checkout (requires git >= 2.25).
+    /// Detect by parsing `git --version` rather than probing `--help`
+    /// (which can invoke a man pager and give a misleading non-zero exit,
+    /// causing these tests to silently skip on a fully capable git).
     fn git_supports_sparse_checkout() -> bool {
-        Command::new("git")
-            .args(["sparse-checkout", "list"])
-            .arg("--help")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+        let out = match Command::new("git").arg("--version").output() {
+            Ok(o) if o.status.success() => o,
+            _ => return false,
+        };
+        let text = String::from_utf8_lossy(&out.stdout);
+        // Expected form: "git version 2.43.0"
+        let version = text.split_whitespace().nth(2).unwrap_or("");
+        let mut parts = version.split('.');
+        let major: u32 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        let minor: u32 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        major > 2 || (major == 2 && minor >= 25)
     }
 
     #[tokio::test]
@@ -192,6 +207,38 @@ mod tests {
         assert!(result.is_ok());
         let config = result.unwrap();
         assert!(config.enabled);
+    }
+
+    #[tokio::test]
+    async fn test_enable_sparse_checkout_no_cone_allows_glob_patterns() {
+        if !git_supports_sparse_checkout() {
+            eprintln!("Skipping: git sparse-checkout not supported");
+            return;
+        }
+
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add docs", &[("docs/readme.md", "# Docs")]);
+
+        // Requesting non-cone mode must actually produce non-cone mode.
+        let config = enable_sparse_checkout(repo.path_str(), false)
+            .await
+            .unwrap();
+        assert!(config.enabled);
+        assert!(
+            !config.cone_mode,
+            "requesting cone_mode=false must yield non-cone mode, got cone_mode=true"
+        );
+
+        // In non-cone mode a glob pattern must be accepted (cone mode rejects
+        // it with 'specify directories rather than patterns').
+        let result = set_sparse_checkout_patterns(repo.path_str(), vec!["*.md".to_string()]).await;
+        assert!(
+            result.is_ok(),
+            "glob pattern should be accepted in non-cone mode: {:?}",
+            result.err()
+        );
+        let config = result.unwrap();
+        assert!(config.patterns.iter().any(|p| p.contains("*.md")));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/squash.rs
+++ b/src-tauri/src/commands/squash.rs
@@ -181,6 +181,15 @@ pub async fn squash_commits(
     // Checkout the new commit to update working directory
     repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
 
+    // git's rebase sequencer runs post-commit once for every commit it writes
+    // (the squashed commit plus each replayed descendant). We build the new
+    // history as a batch and move the ref once, so fire the hook the same
+    // number of times now that HEAD points at the final commit.
+    let commits_created = 1 + commits_after.len();
+    for _ in 0..commits_created {
+        crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
+    }
+
     Ok(SquashResult {
         new_oid: new_head_oid.to_string(),
         squashed_count,
@@ -605,6 +614,43 @@ mod tests {
         assert!(repo.path.join("f1.txt").exists());
         assert!(repo.path.join("f2.txt").exists());
         assert!(repo.path.join("f3.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_squash_runs_post_commit_per_created_commit() {
+        // `git rebase -i` runs post-commit once for every commit it writes.
+        // Squashing C1+C2 in C0-C1-C2-C3 writes the squashed commit and
+        // replays C3 => 2 commits => post-commit must fire twice.
+        let repo = TestRepo::with_initial_commit();
+        let counter = repo.path.join("pc-count");
+        repo.install_hook(
+            "post-commit",
+            &format!("#!/bin/sh\necho x >> \"{}\"\n", counter.display()),
+        );
+
+        let c0 = repo.head_oid();
+        let _c1 = repo.create_commit("Commit 1", &[("f1.txt", "1")]);
+        let c2 = repo.create_commit("Commit 2", &[("f2.txt", "2")]);
+        let _c3 = repo.create_commit("Commit 3", &[("f3.txt", "3")]);
+
+        squash_commits(
+            repo.path_str(),
+            c0.to_string(),
+            c2.to_string(),
+            "Squashed".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let count = std::fs::read_to_string(&counter)
+            .unwrap_or_default()
+            .lines()
+            .count();
+        assert_eq!(
+            count, 2,
+            "post-commit should fire once per created commit (squashed + replayed C3)"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/squash.rs
+++ b/src-tauri/src/commands/squash.rs
@@ -181,14 +181,14 @@ pub async fn squash_commits(
     // Checkout the new commit to update working directory
     repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
 
-    // git's rebase sequencer runs post-commit once for every commit it writes
-    // (the squashed commit plus each replayed descendant). We build the new
-    // history as a batch and move the ref once, so fire the hook the same
-    // number of times now that HEAD points at the final commit.
-    let commits_created = 1 + commits_after.len();
-    for _ in 0..commits_created {
-        crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
-    }
+    // git's rebase sequencer fires post-commit per replayed commit as HEAD
+    // advances. This app replays as an ATOMIC batch — nothing is moved until
+    // the whole sequence succeeds, so a mid-replay conflict leaves the repo
+    // untouched. Advancing HEAD per commit to fire the hook accurately would
+    // break that atomicity, and firing N times with HEAD already at the final
+    // commit would feed every invocation the same (wrong) SHA. So fire
+    // post-commit once, for the final rewritten HEAD.
+    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
 
     Ok(SquashResult {
         new_oid: new_head_oid.to_string(),
@@ -618,10 +618,11 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_squash_runs_post_commit_per_created_commit() {
-        // `git rebase -i` runs post-commit once for every commit it writes.
-        // Squashing C1+C2 in C0-C1-C2-C3 writes the squashed commit and
-        // replays C3 => 2 commits => post-commit must fire twice.
+    async fn test_squash_runs_post_commit_hook() {
+        // The squash replays history as an atomic batch (nothing is moved until
+        // the whole sequence succeeds), so post-commit fires once for the final
+        // rewritten HEAD — firing per replayed commit would either break that
+        // atomicity or feed every invocation the same, already-final SHA.
         let repo = TestRepo::with_initial_commit();
         let counter = repo.path.join("pc-count");
         repo.install_hook(
@@ -647,10 +648,7 @@ mod tests {
             .unwrap_or_default()
             .lines()
             .count();
-        assert_eq!(
-            count, 2,
-            "post-commit should fire once per created commit (squashed + replayed C3)"
-        );
+        assert_eq!(count, 1, "post-commit fires once for the rewritten HEAD");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/squash.rs
+++ b/src-tauri/src/commands/squash.rs
@@ -89,6 +89,16 @@ pub async fn squash_commits(
 
     let squashed_count = commits_to_squash.len() as u32;
 
+    // The squashed range must be part of the current branch history: the
+    // branch ref is force-moved below, so an unrelated `to` would rewrite
+    // the branch to foreign history.
+    let head_commit = repo.head()?.peel_to_commit()?;
+    if head_commit.id() != to && !repo.graph_descendant_of(head_commit.id(), to)? {
+        return Err(LeviathanError::OperationFailed(
+            "The commits to squash must be part of the current branch history.".to_string(),
+        ));
+    }
+
     // Get the tree from the newest commit (to_commit) - this contains the final state
     let tree = to_commit.tree()?;
 
@@ -110,6 +120,46 @@ pub async fn squash_commits(
         &[&from_commit],
     )?;
 
+    // Replay every commit after to_commit (to..HEAD) onto the squashed
+    // commit, like `git rebase -i` does when a mid-history range is
+    // squashed. Without this, moving the branch ref to the squashed commit
+    // would silently discard all descendants of to_commit.
+    let mut commits_after = Vec::new();
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push(head_commit.id())?;
+    revwalk.hide(to)?;
+    revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::REVERSE)?;
+    for oid in revwalk {
+        commits_after.push(repo.find_commit(oid?)?);
+    }
+
+    let mut new_head_oid = new_oid;
+    for commit in &commits_after {
+        let current_base = repo.find_commit(new_head_oid)?;
+        let parent_tree = commit.parent(0)?.tree()?;
+        let commit_tree = commit.tree()?;
+        let base_tree = current_base.tree()?;
+
+        let mut merge_result = repo.merge_trees(&parent_tree, &base_tree, &commit_tree, None)?;
+        if merge_result.has_conflicts() {
+            // Nothing has been moved yet — the repository is untouched.
+            return Err(LeviathanError::OperationFailed(format!(
+                "Cannot squash: replaying the later commit {} onto the squashed \
+                 commit produced a conflict. Use an interactive rebase instead.",
+                commit.id()
+            )));
+        }
+        let new_tree = repo.find_tree(merge_result.write_tree_to(&repo)?)?;
+        new_head_oid = repo.commit(
+            None,
+            &commit.author(),
+            &signature,
+            commit.message().unwrap_or(""),
+            &new_tree,
+            &[&current_base],
+        )?;
+    }
+
     // Now we need to update HEAD to point to the new commit
     // First check if we're on a branch or in detached HEAD state
     let head = repo.head()?;
@@ -119,20 +169,20 @@ pub async fn squash_commits(
         let refname = format!("refs/heads/{}", branch_name);
         repo.reference(
             &refname,
-            new_oid,
+            new_head_oid,
             true,
             &format!("squash: {} commits into one", squashed_count),
         )?;
     } else {
         // Detached HEAD - just update HEAD
-        repo.set_head_detached(new_oid)?;
+        repo.set_head_detached(new_head_oid)?;
     }
 
     // Checkout the new commit to update working directory
     repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
 
     Ok(SquashResult {
-        new_oid: new_oid.to_string(),
+        new_oid: new_head_oid.to_string(),
         squashed_count,
         success: true,
     })
@@ -159,6 +209,25 @@ pub async fn fixup_commit(
     if repo.state() != git2::RepositoryState::Clean {
         return Err(LeviathanError::OperationFailed(
             "Another operation is in progress".to_string(),
+        ));
+    }
+
+    // Refuse on unstaged working-tree changes, like the canonical flow
+    // (`git commit --fixup` + `git rebase --autosquash`), which errors with
+    // "cannot rebase: You have unstaged changes." The final checkout below
+    // would otherwise silently overwrite them. Untracked files are fine.
+    let statuses = repo.statuses(None)?;
+    let has_unstaged = statuses.iter().any(|s| {
+        s.status().intersects(
+            git2::Status::WT_MODIFIED
+                | git2::Status::WT_DELETED
+                | git2::Status::WT_TYPECHANGE
+                | git2::Status::WT_RENAMED,
+        )
+    });
+    if has_unstaged {
+        return Err(LeviathanError::OperationFailed(
+            "Cannot fixup: you have unstaged changes. Commit or stash them first.".to_string(),
         ));
     }
 
@@ -495,6 +564,78 @@ mod tests {
         // Verify final content is preserved
         let content = std::fs::read_to_string(repo.path.join("test.txt")).unwrap();
         assert_eq!(content, "line1\nline2\nline3\n");
+    }
+
+    #[tokio::test]
+    async fn test_squash_commits_mid_history_preserves_descendants() {
+        // `git rebase -i` squashing C1+C2 in C0-C1-C2-C3 yields
+        // C0-(C1+C2)-C3': the later commit C3 and its file are preserved,
+        // not silently discarded.
+        let repo = TestRepo::with_initial_commit();
+        let c0 = repo.head_oid();
+        let _c1 = repo.create_commit("Commit 1", &[("f1.txt", "1")]);
+        let c2 = repo.create_commit("Commit 2", &[("f2.txt", "2")]);
+        let _c3 = repo.create_commit("Commit 3", &[("f3.txt", "3")]);
+
+        let result = squash_commits(
+            repo.path_str(),
+            c0.to_string(),
+            c2.to_string(),
+            "Squashed".to_string(),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "mid-history squash failed: {:?}",
+            result.err()
+        );
+        let squash_result = result.unwrap();
+        assert_eq!(squash_result.squashed_count, 2);
+
+        let git_repo = repo.repo();
+        let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+        // HEAD is the replayed C3, on top of the squashed commit, on top of C0.
+        assert_eq!(head.summary().unwrap(), Some("Commit 3"));
+        assert_eq!(head.id().to_string(), squash_result.new_oid);
+        let squashed = head.parent(0).unwrap();
+        assert_eq!(squashed.summary().unwrap(), Some("Squashed"));
+        assert_eq!(squashed.parent(0).unwrap().id(), c0);
+
+        // All files, including C3's, survive in the working tree.
+        assert!(repo.path.join("f1.txt").exists());
+        assert!(repo.path.join("f2.txt").exists());
+        assert!(repo.path.join("f3.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_fixup_commit_refuses_unstaged_changes() {
+        // The canonical flow (`git commit --fixup` + `git rebase -i
+        // --autosquash`) refuses with "cannot rebase: You have unstaged
+        // changes." — the unstaged edit must survive untouched.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add b", &[("b.txt", "base\n")]);
+        let target_oid = repo.create_commit("Target commit", &[("target.txt", "original")]);
+        repo.create_commit("After commit", &[("after.txt", "after content")]);
+
+        // Staged fix for the target commit.
+        repo.create_file("target.txt", "modified");
+        repo.stage_file("target.txt");
+        // Unstaged precious edit to an unrelated file.
+        repo.create_file("b.txt", "base\nprecious unstaged\n");
+
+        let head_before = repo.head_oid();
+        let result = fixup_commit(repo.path_str(), target_oid.to_string(), None).await;
+        assert!(
+            result.is_err(),
+            "fixup with unstaged changes must refuse like git rebase"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("unstaged"), "unexpected message: {msg}");
+
+        // Nothing was rewritten and the unstaged edit is preserved.
+        assert_eq!(repo.head_oid(), head_before);
+        let content = std::fs::read_to_string(repo.path.join("b.txt")).unwrap();
+        assert_eq!(content, "base\nprecious unstaged\n");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -337,7 +337,12 @@ pub async fn stage_files(path: String, paths: Vec<String>) -> Result<()> {
 
     for file_path in paths {
         let full_path = validate_path_within_repo(Path::new(&path), &file_path)?;
-        if full_path.exists() {
+        // Use symlink_metadata (does NOT follow symlinks) rather than
+        // Path::exists (which follows them). A dangling symlink — one whose
+        // target does not exist — must still be staged as a 120000 blob
+        // containing the link target, exactly as `git add` does; treating it
+        // as a deletion would silently stage the symlink's removal.
+        if std::fs::symlink_metadata(&full_path).is_ok() {
             index.add_path(Path::new(&file_path))?;
         } else {
             index.remove_path(Path::new(&file_path))?;
@@ -353,23 +358,33 @@ pub async fn stage_files(path: String, paths: Vec<String>) -> Result<()> {
 pub async fn unstage_files(path: String, paths: Vec<String>) -> Result<()> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
-    let head_ref = repo.head()?;
-    let head_commit = head_ref.peel_to_commit()?;
-    let head_tree = head_commit.tree()?;
-    let head_object = head_commit.as_object();
+    // Resolve the HEAD commit. On an unborn branch (a freshly initialized
+    // repository with no commits yet) there is no HEAD, and `git reset --
+    // <paths>` resolves against the empty tree — equivalent to removing the
+    // requested paths from the index. Propagating repo.head()'s error here
+    // would wrongly make unstaging impossible until the first commit exists.
+    let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
 
     let mut index = repo.index()?;
 
     for file_path in paths {
         let path_obj = Path::new(&file_path);
 
-        // Check if file exists in HEAD
-        if head_tree.get_path(path_obj).is_ok() {
-            // Reset to HEAD version
-            repo.reset_default(Some(head_object), [path_obj])?;
-        } else {
-            // Remove from index (was newly added)
-            index.remove_path(path_obj)?;
+        match &head_commit {
+            Some(commit) => {
+                let head_tree = commit.tree()?;
+                if head_tree.get_path(path_obj).is_ok() {
+                    // Reset to HEAD version
+                    repo.reset_default(Some(commit.as_object()), [path_obj])?;
+                } else {
+                    // Remove from index (was newly added)
+                    index.remove_path(path_obj)?;
+                }
+            }
+            None => {
+                // Unborn HEAD: reset against the empty tree == drop from index.
+                index.remove_path(path_obj)?;
+            }
         }
     }
 
@@ -387,12 +402,16 @@ pub async fn discard_changes(path: String, paths: Vec<String>) -> Result<()> {
     let head_tree = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
     let index = repo.index()?;
 
-    // Separate files into three categories:
-    // 1. In HEAD: checkout from HEAD tree
-    // 2. In index but not in HEAD: checkout from index
-    // 3. Untracked: delete
-    let mut head_paths: Vec<&str> = Vec::new();
-    let mut index_only_paths: Vec<&str> = Vec::new();
+    // "Discard changes" mirrors `git checkout -- <pathspec>`, which restores
+    // the working tree from the INDEX — never from HEAD. Restoring from HEAD
+    // would silently overwrite staged content (e.g. a file with staged edits
+    // plus later unstaged edits would lose the staged version, which is never
+    // committed and has no reflog: unrecoverable data loss). So:
+    //   1. Tracked (present in the index): restore the worktree from the index.
+    //   2. Untracked (not in the index and not in HEAD): delete it.
+    // A path in HEAD but absent from the index is a staged deletion; there is
+    // no worktree change to discard, so it is left untouched.
+    let mut index_paths: Vec<&str> = Vec::new();
     let mut untracked_paths: Vec<&str> = Vec::new();
 
     for file_path in &paths {
@@ -407,40 +426,23 @@ pub async fn discard_changes(path: String, paths: Vec<String>) -> Result<()> {
         // Check if file exists in index
         let in_index = index.get_path(path_obj, 0).is_some();
 
-        if in_head {
-            // File is in HEAD - checkout from HEAD tree
-            head_paths.push(file_path);
-        } else if in_index {
-            // File is staged but not in HEAD - checkout from index
-            index_only_paths.push(file_path);
-        } else {
-            // File is untracked - need to delete it
+        if in_index {
+            // Tracked - restore the worktree from the staged (index) version.
+            index_paths.push(file_path);
+        } else if !in_head {
+            // Untracked - need to delete it.
             untracked_paths.push(file_path);
         }
+        // in_head && !in_index: staged deletion, nothing to discard.
     }
 
-    // Checkout files from HEAD tree
-    if !head_paths.is_empty() {
-        if let Some(ref tree) = head_tree {
-            let mut checkout_opts = git2::build::CheckoutBuilder::new();
-            checkout_opts.force();
-            checkout_opts.remove_untracked(false);
-
-            for file_path in &head_paths {
-                checkout_opts.path(file_path);
-            }
-
-            repo.checkout_tree(tree.as_object(), Some(&mut checkout_opts))?;
-        }
-    }
-
-    // Checkout files from index (staged but not in HEAD)
-    if !index_only_paths.is_empty() {
+    // Restore tracked files from the index (matches `git checkout -- <path>`).
+    if !index_paths.is_empty() {
         let mut checkout_opts = git2::build::CheckoutBuilder::new();
         checkout_opts.force();
         checkout_opts.remove_untracked(false);
 
-        for file_path in &index_only_paths {
+        for file_path in &index_paths {
             checkout_opts.path(file_path);
         }
 
@@ -691,6 +693,24 @@ pub async fn get_file_hunks(path: String, file_path: String, staged: bool) -> Re
     })
 }
 
+/// Append one unified-diff line (`prefix` + `content`) to `patch`.
+///
+/// When `content` has no trailing newline the line is the file's final line
+/// with no end-of-file newline, so a `\ No newline at end of file` marker is
+/// emitted immediately after it — exactly as git's own patches do. Without
+/// this marker `git apply --cached` either rejects the patch ("patch does not
+/// apply", when the pre-image lacks the newline) or stages a blob with a
+/// spurious trailing newline.
+fn push_diff_line(patch: &mut String, prefix: char, content: &str) {
+    patch.push(prefix);
+    patch.push_str(content);
+    if content.ends_with('\n') {
+        return;
+    }
+    patch.push('\n');
+    patch.push_str("\\ No newline at end of file\n");
+}
+
 /// Build a unified diff patch string from a single hunk
 fn build_hunk_patch(file_path: &str, hunk: &IndexedDiffHunk) -> String {
     let mut patch = String::new();
@@ -708,15 +728,11 @@ fn build_hunk_patch(file_path: &str, hunk: &IndexedDiffHunk) -> String {
     // Lines
     for line in &hunk.lines {
         let prefix = match line.line_type.as_str() {
-            "addition" => "+",
-            "deletion" => "-",
-            _ => " ",
+            "addition" => '+',
+            "deletion" => '-',
+            _ => ' ',
         };
-        patch.push_str(&format!("{}{}", prefix, line.content));
-        // Ensure each line ends with newline
-        if !line.content.ends_with('\n') {
-            patch.push('\n');
-        }
+        push_diff_line(&mut patch, prefix, &line.content);
     }
 
     patch
@@ -816,7 +832,7 @@ pub async fn stage_lines(
 
     for (hunk, selected_indices) in &selected_hunks {
         // Rebuild the hunk with only selected changes
-        let mut new_lines: Vec<String> = Vec::new();
+        let mut hunk_body = String::new();
         let mut old_count: u32 = 0;
         let mut new_count: u32 = 0;
 
@@ -825,38 +841,22 @@ pub async fn stage_lines(
 
             match line.line_type.as_str() {
                 "context" => {
-                    let mut content = line.content.clone();
-                    if !content.ends_with('\n') {
-                        content.push('\n');
-                    }
-                    new_lines.push(format!(" {}", content));
+                    push_diff_line(&mut hunk_body, ' ', &line.content);
                     old_count += 1;
                     new_count += 1;
                 }
                 "addition" if is_selected => {
-                    let mut content = line.content.clone();
-                    if !content.ends_with('\n') {
-                        content.push('\n');
-                    }
-                    new_lines.push(format!("+{}", content));
+                    push_diff_line(&mut hunk_body, '+', &line.content);
                     new_count += 1;
                 }
                 // Not-selected additions fall through to _ => {} (omitted)
                 "deletion" => {
                     if is_selected {
-                        let mut content = line.content.clone();
-                        if !content.ends_with('\n') {
-                            content.push('\n');
-                        }
-                        new_lines.push(format!("-{}", content));
+                        push_diff_line(&mut hunk_body, '-', &line.content);
                         old_count += 1;
                     } else {
                         // Not selected deletions become context lines
-                        let mut content = line.content.clone();
-                        if !content.ends_with('\n') {
-                            content.push('\n');
-                        }
-                        new_lines.push(format!(" {}", content));
+                        push_diff_line(&mut hunk_body, ' ', &line.content);
                         old_count += 1;
                         new_count += 1;
                     }
@@ -871,9 +871,7 @@ pub async fn stage_lines(
             hunk.old_start, old_count, hunk.new_start, new_count
         ));
 
-        for line in &new_lines {
-            patch.push_str(line);
-        }
+        patch.push_str(&hunk_body);
     }
 
     // Apply the patch
@@ -1696,5 +1694,159 @@ mod tests {
         assert_eq!(sorted.unstaged_count, 0);
         assert_eq!(sorted.untracked_count, 0);
         assert_eq!(sorted.conflicted_count, 0);
+    }
+
+    // Finding 21 (data-loss): `discard_changes` on a file with both staged and
+    // later unstaged edits must restore the worktree from the INDEX (like
+    // `git checkout -- <path>`), NOT from HEAD. Restoring from HEAD destroys
+    // the staged version, which is never committed and has no reflog.
+    #[tokio::test]
+    async fn test_discard_changes_preserves_staged_content() {
+        let repo = TestRepo::with_initial_commit();
+
+        // v1 committed
+        repo.create_commit("add f", &[("f.txt", "v1\n")]);
+        // v2 staged
+        repo.create_file("f.txt", "v2-staged\n");
+        repo.stage_file("f.txt");
+        // v3 unstaged on top
+        repo.create_file("f.txt", "v3-worktree\n");
+
+        let result = discard_changes(repo.path_str(), vec!["f.txt".to_string()]).await;
+        assert!(result.is_ok(), "discard failed: {:?}", result.err());
+
+        // Worktree must be restored to the STAGED version (v2), not HEAD (v1).
+        let content = std::fs::read_to_string(repo.path.join("f.txt")).unwrap();
+        assert_eq!(
+            content, "v2-staged\n",
+            "worktree must be restored from the index (staged v2), not HEAD"
+        );
+
+        // The staged index blob must remain v2 — the staged change survives.
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        let entry = index
+            .get_path(Path::new("f.txt"), 0)
+            .expect("f.txt should still be tracked in the index");
+        let blob = git_repo.find_blob(entry.id).unwrap();
+        assert_eq!(
+            blob.content(),
+            b"v2-staged\n",
+            "staged content must not be discarded"
+        );
+    }
+
+    // Finding 25 (wrong-result): staging a dangling symlink (target missing)
+    // must stage it as a 120000 blob containing the link target, exactly like
+    // `git add`. Deciding via Path::exists() (which follows the link) wrongly
+    // treats it as a deletion.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_stage_dangling_symlink() {
+        let repo = TestRepo::with_initial_commit();
+
+        std::os::unix::fs::symlink("does-not-exist", repo.path.join("broken"))
+            .expect("failed to create symlink");
+
+        let result = stage_files(repo.path_str(), vec!["broken".to_string()]).await;
+        assert!(result.is_ok(), "staging failed: {:?}", result.err());
+
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        let entry = index
+            .get_path(Path::new("broken"), 0)
+            .expect("dangling symlink should be staged, not treated as a deletion");
+        assert_eq!(
+            entry.mode, 0o120000,
+            "should be staged as a symlink (120000)"
+        );
+        let blob = git_repo.find_blob(entry.id).unwrap();
+        assert_eq!(
+            blob.content(),
+            b"does-not-exist",
+            "symlink blob must contain the link target"
+        );
+    }
+
+    // Finding 26 (wrong-error): unstaging must work in a repository with no
+    // commits (unborn HEAD). `git reset -- <paths>` resolves against the empty
+    // tree there, dropping the paths from the index.
+    #[tokio::test]
+    async fn test_unstage_files_unborn_head() {
+        let repo = TestRepo::new(); // freshly initialized, no commits
+
+        repo.create_file("new.txt", "content\n");
+        repo.stage_file("new.txt");
+
+        // Sanity: it is staged.
+        {
+            let git_repo = repo.repo();
+            let index = git_repo.index().unwrap();
+            assert!(index.get_path(Path::new("new.txt"), 0).is_some());
+        }
+
+        let result = unstage_files(repo.path_str(), vec!["new.txt".to_string()]).await;
+        assert!(
+            result.is_ok(),
+            "unstage on unborn HEAD should succeed: {:?}",
+            result.err()
+        );
+
+        // The file is no longer staged...
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        assert!(
+            index.get_path(Path::new("new.txt"), 0).is_none(),
+            "file should be removed from the index after unstage"
+        );
+        // ...but still present in the worktree (now untracked).
+        assert!(repo.path.join("new.txt").exists());
+    }
+
+    // Finding 30 (wrong-result): staging the last hunk of a file whose final
+    // line has no trailing newline must succeed and stage the exact worktree
+    // bytes. Without the "\ No newline at end of file" marker the generated
+    // patch is rejected by `git apply --cached` ("patch does not apply").
+    #[tokio::test]
+    async fn test_stage_hunk_by_index_no_trailing_newline() {
+        let repo = TestRepo::with_initial_commit();
+
+        // Commit a file whose final line has NO trailing newline.
+        repo.create_commit("add nonl", &[("nonl.txt", "line1\nline2")]);
+
+        // Modify the final (no-newline) line, still without a trailing newline.
+        repo.create_file("nonl.txt", "line1\nCHANGED");
+
+        let hunks = get_file_hunks(repo.path_str(), "nonl.txt".to_string(), false)
+            .await
+            .unwrap();
+        assert!(!hunks.hunks.is_empty());
+
+        let result = stage_hunk_by_index(repo.path_str(), "nonl.txt".to_string(), 0).await;
+        assert!(
+            result.is_ok(),
+            "staging a no-trailing-newline hunk should succeed: {:?}",
+            result.err()
+        );
+
+        // The staged blob must be the exact worktree bytes (no spurious \n).
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        let entry = index.get_path(Path::new("nonl.txt"), 0).unwrap();
+        let blob = git_repo.find_blob(entry.id).unwrap();
+        assert_eq!(
+            blob.content(),
+            b"line1\nCHANGED",
+            "staged content must match the worktree bytes exactly"
+        );
+
+        // And the file should now be fully staged (no remaining unstaged hunks).
+        let remaining = get_file_hunks(repo.path_str(), "nonl.txt".to_string(), false)
+            .await
+            .unwrap();
+        assert!(
+            remaining.hunks.is_empty(),
+            "file should be fully staged after staging its only hunk"
+        );
     }
 }

--- a/src-tauri/src/commands/stash.rs
+++ b/src-tauri/src/commands/stash.rs
@@ -48,12 +48,18 @@ pub async fn get_stashes(path: String) -> Result<Vec<Stash>> {
 }
 
 /// Create a new stash
+///
+/// Returns `Ok(None)` when the working tree is clean and there is nothing to
+/// stash. This mirrors `git stash push`, which prints "No local changes to
+/// save" and exits 0 — a benign informational no-op, not a failure. libgit2
+/// reports nothing-to-stash as `ErrorCode::NotFound`; we translate that into a
+/// `None` result so the UI can show an informational toast instead of an error.
 #[command]
 pub async fn create_stash(
     path: String,
     message: Option<String>,
     include_untracked: Option<bool>,
-) -> Result<Stash> {
+) -> Result<Option<Stash>> {
     let mut repo = git2::Repository::open(Path::new(&path))?;
     let signature = repo.signature()?;
 
@@ -62,13 +68,17 @@ pub async fn create_stash(
         flags |= git2::StashFlags::INCLUDE_UNTRACKED;
     }
 
-    let oid = repo.stash_save(&signature, message.as_deref().unwrap_or("WIP"), Some(flags))?;
+    let oid = match repo.stash_save(&signature, message.as_deref().unwrap_or("WIP"), Some(flags)) {
+        Ok(oid) => oid,
+        Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
 
-    Ok(Stash {
+    Ok(Some(Stash {
         index: 0,
         message: message.unwrap_or_else(|| "WIP".to_string()),
         oid: oid.to_string(),
-    })
+    }))
 }
 
 /// Apply a stash
@@ -299,7 +309,7 @@ mod tests {
 
         let result = create_stash(repo.path_str(), Some("Test stash".to_string()), None).await;
         assert!(result.is_ok());
-        let stash = result.unwrap();
+        let stash = result.unwrap().expect("clean tree? expected a stash");
         assert_eq!(stash.index, 0);
         assert_eq!(stash.message, "Test stash");
     }
@@ -315,16 +325,25 @@ mod tests {
 
         let result = create_stash(repo.path_str(), None, None).await;
         assert!(result.is_ok());
-        let stash = result.unwrap();
+        let stash = result.unwrap().expect("expected a stash");
         assert_eq!(stash.message, "WIP");
     }
 
     #[tokio::test]
-    async fn test_create_stash_no_changes_fails() {
+    async fn test_create_stash_no_changes_is_noop() {
         let repo = TestRepo::with_initial_commit();
-        // No changes to stash
+        // No changes to stash. Canonical `git stash push` on a clean tree prints
+        // "No local changes to save" and exits 0 — a benign no-op, not a failure.
         let result = create_stash(repo.path_str(), Some("Empty stash".to_string()), None).await;
-        assert!(result.is_err());
+        assert!(
+            matches!(result, Ok(None)),
+            "stashing a clean tree must be a successful no-op (Ok(None)), got {:?}",
+            result
+        );
+
+        // And no stash entry should have been created.
+        let stashes = get_stashes(repo.path_str()).await.unwrap();
+        assert!(stashes.is_empty());
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -151,6 +151,7 @@ pub struct HourActivity {
 pub async fn get_repo_stats(path: String, max_commits: Option<usize>) -> Result<RepoStats> {
     let repo = git2::Repository::open(Path::new(&path))?;
     let max = max_commits.unwrap_or(10000);
+    let mailmap = repo.mailmap().ok();
 
     let mut revwalk = repo.revwalk()?;
     // push_head may fail for empty repos - that's OK
@@ -182,9 +183,7 @@ pub async fn get_repo_stats(path: String, max_commits: Option<usize>) -> Result<
         total_commits += 1;
 
         let time_secs = commit.time().seconds();
-        let author = commit.author();
-        let author_name = author.name().ok().unwrap_or("Unknown").to_string();
-        let author_email = author.email().ok().unwrap_or("unknown").to_string();
+        let (author_name, author_email) = resolve_author(&commit, mailmap.as_ref());
 
         // Track first and latest commit
         match first_commit_date {
@@ -217,22 +216,22 @@ pub async fn get_repo_stats(path: String, max_commits: Option<usize>) -> Result<
             entry.latest_commit = time_secs;
         }
 
-        // Time-based activity (approximate from epoch seconds)
-        // Simple date calculation from unix timestamp
-        let days_since_epoch = time_secs / 86400;
+        // Time-based activity in the author's recorded local timezone, matching
+        // what `git log` displays (author-local time, not UTC).
+        let local_secs = author_local_secs(&commit);
+        let days_since_epoch = local_secs.div_euclid(86400);
         // Day of week: Jan 1 1970 was Thursday (4)
-        let dow = ((days_since_epoch % 7) + 4) % 7;
+        let dow = ((days_since_epoch % 7) + 4).rem_euclid(7);
         dow_activity[dow as usize] += 1;
 
-        // Hour of day (UTC)
-        let hour = ((time_secs % 86400) / 3600) as usize;
+        // Hour of day (author-local)
+        let hour = (local_secs.rem_euclid(86400) / 3600) as usize;
         if hour < 24 {
             hour_activity[hour] += 1;
         }
 
-        // Year and month (approximate)
-        // More accurate calculation
-        let (year, month) = epoch_to_year_month(time_secs);
+        // Year and month (author-local)
+        let (year, month) = epoch_to_year_month(local_secs);
         *month_activity.entry((year, month)).or_insert(0) += 1;
     }
 
@@ -328,6 +327,7 @@ pub async fn get_contributor_stats(
 ) -> Result<Vec<ContributorStats>> {
     let repo = git2::Repository::open(Path::new(&path))?;
     let max = max_commits.unwrap_or(5000);
+    let mailmap = repo.mailmap().ok();
 
     let mut revwalk = repo.revwalk()?;
     revwalk.push_head()?;
@@ -343,34 +343,10 @@ pub async fn get_contributor_stats(
         let oid = oid_result?;
         let commit = repo.find_commit(oid)?;
         let time_secs = commit.time().seconds();
-        let author = commit.author();
-        let author_name = author.name().ok().unwrap_or("Unknown").to_string();
-        let author_email = author.email().ok().unwrap_or("unknown").to_string();
+        let (author_name, author_email) = resolve_author(&commit, mailmap.as_ref());
 
-        // Get diff stats for this commit
-        let (added, deleted) = if commit.parent_count() > 0 {
-            if let Ok(parent) = commit.parent(0) {
-                if let (Ok(parent_tree), Ok(commit_tree)) = (parent.tree(), commit.tree()) {
-                    if let Ok(diff) =
-                        repo.diff_tree_to_tree(Some(&parent_tree), Some(&commit_tree), None)
-                    {
-                        if let Ok(stats) = diff.stats() {
-                            (stats.insertions(), stats.deletions())
-                        } else {
-                            (0, 0)
-                        }
-                    } else {
-                        (0, 0)
-                    }
-                } else {
-                    (0, 0)
-                }
-            } else {
-                (0, 0)
-            }
-        } else {
-            (0, 0)
-        };
+        // Get diff stats for this commit (mirrors `git log --numstat`).
+        let (added, deleted) = commit_line_churn(&repo, &commit);
 
         let key = author_email.clone();
         let entry = contributors_map.entry(key).or_insert(ContributorStats {
@@ -435,6 +411,61 @@ fn epoch_to_year_month(epoch: i64) -> (i32, u32) {
 
 fn is_leap_year(year: i32) -> bool {
     (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+}
+
+/// Resolve a commit's author name/email, applying the repository's `.mailmap`
+/// when available. Canonical git stats commands (`git shortlog`, `git log`)
+/// honor the mailmap by default, coalescing identities that changed name/email.
+fn resolve_author(commit: &git2::Commit, mailmap: Option<&git2::Mailmap>) -> (String, String) {
+    if let Some(mm) = mailmap {
+        if let Ok(sig) = commit.author_with_mailmap(mm) {
+            return (
+                sig.name().unwrap_or("Unknown").to_string(),
+                sig.email().unwrap_or("unknown").to_string(),
+            );
+        }
+    }
+    let author = commit.author();
+    (
+        author.name().unwrap_or("Unknown").to_string(),
+        author.email().unwrap_or("unknown").to_string(),
+    )
+}
+
+/// Compute a commit's timestamp in the author's recorded local timezone.
+/// Git records and displays author-local time (e.g. `%ad`), so activity
+/// buckets (hour/weekday/month) must use the offset rather than raw UTC.
+fn author_local_secs(commit: &git2::Commit) -> i64 {
+    let time = commit.time();
+    time.seconds() + i64::from(time.offset_minutes()) * 60
+}
+
+/// Per-commit line churn matching `git log --numstat` defaults:
+/// merge commits contribute no diff, and renames are detected (counted as
+/// 0 added / 0 deleted) rather than as a full delete + add.
+fn commit_line_churn(repo: &git2::Repository, commit: &git2::Commit) -> (usize, usize) {
+    if commit.parent_count() != 1 {
+        return (0, 0);
+    }
+    let parent = match commit.parent(0) {
+        Ok(p) => p,
+        Err(_) => return (0, 0),
+    };
+    let (parent_tree, commit_tree) = match (parent.tree(), commit.tree()) {
+        (Ok(pt), Ok(ct)) => (pt, ct),
+        _ => return (0, 0),
+    };
+    let mut diff = match repo.diff_tree_to_tree(Some(&parent_tree), Some(&commit_tree), None) {
+        Ok(d) => d,
+        Err(_) => return (0, 0),
+    };
+    let mut find_opts = git2::DiffFindOptions::new();
+    find_opts.renames(true);
+    let _ = diff.find_similar(Some(&mut find_opts));
+    match diff.stats() {
+        Ok(stats) => (stats.insertions(), stats.deletions()),
+        Err(_) => (0, 0),
+    }
 }
 
 /// Parse ISO 8601 date string to epoch seconds
@@ -503,6 +534,7 @@ pub async fn get_repo_statistics(
     until: Option<String>,
 ) -> Result<RepoStatistics> {
     let repo = git2::Repository::open(Path::new(&path))?;
+    let mailmap = repo.mailmap().ok();
 
     // Parse date filters
     let since_epoch = since.as_ref().and_then(|s| parse_iso8601_to_epoch(s));
@@ -555,9 +587,7 @@ pub async fn get_repo_statistics(
 
         total_commits += 1;
 
-        let author = commit.author();
-        let author_name = author.name().ok().unwrap_or("Unknown").to_string();
-        let author_email = author.email().ok().unwrap_or("unknown").to_string();
+        let (author_name, author_email) = resolve_author(&commit, mailmap.as_ref());
 
         // Track first and last commit
         match first_commit_date {
@@ -571,27 +601,11 @@ pub async fn get_repo_statistics(
             _ => {}
         }
 
-        // Get diff stats (lines added/deleted)
-        let (added, deleted) = if include_contributors && commit.parent_count() > 0 {
-            if let Ok(parent) = commit.parent(0) {
-                if let (Ok(parent_tree), Ok(commit_tree)) = (parent.tree(), commit.tree()) {
-                    if let Ok(diff) =
-                        repo.diff_tree_to_tree(Some(&parent_tree), Some(&commit_tree), None)
-                    {
-                        if let Ok(stats) = diff.stats() {
-                            (stats.insertions() as u64, stats.deletions() as u64)
-                        } else {
-                            (0, 0)
-                        }
-                    } else {
-                        (0, 0)
-                    }
-                } else {
-                    (0, 0)
-                }
-            } else {
-                (0, 0)
-            }
+        // Get diff stats (lines added/deleted), mirroring `git log --numstat`:
+        // merges contribute nothing and renames count as 0/0.
+        let (added, deleted) = if include_contributors {
+            let (a, d) = commit_line_churn(&repo, &commit);
+            (a as u64, d as u64)
         } else {
             (0, 0)
         };
@@ -624,23 +638,26 @@ pub async fn get_repo_statistics(
             }
         }
 
-        // Activity breakdown
+        // Activity breakdown in the author's recorded local timezone, matching
+        // what `git log` displays (author-local time, not UTC).
         if include_activity {
+            let local_secs = author_local_secs(&commit);
+
             // Year/month activity
-            let (year, month) = epoch_to_year_month(time_secs);
+            let (year, month) = epoch_to_year_month(local_secs);
             let entry = month_activity
                 .entry((year as u32, month))
                 .or_insert((0, HashSet::new()));
             entry.0 += 1;
             entry.1.insert(author_email.clone());
 
-            // Day of week (0=Sunday)
-            let days_since_epoch = time_secs / 86400;
-            let dow = ((days_since_epoch % 7) + 4) % 7; // Jan 1, 1970 was Thursday (4)
+            // Day of week (0=Sunday); Jan 1, 1970 was Thursday (4)
+            let days_since_epoch = local_secs.div_euclid(86400);
+            let dow = ((days_since_epoch % 7) + 4).rem_euclid(7);
             weekday_activity[dow as usize] += 1;
 
-            // Hour of day (UTC)
-            let hour = ((time_secs % 86400) / 3600) as usize;
+            // Hour of day (author-local)
+            let hour = (local_secs.rem_euclid(86400) / 3600) as usize;
             if hour < 24 {
                 hour_activity[hour] += 1;
             }
@@ -816,9 +833,8 @@ pub async fn get_repo_statistics(
                         continue;
                     }
                 }
-                if let Ok(email) = commit.author().email() {
-                    unique_authors.insert(email.to_string());
-                }
+                let (_, email) = resolve_author(&commit, mailmap.as_ref());
+                unique_authors.insert(email);
             }
         }
         unique_authors.len() as u32
@@ -1113,5 +1129,257 @@ mod tests {
 
         // Repo age should be 0 for same-day commits
         assert_eq!(stats.repo_age_days, 0);
+    }
+
+    // ---- Regression-test helpers for canonical git parity ----------------
+
+    /// Build a string of `n` distinct lines with the given prefix.
+    fn lines(prefix: &str, n: usize) -> String {
+        (1..=n)
+            .map(|i| format!("{prefix}{i}\n"))
+            .collect::<String>()
+    }
+
+    /// Create a commit with an explicit author identity, timestamp, file
+    /// changes, and parents. `changes` maps a path to `Some(content)` to
+    /// create/update or `None` to delete. When `update_ref` is provided the
+    /// named ref is moved to the new commit.
+    #[allow(clippy::too_many_arguments)]
+    fn commit_with(
+        repo: &git2::Repository,
+        name: &str,
+        email: &str,
+        when: git2::Time,
+        message: &str,
+        changes: &[(&str, Option<&str>)],
+        parents: &[git2::Oid],
+        update_ref: Option<&str>,
+    ) -> git2::Oid {
+        // Build the tree from the first parent (all test paths are top-level).
+        let base_tree = parents
+            .first()
+            .map(|p| repo.find_commit(*p).expect("parent").tree().expect("tree"));
+        let mut builder = repo.treebuilder(base_tree.as_ref()).expect("tree builder");
+        for (path, content) in changes {
+            match content {
+                Some(c) => {
+                    let blob = repo.blob(c.as_bytes()).expect("write blob");
+                    builder.insert(path, blob, 0o100644).expect("insert entry");
+                }
+                None => {
+                    builder.remove(path).expect("remove entry");
+                }
+            }
+        }
+        let tree_oid = builder.write().expect("write tree");
+        let tree = repo.find_tree(tree_oid).expect("find tree");
+        let sig = git2::Signature::new(name, email, &when).expect("signature");
+        let parent_commits: Vec<git2::Commit> = parents
+            .iter()
+            .map(|p| repo.find_commit(*p).expect("parent"))
+            .collect();
+        let parent_refs: Vec<&git2::Commit> = parent_commits.iter().collect();
+        repo.commit(update_ref, &sig, &sig, message, &tree, &parent_refs)
+            .expect("create commit")
+    }
+
+    fn find_contrib<'a>(contributors: &'a [ContributorStats], email: &str) -> &'a ContributorStats {
+        contributors
+            .iter()
+            .find(|c| c.email == email)
+            .unwrap_or_else(|| panic!("contributor {email} not found"))
+    }
+
+    // Finding 102: contributor/total churn must match `git log --numstat` —
+    // merges contribute no diff, and a pure rename counts as 0 added/0 deleted
+    // (not a full delete + add).
+    #[tokio::test]
+    async fn test_contributor_stats_skips_merges_and_detects_renames() {
+        let repo = TestRepo::new();
+        let git = repo.repo();
+        let t = git2::Time::new(1_600_000_000, 0);
+        let big = lines("l", 100);
+        let bob_lines = lines("b", 50);
+
+        // C0 (root): Alice seeds a base file.
+        let c0 = commit_with(
+            &git,
+            "Alice",
+            "alice@example.com",
+            t,
+            "seed",
+            &[("base.txt", Some("base\n"))],
+            &[],
+            Some("refs/heads/main"),
+        );
+        // C1: Alice adds a 100-line file.
+        let c1 = commit_with(
+            &git,
+            "Alice",
+            "alice@example.com",
+            t,
+            "add big",
+            &[("big.txt", Some(&big))],
+            &[c0],
+            Some("refs/heads/main"),
+        );
+        // Feature branch: Bob adds a 50-line file.
+        let cb = commit_with(
+            &git,
+            "Bob",
+            "bob@example.com",
+            t,
+            "bob work",
+            &[("bob.txt", Some(&bob_lines))],
+            &[c1],
+            Some("refs/heads/feature"),
+        );
+        // C2: Carol renames big.txt -> renamed.txt (byte-identical content).
+        let c2 = commit_with(
+            &git,
+            "Carol",
+            "carol@example.com",
+            t,
+            "rename big",
+            &[("big.txt", None), ("renamed.txt", Some(&big))],
+            &[c1],
+            Some("refs/heads/main"),
+        );
+        // Merge: Carol merges feature; first-parent diff brings in bob.txt.
+        commit_with(
+            &git,
+            "Carol",
+            "carol@example.com",
+            t,
+            "merge feature",
+            &[("bob.txt", Some(&bob_lines))],
+            &[c2, cb],
+            Some("refs/heads/main"),
+        );
+        // TestRepo::new() leaves HEAD on the unborn default branch (which is
+        // `master` when no init.defaultBranch is configured); point it at the
+        // branch this history was built on so the None revspec resolves.
+        git.set_head("refs/heads/main").unwrap();
+
+        let contributors = get_contributor_stats(repo.path_str(), None).await.unwrap();
+
+        let alice = find_contrib(&contributors, "alice@example.com");
+        assert_eq!(alice.lines_added, 100, "Alice's non-root addition");
+        assert_eq!(alice.lines_deleted, 0);
+
+        let bob = find_contrib(&contributors, "bob@example.com");
+        assert_eq!(bob.lines_added, 50);
+        assert_eq!(bob.lines_deleted, 0);
+
+        // Carol's only work is a pure rename + a merge: canonical numstat is 0/0.
+        let carol = find_contrib(&contributors, "carol@example.com");
+        assert_eq!(
+            carol.lines_added, 0,
+            "rename must count as 0 added and merge must be skipped"
+        );
+        assert_eq!(carol.lines_deleted, 0);
+
+        // get_repo_statistics shares the same churn logic.
+        let stats = get_repo_statistics(repo.path_str(), false, true, false, None, None)
+            .await
+            .unwrap();
+        let top = stats.top_contributors.unwrap();
+        let carol2 = top.iter().find(|c| c.email == "carol@example.com").unwrap();
+        assert_eq!(carol2.lines_added, 0);
+        assert_eq!(carol2.lines_deleted, 0);
+    }
+
+    // Finding 103: contributor aggregation must honor `.mailmap`, coalescing
+    // identities like `git shortlog -sne` does.
+    #[tokio::test]
+    async fn test_contributor_stats_respects_mailmap() {
+        let repo = TestRepo::new();
+        std::fs::write(
+            repo.path.join(".mailmap"),
+            "Alice Proper <alice@proper.com> <alice@old.com>\n",
+        )
+        .expect("write mailmap");
+
+        let git = repo.repo();
+        let t = git2::Time::new(1_600_000_000, 0);
+        let c0 = commit_with(
+            &git,
+            "Alice",
+            "alice@old.com",
+            t,
+            "first",
+            &[("a.txt", Some("a\n"))],
+            &[],
+            Some("refs/heads/main"),
+        );
+        commit_with(
+            &git,
+            "Alice Proper",
+            "alice@proper.com",
+            t,
+            "second",
+            &[("b.txt", Some("b\n"))],
+            &[c0],
+            Some("refs/heads/main"),
+        );
+
+        let stats = get_repo_statistics(repo.path_str(), false, true, false, None, None)
+            .await
+            .unwrap();
+        let contributors = stats.top_contributors.unwrap();
+        assert_eq!(
+            contributors.len(),
+            1,
+            "mailmap should coalesce the two identities into one"
+        );
+        assert_eq!(contributors[0].name, "Alice Proper");
+        assert_eq!(contributors[0].email, "alice@proper.com");
+        assert_eq!(contributors[0].commits, 2);
+        assert_eq!(stats.total_contributors, 1);
+    }
+
+    // Finding 104: activity buckets must use the author's recorded timezone,
+    // matching what `git log` displays, not UTC.
+    #[tokio::test]
+    async fn test_activity_buckets_use_author_timezone() {
+        let repo = TestRepo::new();
+        let git = repo.repo();
+        // 14:00 UTC with a +09:00 offset => 23:00 author-local time.
+        let when = git2::Time::new(50_400, 540);
+        commit_with(
+            &git,
+            "Kenji",
+            "kenji@example.com",
+            when,
+            "evening commit",
+            &[("f.txt", Some("x\n"))],
+            &[],
+            Some("refs/heads/main"),
+        );
+
+        let stats = get_repo_statistics(repo.path_str(), true, false, false, None, None)
+            .await
+            .unwrap();
+        let hours = stats.activity_by_hour.unwrap();
+        assert_eq!(
+            hours[23].commits, 1,
+            "commit should bucket at local hour 23"
+        );
+        assert_eq!(hours[14].commits, 0, "should not bucket at UTC hour 14");
+
+        // get_repo_stats shares the same bucketing logic.
+        let legacy = get_repo_stats(repo.path_str(), None).await.unwrap();
+        let h23 = legacy
+            .activity_by_hour
+            .iter()
+            .find(|h| h.hour == 23)
+            .unwrap();
+        assert_eq!(h23.commit_count, 1);
+        let h14 = legacy
+            .activity_by_hour
+            .iter()
+            .find(|h| h.hour == 14)
+            .unwrap();
+        assert_eq!(h14.commit_count, 0);
     }
 }

--- a/src-tauri/src/commands/submodule.rs
+++ b/src-tauri/src/commands/submodule.rs
@@ -305,18 +305,19 @@ pub async fn deinit_submodule(
 pub async fn remove_submodule(path: String, submodule_path: String) -> Result<()> {
     let repo_path = Path::new(&path);
 
+    // Mirror canonical git submodule removal: `git submodule deinit -f <path>`
+    // followed by `git rm -f <path>`. This removes the working tree, the
+    // .gitmodules entry, and the index entry, but intentionally LEAVES the
+    // submodule's object store under `.git/modules/<name>` intact so that any
+    // local commits made inside the submodule that were never pushed remain
+    // recoverable. Deleting `.git/modules/<name>` here (as a previous version
+    // did) permanently destroyed those commits with no reflog and no recovery
+    // path — a data-loss bug that canonical git never inflicts.
+
     // Step 1: Deinit the submodule
     run_git_command(repo_path, &["submodule", "deinit", "-f", &submodule_path])?;
 
-    // Step 2: Remove from .git/modules
-    let git_modules_path = repo_path.join(".git").join("modules").join(&submodule_path);
-    if git_modules_path.exists() {
-        std::fs::remove_dir_all(&git_modules_path).map_err(|e| {
-            LeviathanError::OperationFailed(format!("Failed to remove .git/modules: {}", e))
-        })?;
-    }
-
-    // Step 3: Remove from working tree and index
+    // Step 2: Remove from working tree and index (keeps .git/modules for recovery)
     run_git_command(repo_path, &["rm", "-f", &submodule_path])?;
 
     Ok(())
@@ -531,5 +532,85 @@ mod tests {
         // Remove on nonexistent submodule should fail
         let result = remove_submodule(repo.path_str(), "nonexistent".to_string()).await;
         assert!(result.is_err());
+    }
+
+    /// Run a git command in `dir`, panicking on failure. Enables local-file
+    /// protocol so `submodule add ../path` works in the sandbox.
+    fn git_in(dir: &Path, args: &[&str]) -> String {
+        let output = create_command("git")
+            .current_dir(dir)
+            .arg("-c")
+            .arg("protocol.file.allow=always")
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    /// Canonical `git rm`-based submodule removal preserves the submodule's
+    /// object store under `.git/modules/<name>`, so unpushed commits made
+    /// inside the submodule remain recoverable. remove_submodule must NOT
+    /// destroy that object store.
+    #[tokio::test]
+    async fn test_remove_submodule_preserves_unpushed_commits() {
+        // Source repository that will be used as the submodule.
+        let source = TestRepo::with_initial_commit();
+
+        // Superproject.
+        let super_repo = TestRepo::with_initial_commit();
+        let super_path = super_repo.path.clone();
+
+        // Add the submodule at deps/lib and commit.
+        let source_url = source.path.to_string_lossy().to_string();
+        git_in(&super_path, &["submodule", "add", &source_url, "deps/lib"]);
+        git_in(&super_path, &["commit", "-m", "add submodule"]);
+
+        // Make a commit inside the submodule that is never pushed.
+        let sub_path = super_path.join("deps").join("lib");
+        git_in(&sub_path, &["config", "user.email", "test@example.com"]);
+        git_in(&sub_path, &["config", "user.name", "Test User"]);
+        std::fs::write(sub_path.join("local.txt"), "local work").unwrap();
+        git_in(&sub_path, &["add", "local.txt"]);
+        git_in(&sub_path, &["commit", "-m", "unpushed local work"]);
+        let unpushed_oid = git_in(&sub_path, &["rev-parse", "HEAD"]);
+
+        // Sanity: the object store exists before removal.
+        let modules_dir = super_path.join(".git").join("modules").join("deps/lib");
+        assert!(
+            modules_dir.exists(),
+            "submodule gitdir should exist before removal"
+        );
+
+        // Remove the submodule.
+        let result = remove_submodule(super_repo.path_str(), "deps/lib".to_string()).await;
+        assert!(
+            result.is_ok(),
+            "remove_submodule failed: {:?}",
+            result.err()
+        );
+
+        // Working tree entry is gone...
+        assert!(
+            !super_path.join("deps").join("lib").exists(),
+            "submodule working tree should be removed"
+        );
+
+        // ...but the object store is preserved and the unpushed commit is
+        // still recoverable (matching canonical `git rm`).
+        assert!(
+            modules_dir.exists(),
+            "remove_submodule destroyed .git/modules — unpushed commits are unrecoverable"
+        );
+        let obj_type = git_in(&modules_dir, &["cat-file", "-t", &unpushed_oid]);
+        assert_eq!(
+            obj_type, "commit",
+            "unpushed submodule commit should remain recoverable after removal"
+        );
     }
 }

--- a/src-tauri/src/commands/tags.rs
+++ b/src-tauri/src/commands/tags.rs
@@ -23,6 +23,43 @@ pub struct TagDetails {
     pub is_signed: bool,
 }
 
+/// Whether a tag object's raw message contains any recognized signature block.
+/// Covers OpenPGP, SSH, and x509 (gpgsm) signatures, matching `git verify-tag`.
+fn message_is_signed(bytes: &[u8]) -> bool {
+    let msg = String::from_utf8_lossy(bytes);
+    msg.contains("-----BEGIN PGP SIGNATURE-----")
+        || msg.contains("-----BEGIN SSH SIGNATURE-----")
+        || msg.contains("-----BEGIN SIGNED MESSAGE-----")
+}
+
+/// Whether tag signing is enabled for the repository (tag.gpgsign = true).
+fn tag_signing_enabled(repo: &git2::Repository) -> bool {
+    repo.config()
+        .and_then(|c| c.get_bool("tag.gpgsign"))
+        .unwrap_or(false)
+}
+
+/// Create a signed annotated tag via the git CLI.
+///
+/// libgit2's `Repository::tag` cannot sign, so honoring tag.gpgsign requires
+/// shelling out. Errors (e.g. no signing key) surface to the user, exactly as
+/// `git tag -s` would refuse.
+fn create_signed_tag_cli(path: &str, name: &str, target: &str, message: &str) -> Result<()> {
+    let output = crate::utils::create_command("git")
+        .current_dir(path)
+        .args(["tag", "-s", "-m", message, name, target])
+        .output()
+        .map_err(|e| LeviathanError::OperationFailed(format!("Failed to run git tag: {}", e)))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(LeviathanError::OperationFailed(format!(
+            "Failed to create signed tag: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(())
+}
+
 /// Get all tags
 #[command]
 pub async fn get_tags(path: String) -> Result<Vec<Tag>> {
@@ -85,14 +122,8 @@ pub async fn get_tag_details(path: String, name: String) -> Result<TagDetails> {
 
     // Try to get tag details if it's an annotated tag
     let details = if let Ok(tag) = repo.find_tag(ref_oid) {
-        // Check if tag is signed by looking for PGP signature in the raw message
-        let is_signed = tag
-            .message_bytes()
-            .map(|bytes| {
-                let msg = String::from_utf8_lossy(bytes);
-                msg.contains("-----BEGIN PGP SIGNATURE-----")
-            })
-            .unwrap_or(false);
+        // Check if tag is signed by looking for a signature block in the raw message
+        let is_signed = tag.message_bytes().map(message_is_signed).unwrap_or(false);
 
         TagDetails {
             name,
@@ -147,9 +178,14 @@ pub async fn create_tag(
     let target_obj = repo.find_object(target_oid, None)?;
 
     let (is_annotated, tagger) = if let Some(ref msg) = message {
-        // Create annotated tag
+        // Create annotated tag. libgit2 cannot sign, so when tag.gpgsign is on we
+        // must shell out to `git tag -s` to honor the configured signing.
         let signature = repo.signature()?;
-        repo.tag(&name, &target_obj, &signature, msg, false)?;
+        if tag_signing_enabled(&repo) {
+            create_signed_tag_cli(&path, &name, &target_oid.to_string(), msg)?;
+        } else {
+            repo.tag(&name, &target_obj, &signature, msg, false)?;
+        }
         (
             true,
             Some(Signature {
@@ -205,6 +241,10 @@ pub async fn push_tag(
         format!("refs/tags/{}:refs/tags/{}", name, name)
     };
 
+    // Run pre-push like canonical git — the git2 push path otherwise bypasses
+    // it. A non-zero exit aborts the tag push.
+    crate::commands::hooks::run_pre_push_tag(&repo, remote_name, &name)?;
+
     remote_obj.push(&[&refspec], Some(&mut push_opts))?;
 
     Ok(())
@@ -235,18 +275,21 @@ pub async fn edit_tag_message(path: String, name: String, message: String) -> Re
     // Delete the old tag
     repo.tag_delete(&name)?;
 
-    // Create new tag with updated message
+    // Create new tag with updated message, honoring tag.gpgsign (libgit2 cannot
+    // sign, so fall back to `git tag -s` when signing is enabled).
     let signature = repo.signature()?;
-    let new_tag_oid = repo.tag(&name, &target_obj, &signature, &message, false)?;
+    let new_tag_oid = if tag_signing_enabled(&repo) {
+        create_signed_tag_cli(&path, &name, &target_oid.to_string(), &message)?;
+        repo.refname_to_id(&format!("refs/tags/{}", name))?
+    } else {
+        repo.tag(&name, &target_obj, &signature, &message, false)?
+    };
 
     // Return the updated tag details
     let new_tag = repo.find_tag(new_tag_oid)?;
     let is_signed = new_tag
         .message_bytes()
-        .map(|bytes| {
-            let msg = String::from_utf8_lossy(bytes);
-            msg.contains("-----BEGIN PGP SIGNATURE-----")
-        })
+        .map(message_is_signed)
         .unwrap_or(false);
 
     Ok(TagDetails {
@@ -266,6 +309,37 @@ pub async fn edit_tag_message(path: String, name: String, message: String) -> Re
 mod tests {
     use super::*;
     use crate::test_utils::TestRepo;
+
+    // ---- pre-push hook parity for tag pushes ----
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_push_tag_pre_push_hook_aborts() {
+        let repo = TestRepo::with_initial_commit();
+        let bare = tempfile::tempdir().unwrap();
+        git2::Repository::init_bare(bare.path()).unwrap();
+        repo.add_remote("origin", &bare.path().to_string_lossy());
+        repo.create_lightweight_tag("v1");
+
+        repo.install_hook(
+            "pre-push",
+            "#!/bin/sh\ncat >/dev/null\necho tag-denied 1>&2\nexit 1\n",
+        );
+
+        let result = push_tag(
+            repo.path_str(),
+            "v1".to_string(),
+            Some("origin".to_string()),
+            None,
+            None,
+        )
+        .await;
+        assert!(result.is_err(), "pre-push exit 1 must abort the tag push");
+        assert!(result.unwrap_err().to_string().contains("tag-denied"));
+
+        let bare_repo = git2::Repository::open(bare.path()).unwrap();
+        assert!(bare_repo.refname_to_id("refs/tags/v1").is_err());
+    }
 
     #[tokio::test]
     async fn test_get_tags_empty() {
@@ -540,5 +614,102 @@ mod tests {
 
         // Target should still point to the same commit
         assert_eq!(result.target_oid, head_oid.to_string());
+    }
+
+    #[test]
+    fn test_message_is_signed_formats() {
+        assert!(message_is_signed(
+            b"msg\n-----BEGIN PGP SIGNATURE-----\n...\n"
+        ));
+        assert!(message_is_signed(
+            b"msg\n-----BEGIN SSH SIGNATURE-----\n...\n"
+        ));
+        assert!(message_is_signed(
+            b"msg\n-----BEGIN SIGNED MESSAGE-----\n...\n"
+        ));
+        assert!(!message_is_signed(b"just a plain tag message"));
+    }
+
+    /// Configure the repo for SSH tag signing. Returns false (test should skip)
+    /// when ssh-keygen is unavailable.
+    fn setup_ssh_signing(repo: &TestRepo, keydir: &std::path::Path) -> bool {
+        let key = keydir.join("id");
+        let gen = std::process::Command::new("ssh-keygen")
+            .args(["-t", "ed25519", "-N", "", "-f", key.to_str().unwrap(), "-q"])
+            .output();
+        if gen.map(|o| !o.status.success()).unwrap_or(true) {
+            return false;
+        }
+        let pubkey = format!("{}.pub", key.to_str().unwrap());
+        let cfg = |k: &str, v: &str| {
+            std::process::Command::new("git")
+                .current_dir(&repo.path)
+                .args(["config", k, v])
+                .output()
+                .unwrap();
+        };
+        cfg("gpg.format", "ssh");
+        cfg("user.signingkey", &pubkey);
+        cfg("tag.gpgsign", "true");
+        true
+    }
+
+    // Finding 99: with tag.gpgsign=true, app-created annotated tags must be signed.
+    #[tokio::test]
+    async fn test_create_tag_signs_when_tag_gpgsign_enabled() {
+        let repo = TestRepo::with_initial_commit();
+        let keydir = tempfile::TempDir::new().unwrap();
+        if !setup_ssh_signing(&repo, keydir.path()) {
+            return; // ssh-keygen unavailable
+        }
+
+        create_tag(
+            repo.path_str(),
+            "v1.0.0".to_string(),
+            None,
+            Some("Signed release".to_string()),
+        )
+        .await
+        .unwrap();
+
+        let details = get_tag_details(repo.path_str(), "v1.0.0".to_string())
+            .await
+            .unwrap();
+        assert!(
+            details.is_signed,
+            "annotated tag must be signed when tag.gpgsign=true"
+        );
+    }
+
+    // Finding 99: editing a tag message must also re-sign when tag.gpgsign=true.
+    #[tokio::test]
+    async fn test_edit_tag_message_signs_when_tag_gpgsign_enabled() {
+        let repo = TestRepo::with_initial_commit();
+        let keydir = tempfile::TempDir::new().unwrap();
+        if !setup_ssh_signing(&repo, keydir.path()) {
+            return; // ssh-keygen unavailable
+        }
+
+        create_tag(
+            repo.path_str(),
+            "v1.0.0".to_string(),
+            None,
+            Some("Original".to_string()),
+        )
+        .await
+        .unwrap();
+
+        let details = edit_tag_message(
+            repo.path_str(),
+            "v1.0.0".to_string(),
+            "Updated signed".to_string(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(details.message, Some("Updated signed".to_string()));
+        assert!(
+            details.is_signed,
+            "edited tag must be signed when tag.gpgsign=true"
+        );
     }
 }

--- a/src-tauri/src/commands/undo.rs
+++ b/src-tauri/src/commands/undo.rs
@@ -8,7 +8,68 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use tauri::command;
 
+use crate::error::LeviathanError;
 use crate::error::Result;
+
+/// Refuse to reset while a multi-step operation (rebase, bisect, or a
+/// cherry-pick/revert *sequence*) is in progress. Canonical `git reset` leaves
+/// `.git/rebase-merge`, `.git/rebase-apply`, `.git/BISECT_LOG` and the sequencer
+/// directory in place, but libgit2's reset unconditionally runs
+/// `git_repository_state_cleanup` for MIXED/HARD resets and deletes them,
+/// silently destroying the in-progress operation. Mirror git by refusing.
+/// (A plain single-op Merge / CherryPick / Revert is intentionally allowed:
+/// `git reset` is the documented way to abort those, and clearing MERGE_HEAD /
+/// CHERRY_PICK_HEAD / REVERT_HEAD is exactly what git itself does.)
+fn ensure_resettable(repo: &git2::Repository) -> Result<()> {
+    use git2::RepositoryState::*;
+    match repo.state() {
+        Rebase | RebaseInteractive | RebaseMerge | ApplyMailbox | ApplyMailboxOrRebase => {
+            Err(LeviathanError::OperationFailed(
+                "Cannot reset while a rebase is in progress. Finish or abort the rebase (git rebase --continue or --abort) before undoing.".to_string(),
+            ))
+        }
+        Bisect => Err(LeviathanError::OperationFailed(
+            "Cannot reset while a bisect is in progress. Run 'git bisect reset' before undoing.".to_string(),
+        )),
+        CherryPickSequence => Err(LeviathanError::OperationFailed(
+            "Cannot reset while a cherry-pick sequence is in progress. Finish or abort it (git cherry-pick --continue or --abort) before undoing.".to_string(),
+        )),
+        RevertSequence => Err(LeviathanError::OperationFailed(
+            "Cannot reset while a revert sequence is in progress. Finish or abort it (git revert --continue or --abort) before undoing.".to_string(),
+        )),
+        _ => Ok(()),
+    }
+}
+
+/// Parse the source ref of a checkout reflog message.
+/// Format: "checkout: moving from <from> to <to>".
+fn parse_checkout_source(message: &str) -> Option<String> {
+    let rest = message.split_once("moving from ")?.1;
+    let from = rest.rsplit_once(" to ")?.0.trim();
+    if from.is_empty() {
+        None
+    } else {
+        Some(from.to_string())
+    }
+}
+
+/// Record a marker in repo config so `redo_last_action` can distinguish an
+/// app-performed undo from a user-initiated reset. `redo_target` is the state
+/// redo should restore (HEAD before the undo); `undo_head` is HEAD immediately
+/// after the undo, used to detect whether anything changed since.
+fn set_redo_marker(repo: &git2::Repository, redo_target: &str, undo_head: &str) {
+    if let Ok(mut cfg) = repo.config() {
+        let _ = cfg.set_str("leviathan.redotarget", redo_target);
+        let _ = cfg.set_str("leviathan.redohead", undo_head);
+    }
+}
+
+fn clear_redo_marker(repo: &git2::Repository) {
+    if let Ok(mut cfg) = repo.config() {
+        let _ = cfg.remove("leviathan.redotarget");
+        let _ = cfg.remove("leviathan.redohead");
+    }
+}
 
 /// Represents a single undoable git action parsed from the reflog
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -272,10 +333,42 @@ pub async fn undo_last_action(path: String) -> Result<UndoAction> {
     // Parse the action we're undoing
     let (action_type, description) = parse_reflog_action(&message);
 
+    // Undoing a checkout must restore the previous HEAD *symbolically* — like
+    // `git switch -` — which returns to the previous branch and never moves any
+    // branch ref. A mixed reset here would rewrite the current branch to the
+    // pre-checkout commit and orphan its commits (data loss).
+    if action_type == "checkout" {
+        return undo_checkout(
+            &repo,
+            &message,
+            &before_oid_str,
+            &target_oid_str,
+            timestamp,
+            author,
+            description,
+        );
+    }
+
+    // Refuse if a rebase/bisect/sequence is in progress: a reset would destroy it.
+    ensure_resettable(&repo)?;
+
+    // If the recorded action did not move HEAD (e.g. a synthetic record_action
+    // entry such as a branch delete, or a checkout between two refs at the same
+    // commit), a reset to that OID is a silent no-op that restores nothing.
+    // Refuse rather than claim a successful undo.
+    if target_oid_str == before_oid_str {
+        return Err(LeviathanError::OperationFailed(
+            "This action did not move HEAD, so it cannot be undone by resetting. Nothing was changed.".to_string(),
+        ));
+    }
+
     // Perform a mixed reset to the previous state
     let target_oid = git2::Oid::from_str(&target_oid_str)?;
     let target_commit = repo.find_commit(target_oid)?;
     repo.reset(target_commit.as_object(), git2::ResetType::Mixed, None)?;
+
+    // Record a marker so a subsequent redo can tell this was an app undo.
+    set_redo_marker(&repo, &before_oid_str, &target_oid_str);
 
     let details = serde_json::json!({
         "undoneAction": action_type,
@@ -293,60 +386,115 @@ pub async fn undo_last_action(path: String) -> Result<UndoAction> {
     })
 }
 
-/// Redo the last undone action by moving HEAD forward in the reflog
+/// Undo a checkout by switching back to the previous branch (or detached
+/// commit) symbolically, exactly like `git switch -`. Never moves a branch ref.
+#[allow(clippy::too_many_arguments)]
+fn undo_checkout(
+    repo: &git2::Repository,
+    message: &str,
+    before_oid_str: &str,
+    fallback_oid_str: &str,
+    timestamp: i64,
+    author: String,
+    description: String,
+) -> Result<UndoAction> {
+    let from = parse_checkout_source(message).ok_or_else(|| {
+        LeviathanError::OperationFailed(
+            "Could not determine which branch to switch back to for this checkout.".to_string(),
+        )
+    })?;
+
+    let make_action = |after: String| {
+        let details = serde_json::json!({
+            "undoneAction": "checkout",
+            "undoneDescription": description,
+            "author": author,
+        });
+        UndoAction {
+            action_type: "undo".to_string(),
+            description: format!("Undo: {}", description),
+            timestamp,
+            before_ref: before_oid_str.to_string(),
+            after_ref: after,
+            details: Some(details.to_string()),
+        }
+    };
+
+    // Prefer switching back to the named branch (symbolic, like `git switch -`).
+    if let Ok(branch) = repo.find_branch(&from, git2::BranchType::Local) {
+        let commit = branch.get().peel_to_commit()?;
+        repo.checkout_tree(commit.as_object(), None)?;
+        repo.set_head(&format!("refs/heads/{}", from))?;
+        return Ok(make_action(commit.id().to_string()));
+    }
+
+    // Otherwise the previous location was a detached commit; restore it detached.
+    let oid = git2::Oid::from_str(fallback_oid_str)?;
+    let commit = repo.find_commit(oid)?;
+    repo.checkout_tree(commit.as_object(), None)?;
+    repo.set_head_detached(oid)?;
+    Ok(make_action(fallback_oid_str.to_string()))
+}
+
+/// Redo the last undone action.
+///
+/// Only fires when the immediately preceding HEAD movement was an undo the app
+/// performed (recognized via a marker written by `undo_last_action`). A reset
+/// the user performed themselves — through the reflog dialog, Smart Undo, or the
+/// git CLI — is NOT an app undo, and "redoing" over it is refused so the user's
+/// deliberate reset is never silently reverted.
 #[command]
 pub async fn redo_last_action(path: String) -> Result<UndoAction> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
-    // To redo, we look for the reflog entry that was created by our undo
-    // (which is a reset). The entry before that reset is our redo target.
-    let (before_oid_str, target_oid_str, timestamp, author) = {
-        let reflog = repo.reflog("HEAD")?;
-
-        if reflog.len() < 2 {
-            return Err(crate::error::LeviathanError::OperationFailed(
-                "Nothing to redo: not enough reflog history".to_string(),
-            ));
+    // Read the app-undo marker. Absent marker => the last action was not an
+    // app undo, so there is nothing to redo.
+    let (redo_target, undo_head) = {
+        let cfg = repo.config()?;
+        let target = cfg.get_string("leviathan.redotarget").ok();
+        let head = cfg.get_string("leviathan.redohead").ok();
+        match (target, head) {
+            (Some(t), Some(h)) if !t.is_empty() && !h.is_empty() => (t, h),
+            _ => {
+                return Err(LeviathanError::OperationFailed(
+                    "Nothing to redo: the last action was not an undo.".to_string(),
+                ));
+            }
         }
-
-        // The most recent entry (index 0) should be the reset from an undo.
-        // Its id_old (before_ref) is the state we want to redo to.
-        let current_entry = reflog.get(0).ok_or_else(|| {
-            crate::error::LeviathanError::OperationFailed(
-                "Failed to read current reflog entry".to_string(),
-            )
-        })?;
-
-        let msg = current_entry
-            .message()
-            .ok()
-            .flatten()
-            .unwrap_or("")
-            .to_string();
-        if !msg.to_lowercase().contains("reset") {
-            return Err(crate::error::LeviathanError::OperationFailed(
-                "Nothing to redo: last action was not an undo".to_string(),
-            ));
-        }
-
-        // The old id of the current entry is where we were before the undo
-        let current_oid = current_entry.id_new().to_string();
-        let redo_target = current_entry.id_old().to_string();
-        let ts = current_entry.committer().when().seconds();
-        let auth = current_entry
-            .committer()
-            .name()
-            .ok()
-            .unwrap_or("Unknown")
-            .to_string();
-
-        (current_oid, redo_target, ts, auth)
     };
 
-    // Perform a mixed reset to the redo target
-    let target_oid = git2::Oid::from_str(&target_oid_str)?;
+    // If HEAD has moved since the undo (a new commit, a manual reset, etc.),
+    // the marker is stale and redoing would clobber whatever the user did next.
+    let current_head = repo
+        .head()
+        .ok()
+        .and_then(|h| h.target())
+        .map(|o| o.to_string());
+    if current_head.as_deref() != Some(undo_head.as_str()) {
+        return Err(LeviathanError::OperationFailed(
+            "Nothing to redo: the repository has changed since the last undo.".to_string(),
+        ));
+    }
+
+    // Refuse if a rebase/bisect/sequence is in progress: a reset would destroy it.
+    ensure_resettable(&repo)?;
+
+    // Perform a mixed reset to the redo target (undo always used a mixed reset).
+    let target_oid = git2::Oid::from_str(&redo_target)?;
     let target_commit = repo.find_commit(target_oid)?;
     repo.reset(target_commit.as_object(), git2::ResetType::Mixed, None)?;
+
+    // The marker has been consumed.
+    clear_redo_marker(&repo);
+
+    let author = match repo.signature() {
+        Ok(sig) => sig.name().unwrap_or("Unknown").to_string(),
+        Err(_) => "Unknown".to_string(),
+    };
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
 
     let details = serde_json::json!({
         "author": author,
@@ -356,8 +504,8 @@ pub async fn redo_last_action(path: String) -> Result<UndoAction> {
         action_type: "redo".to_string(),
         description: "Redo: restored previous state".to_string(),
         timestamp,
-        before_ref: before_oid_str,
-        after_ref: target_oid_str,
+        before_ref: undo_head,
+        after_ref: redo_target,
         details: Some(details.to_string()),
     })
 }
@@ -775,24 +923,104 @@ mod tests {
         let repo = TestRepo::with_initial_commit();
         // Determine the default branch name
         let default_branch = repo.current_branch();
+        // Record the OID of the default branch before anything happens.
+        let main_oid_before = repo.head_oid();
         repo.create_branch("feature");
 
-        // Record the OID before checkout
-        let before_checkout_oid = repo.head_oid();
-
-        // Create a commit on feature branch with different tree
+        // Create a commit on feature branch with a different tree
         repo.checkout_branch("feature");
         repo.create_commit("Feature work", &[("feature.txt", "work")]);
         let feature_oid = repo.head_oid();
+        assert_ne!(feature_oid, main_oid_before);
 
         // Checkout back to default branch
         repo.checkout_branch(&default_branch);
-        assert_eq!(repo.head_oid(), before_checkout_oid);
+        assert_eq!(repo.head_oid(), main_oid_before);
 
-        // Undo the checkout (should go back to feature branch HEAD)
+        // Undo the checkout. Canonical git undoes a checkout with `git switch -`,
+        // which returns to the previous branch *symbolically* and never moves a
+        // branch ref.
         let result = undo_last_action(repo.path_str()).await;
         assert!(result.is_ok());
+
+        // HEAD is back on the feature branch (symbolic switch), not the default.
+        assert_eq!(repo.current_branch(), "feature");
         assert_eq!(repo.head_oid(), feature_oid);
+
+        // Neither branch ref moved: the default branch stayed where it was, and
+        // no commit was orphaned.
+        let git_repo = repo.repo();
+        let main_ref = git_repo
+            .find_branch(&default_branch, git2::BranchType::Local)
+            .unwrap();
+        assert_eq!(main_ref.get().target().unwrap(), main_oid_before);
+        let feature_ref = git_repo
+            .find_branch("feature", git2::BranchType::Local)
+            .unwrap();
+        assert_eq!(feature_ref.get().target().unwrap(), feature_oid);
+    }
+
+    #[tokio::test]
+    async fn test_undo_record_action_is_refused() {
+        // A synthetic record_action entry sits at the current HEAD OID, so
+        // "undoing" it would be a no-op mixed reset. That must be refused, not
+        // reported as a successful undo that restored nothing.
+        let repo = TestRepo::with_initial_commit();
+        let head_before = repo.head_oid();
+
+        let action = UndoAction {
+            action_type: "branch_delete".to_string(),
+            description: "Deleted branch feature".to_string(),
+            timestamp: 0,
+            before_ref: head_before.to_string(),
+            after_ref: head_before.to_string(),
+            details: None,
+        };
+        record_action(repo.path_str(), action).await.unwrap();
+
+        let result = undo_last_action(repo.path_str()).await;
+        assert!(result.is_err(), "undo of a no-op record_action must fail");
+        // HEAD must be untouched.
+        assert_eq!(repo.head_oid(), head_before);
+    }
+
+    #[tokio::test]
+    async fn test_redo_after_user_reset_is_refused() {
+        // A reset the user performed themselves (here via reset_to_reflog) is
+        // NOT an app undo, so redo must refuse and must NOT revert it.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Second", &[("f2.txt", "2")]);
+        let second_oid = repo.head_oid();
+
+        crate::commands::reflog::reset_to_reflog(repo.path_str(), 1, "hard".to_string())
+            .await
+            .unwrap();
+        let after_reset = repo.head_oid();
+        assert_ne!(after_reset, second_oid);
+
+        let result = redo_last_action(repo.path_str()).await;
+        assert!(
+            result.is_err(),
+            "redo must not fire after a user-initiated reset"
+        );
+        // The user's deliberate reset is preserved.
+        assert_eq!(repo.head_oid(), after_reset);
+    }
+
+    #[tokio::test]
+    async fn test_undo_refused_during_bisect() {
+        // A reset mid-bisect would erase .git/BISECT_LOG; git preserves it.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Second", &[("f2.txt", "2")]);
+        let second_oid = repo.head_oid();
+
+        std::fs::write(repo.path.join(".git").join("BISECT_LOG"), b"").unwrap();
+        assert_eq!(repo.repo().state(), git2::RepositoryState::Bisect);
+
+        let result = undo_last_action(repo.path_str()).await;
+        assert!(result.is_err(), "undo must refuse during a bisect");
+        assert_eq!(repo.head_oid(), second_oid);
+        assert!(repo.path.join(".git").join("BISECT_LOG").exists());
     }
 
     #[tokio::test]

--- a/src-tauri/src/test_utils.rs
+++ b/src-tauri/src/test_utils.rs
@@ -167,6 +167,20 @@ impl TestRepo {
             .expect("Failed to create lightweight tag");
     }
 
+    /// Install an executable hook into `.git/hooks/<name>` with the given
+    /// script body. On non-unix the executable bit cannot be set, so tests
+    /// that assert hook execution are unix-only.
+    #[cfg(unix)]
+    pub fn install_hook(&self, name: &str, script: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        let hooks_dir = self.path.join(".git").join("hooks");
+        std::fs::create_dir_all(&hooks_dir).expect("Failed to create hooks dir");
+        let hook_path = hooks_dir.join(name);
+        std::fs::write(&hook_path, script).expect("Failed to write hook");
+        std::fs::set_permissions(&hook_path, std::fs::Permissions::from_mode(0o755))
+            .expect("Failed to chmod hook");
+    }
+
     /// Create a fake remote branch ref (simulates `origin/branch-name`).
     /// This creates a ref at `refs/remotes/origin/<name>` pointing at `target_oid`.
     pub fn create_remote_branch(&self, name: &str, target_oid: git2::Oid) {

--- a/src/__tests__/app-shell-pull-stash-copy.integration.test.ts
+++ b/src/__tests__/app-shell-pull-stash-copy.integration.test.ts
@@ -223,6 +223,14 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
 
   describe('handleCreateStash', () => {
     it('shows a success toast and refreshes on success', async () => {
+      mockInvoke = async (command: string) => {
+        if (command === 'create_stash') {
+          return { index: 0, message: 'WIP', oid: 'abc123' };
+        }
+        if (command === 'open_repository') return mockOpenRepository;
+        return null;
+      };
+
       const el = createAppShell();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (el as any).handleCreateStash();
@@ -231,6 +239,27 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       expect(findCommands('open_repository').length).to.be.greaterThan(0);
       const toasts = uiStore.getState().toasts;
       expect(toasts.some((t) => t.type === 'success' && /Stash created/i.test(t.message))).to.be.true;
+    });
+
+    it('shows an informational (not error) toast and does not refresh when the tree is clean', async () => {
+      // Backend returns null when there is nothing to stash — a benign no-op,
+      // mirroring `git stash push` ("No local changes to save", exit 0).
+      mockInvoke = async (command: string) => {
+        if (command === 'create_stash') return null;
+        if (command === 'open_repository') return mockOpenRepository;
+        return null;
+      };
+
+      const el = createAppShell();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleCreateStash();
+
+      expect(findCommands('create_stash').length).to.equal(1);
+      const toasts = uiStore.getState().toasts;
+      expect(toasts.some((t) => t.type === 'error')).to.be.false;
+      expect(toasts.some((t) => t.type === 'info' && /No local changes to save/i.test(t.message))).to.be.true;
+      // Clean tree: no state change, so no refresh.
+      expect(findCommands('open_repository').length).to.equal(0);
     });
 
     it('shows an error toast and does not refresh on failure', async () => {

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1589,9 +1589,16 @@ export class AppShell extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // A merge commit has no single "the change" to undo; git requires an
+    // explicit mainline parent (`git revert -m`). Default to the first parent
+    // (the branch the merge landed on), which is what reverting a merge almost
+    // always means, and tell the user so.
+    const isMergeCommit = commit.parentIds.length > 1;
     const confirmed = await showConfirm(
       'Revert Commit',
-      `Are you sure you want to revert commit ${commit.oid.substring(0, 7)}? This will create a new commit that undoes the changes.`,
+      isMergeCommit
+        ? `Commit ${commit.oid.substring(0, 7)} is a merge commit. Reverting it will create a new commit that undoes the merge relative to its first parent (mainline). Continue?`
+        : `Are you sure you want to revert commit ${commit.oid.substring(0, 7)}? This will create a new commit that undoes the changes.`,
       'warning'
     );
     if (!confirmed) return;
@@ -1600,6 +1607,7 @@ export class AppShell extends LitElement {
       m.revert({
         path: this.activeRepository!.repository.path,
         commitOid: commit.oid,
+        mainline: isMergeCommit ? 1 : undefined,
       })
     );
 

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2586,6 +2586,11 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
     const result = await gitService.createStash({ path: this.activeRepository.repository.path });
     if (result.success) {
+      if (result.data === null) {
+        // Clean working tree: nothing to stash — informational, not an error.
+        showToast('No local changes to save', 'info');
+        return;
+      }
       showToast('Stash created', 'success');
       this.handleRefresh();
     } else {

--- a/src/components/__tests__/lv-stash-list.test.ts
+++ b/src/components/__tests__/lv-stash-list.test.ts
@@ -49,7 +49,9 @@ function setupDefaultMocks(stashes = mockStashes): void {
       case 'get_stashes':
         return stashes;
       case 'create_stash':
-        return null;
+        // A real stash is created (non-null) when the tree has changes; null is
+        // reserved for the clean-tree no-op case covered by its own test.
+        return { index: 0, message: 'WIP on main: abc123 first commit', oid: 'abc123' };
       case 'apply_stash':
         return null;
       case 'pop_stash':
@@ -201,6 +203,28 @@ describe('lv-stash-list', () => {
       const createCalls = findCommands('create_stash');
       expect(createCalls.length).to.equal(1);
       expect(stashCreatedFired).to.be.true;
+    });
+
+    it('create stash on a clean tree is a no-op: no stash-created event', async () => {
+      // Backend returns null when there is nothing to stash (clean tree). This
+      // is a benign no-op — no event, no error.
+      mockInvoke = async (command: string) => {
+        if (command === 'get_stashes') return mockStashes;
+        if (command === 'create_stash') return null;
+        return null;
+      };
+      const el = await renderStashList();
+      clearHistory();
+
+      let stashCreatedFired = false;
+      el.addEventListener('stash-created', () => { stashCreatedFired = true; });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleCreateStash();
+      await el.updateComplete;
+
+      expect(findCommands('create_stash').length).to.equal(1);
+      expect(stashCreatedFired).to.be.false;
     });
 
     it('click Apply calls apply_stash with correct index', async () => {

--- a/src/components/dialogs/__tests__/lv-cherry-pick-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-cherry-pick-dialog.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Cherry-Pick Dialog Tests
+ *
+ * Regression coverage for merge-commit cherry-picks: the backend requires an
+ * explicit mainline parent for a merge commit (like `git cherry-pick -m`), so
+ * the dialog must expose a mainline selector for merge commits and forward the
+ * chosen `mainline` — while omitting it for ordinary single-parent commits.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+import type { Commit } from '../../../types/git.types.ts';
+
+let lastInvokedCommand: string | null = null;
+let lastInvokedArgs: Record<string, unknown> | null = null;
+let cbId = 0;
+
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+const mockInvoke: MockInvoke = async (command: string, args?: unknown) => {
+  if (command === 'plugin:notification|is_permission_granted') return false;
+  lastInvokedCommand = command;
+  lastInvokedArgs = (args as Record<string, unknown>) ?? null;
+  if (command === 'cherry_pick') {
+    // Mimic a successful cherry-pick returning the new commit.
+    return {
+      oid: 'newcommit0000',
+      shortId: 'newcomm',
+      summary: 'Cherry-picked',
+      message: 'Cherry-picked',
+      body: null,
+      timestamp: Math.floor(Date.now() / 1000),
+      author: { name: 'T', email: 't@e.com', timestamp: 0 },
+      committer: { name: 'T', email: 't@e.com', timestamp: 0 },
+      parentIds: ['base'],
+    };
+  }
+  return null;
+};
+
+(globalThis as unknown as { __TAURI_INTERNALS__: unknown }).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// Import the component AFTER setting up the mock
+import '../lv-cherry-pick-dialog.ts';
+import type { LvCherryPickDialog } from '../lv-cherry-pick-dialog.ts';
+
+function makeCommit(parentIds: string[]): Commit {
+  const ts = Math.floor(Date.now() / 1000);
+  return {
+    oid: 'target00000000',
+    shortId: 'target0',
+    summary: 'A commit',
+    message: 'A commit',
+    body: null,
+    timestamp: ts,
+    author: { name: 'Test User', email: 'test@example.com', timestamp: ts },
+    committer: { name: 'Test User', email: 'test@example.com', timestamp: ts },
+    parentIds,
+  };
+}
+
+describe('lv-cherry-pick-dialog', () => {
+  beforeEach(() => {
+    lastInvokedCommand = null;
+    lastInvokedArgs = null;
+  });
+
+  it('shows a mainline selector only for merge commits', async () => {
+    const el = await fixture<LvCherryPickDialog>(
+      html`<lv-cherry-pick-dialog .repositoryPath=${'/test/repo'}></lv-cherry-pick-dialog>`,
+    );
+
+    // Single-parent commit: no mainline selector.
+    el.open(makeCommit(['p1']));
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('#mainline-select')).to.be.null;
+
+    // Merge commit: selector appears with one option per parent.
+    el.open(makeCommit(['p1', 'p2']));
+    await el.updateComplete;
+    const select = el.shadowRoot!.querySelector('#mainline-select') as HTMLSelectElement;
+    expect(select).to.not.be.null;
+    expect(select.querySelectorAll('option')).to.have.length(2);
+  });
+
+  it('forwards the chosen mainline when cherry-picking a merge commit', async () => {
+    const el = await fixture<LvCherryPickDialog>(
+      html`<lv-cherry-pick-dialog .repositoryPath=${'/test/repo'}></lv-cherry-pick-dialog>`,
+    );
+    el.open(makeCommit(['p1', 'p2']));
+    await el.updateComplete;
+
+    // Choose the second parent as mainline.
+    const select = el.shadowRoot!.querySelector('#mainline-select') as HTMLSelectElement;
+    select.value = '2';
+    select.dispatchEvent(new Event('change'));
+    await el.updateComplete;
+
+    const btn = Array.from(el.shadowRoot!.querySelectorAll('button')).find((b) =>
+      /cherry-pick/i.test(b.textContent ?? ''),
+    ) as HTMLButtonElement;
+    btn.click();
+    await el.updateComplete;
+
+    expect(lastInvokedCommand).to.equal('cherry_pick');
+    expect(lastInvokedArgs?.mainline).to.equal(2);
+  });
+
+  it('omits mainline for a non-merge commit', async () => {
+    const el = await fixture<LvCherryPickDialog>(
+      html`<lv-cherry-pick-dialog .repositoryPath=${'/test/repo'}></lv-cherry-pick-dialog>`,
+    );
+    el.open(makeCommit(['p1']));
+    await el.updateComplete;
+
+    const btn = Array.from(el.shadowRoot!.querySelectorAll('button')).find((b) =>
+      /cherry-pick/i.test(b.textContent ?? ''),
+    ) as HTMLButtonElement;
+    btn.click();
+    await el.updateComplete;
+
+    expect(lastInvokedCommand).to.equal('cherry_pick');
+    expect(lastInvokedArgs?.mainline).to.equal(undefined);
+  });
+});

--- a/src/components/dialogs/__tests__/lv-clean-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-clean-dialog.test.ts
@@ -9,11 +9,25 @@ import { expect, fixture, html } from '@open-wc/testing';
 let failingCommands: Set<string> = new Set();
 let cleanableEntries: unknown[] = [];
 let lastCleanFilesArgs: Record<string, unknown> | null = null;
+// Controls the result of the app's showConfirm() dialog (plugin-dialog's
+// confirm() routes through `plugin:dialog|message` and treats a truthy return
+// as "confirmed").
+let confirmResult = true;
 
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
 
 const mockInvoke: MockInvoke = async (command: string, args?: unknown) => {
   if (command === 'plugin:notification|is_permission_granted') return false;
+
+  if (
+    command === 'plugin:dialog|message' ||
+    command === 'plugin:dialog|confirm' ||
+    command === 'plugin:dialog|ask'
+  ) {
+    // plugin-dialog's confirm() resolves true only when the command returns the
+    // OK button label ('Ok'); anything else is treated as declined.
+    return confirmResult ? 'Ok' : 'Cancel';
+  }
 
   if (failingCommands.has(command)) {
     throw { code: 'COMMAND_ERROR', message: 'Permission denied' };
@@ -45,6 +59,7 @@ describe('lv-clean-dialog', () => {
     failingCommands = new Set();
     cleanableEntries = [];
     lastCleanFilesArgs = null;
+    confirmResult = true;
     const state = uiStore.getState();
     state.toasts.forEach(t => state.removeToast(t.id));
   });
@@ -123,52 +138,42 @@ describe('lv-clean-dialog', () => {
     cleanableEntries = [
       { path: 'vendor/', isDirectory: true, isIgnored: false, isNestedRepo: true, size: null },
     ];
-    const originalConfirm = window.confirm;
-    window.confirm = () => true;
+    confirmResult = true;
 
-    try {
-      const el = await fixture<LvCleanDialog>(
-        html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
-      );
-      await waitForEntries(el);
+    const el = await fixture<LvCleanDialog>(
+      html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
+    );
+    await waitForEntries(el);
 
-      // User explicitly opts into deleting the nested repo.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (el as any).selectedPaths = new Set(['vendor/']);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (el as any).handleClean();
+    // User explicitly opts into deleting the nested repo.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any).selectedPaths = new Set(['vendor/']);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleClean();
 
-      expect(lastCleanFilesArgs).to.not.be.null;
-      expect(lastCleanFilesArgs!.forceNested).to.be.true;
-    } finally {
-      window.confirm = originalConfirm;
-    }
+    expect(lastCleanFilesArgs).to.not.be.null;
+    expect(lastCleanFilesArgs!.forceNested).to.be.true;
   });
 
   it('aborts the clean when the nested-repo confirmation is declined', async () => {
     cleanableEntries = [
       { path: 'vendor/', isDirectory: true, isIgnored: false, isNestedRepo: true, size: null },
     ];
-    const originalConfirm = window.confirm;
-    window.confirm = () => false;
+    confirmResult = false;
 
-    try {
-      const el = await fixture<LvCleanDialog>(
-        html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
-      );
-      await waitForEntries(el);
+    const el = await fixture<LvCleanDialog>(
+      html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
+    );
+    await waitForEntries(el);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (el as any).selectedPaths = new Set(['vendor/']);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (el as any).handleClean();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any).selectedPaths = new Set(['vendor/']);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleClean();
 
-      // Declining must not invoke clean_files at all.
-      expect(lastCleanFilesArgs).to.be.null;
-      expect(el.open).to.be.true;
-    } finally {
-      window.confirm = originalConfirm;
-    }
+    // Declining must not invoke clean_files at all.
+    expect(lastCleanFilesArgs).to.be.null;
+    expect(el.open).to.be.true;
   });
 
   it('passes forceNested=false for ordinary (non-nested) selections', async () => {

--- a/src/components/dialogs/__tests__/lv-clean-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-clean-dialog.test.ts
@@ -7,24 +7,25 @@
 import { expect, fixture, html } from '@open-wc/testing';
 
 let failingCommands: Set<string> = new Set();
+let cleanableEntries: unknown[] = [];
+let lastCleanFilesArgs: Record<string, unknown> | null = null;
 
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
 
-const mockInvoke: MockInvoke = async (command: string) => {
+const mockInvoke: MockInvoke = async (command: string, args?: unknown) => {
   if (command === 'plugin:notification|is_permission_granted') return false;
 
   if (failingCommands.has(command)) {
     throw { code: 'COMMAND_ERROR', message: 'Permission denied' };
   }
 
-  if (command === 'get_untracked_files') {
-    return [
-      { path: 'untracked.txt', size: 100, isDirectory: false },
-    ];
+  if (command === 'get_cleanable_files') {
+    return cleanableEntries;
   }
 
   if (command === 'clean_files') {
-    return 1;
+    lastCleanFilesArgs = args as Record<string, unknown>;
+    return (args as { paths?: unknown[] }).paths?.length ?? 1;
   }
 
   return null;
@@ -42,6 +43,8 @@ import { uiStore } from '../../../stores/ui.store.ts';
 describe('lv-clean-dialog', () => {
   beforeEach(() => {
     failingCommands = new Set();
+    cleanableEntries = [];
+    lastCleanFilesArgs = null;
     const state = uiStore.getState();
     state.toasts.forEach(t => state.removeToast(t.id));
   });
@@ -87,5 +90,101 @@ describe('lv-clean-dialog', () => {
     const errorToast = toasts.find(t => t.type === 'error');
     expect(errorToast).to.not.be.undefined;
     expect(errorToast!.message).to.include('Permission denied');
+  });
+
+  // --- Finding 51: nested git repositories must be protected ---
+  async function waitForEntries(el: LvCleanDialog): Promise<void> {
+    for (let i = 0; i < 50; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (((el as any).entries as unknown[]).length > 0) return;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 0));
+    }
+  }
+
+  it('does not pre-select untracked nested repositories', async () => {
+    cleanableEntries = [
+      { path: 'untracked.txt', isDirectory: false, isIgnored: false, isNestedRepo: false, size: 100 },
+      { path: 'vendor/', isDirectory: true, isIgnored: false, isNestedRepo: true, size: null },
+    ];
+
+    const el = await fixture<LvCleanDialog>(
+      html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
+    );
+    await waitForEntries(el);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const selected = (el as any).selectedPaths as Set<string>;
+    expect(selected.has('untracked.txt')).to.be.true;
+    expect(selected.has('vendor/')).to.be.false;
+  });
+
+  it('requires confirmation and passes forceNested when a nested repo is selected', async () => {
+    cleanableEntries = [
+      { path: 'vendor/', isDirectory: true, isIgnored: false, isNestedRepo: true, size: null },
+    ];
+    const originalConfirm = window.confirm;
+    window.confirm = () => true;
+
+    try {
+      const el = await fixture<LvCleanDialog>(
+        html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
+      );
+      await waitForEntries(el);
+
+      // User explicitly opts into deleting the nested repo.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).selectedPaths = new Set(['vendor/']);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleClean();
+
+      expect(lastCleanFilesArgs).to.not.be.null;
+      expect(lastCleanFilesArgs!.forceNested).to.be.true;
+    } finally {
+      window.confirm = originalConfirm;
+    }
+  });
+
+  it('aborts the clean when the nested-repo confirmation is declined', async () => {
+    cleanableEntries = [
+      { path: 'vendor/', isDirectory: true, isIgnored: false, isNestedRepo: true, size: null },
+    ];
+    const originalConfirm = window.confirm;
+    window.confirm = () => false;
+
+    try {
+      const el = await fixture<LvCleanDialog>(
+        html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
+      );
+      await waitForEntries(el);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).selectedPaths = new Set(['vendor/']);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleClean();
+
+      // Declining must not invoke clean_files at all.
+      expect(lastCleanFilesArgs).to.be.null;
+      expect(el.open).to.be.true;
+    } finally {
+      window.confirm = originalConfirm;
+    }
+  });
+
+  it('passes forceNested=false for ordinary (non-nested) selections', async () => {
+    cleanableEntries = [
+      { path: 'untracked.txt', isDirectory: false, isIgnored: false, isNestedRepo: false, size: 100 },
+    ];
+
+    const el = await fixture<LvCleanDialog>(
+      html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
+    );
+    await waitForEntries(el);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleClean();
+
+    expect(lastCleanFilesArgs).to.not.be.null;
+    expect(lastCleanFilesArgs!.forceNested).to.be.false;
   });
 });

--- a/src/components/dialogs/__tests__/lv-gpg-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-gpg-dialog.test.ts
@@ -1,0 +1,74 @@
+/**
+ * GPG Dialog setup-detection tests
+ *
+ * Regression coverage for finding 98: an SSH signer (gpg.format=ssh with a
+ * configured user.signingkey) must NOT be pushed into the "generate a GPG key"
+ * setup flow just because no GPG keyring keys exist.
+ */
+
+// Mock Tauri API before importing any modules that use it
+const mockInvoke = (): Promise<unknown> => Promise.resolve(null);
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: mockInvoke,
+};
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-gpg-dialog.ts';
+import type { LvGpgDialog } from '../lv-gpg-dialog.ts';
+import type { GpgConfig } from '../../../services/git.service.ts';
+
+function makeConfig(overrides: Partial<GpgConfig>): GpgConfig {
+  return {
+    gpgAvailable: false,
+    gpgVersion: null,
+    signingKey: null,
+    signCommits: false,
+    signTags: false,
+    gpgProgram: null,
+    gpgFormat: null,
+    ...overrides,
+  };
+}
+
+interface DialogInternals {
+  config: GpgConfig | null;
+  keys: unknown[];
+  setupMode: boolean;
+  setupStep: string;
+  detectSetupState(): void;
+}
+
+describe('lv-gpg-dialog SSH signing setup detection', () => {
+  it('does not force a configured SSH signer into GPG generate-guide mode', async () => {
+    const el = await fixture<LvGpgDialog>(
+      html`<lv-gpg-dialog></lv-gpg-dialog>`
+    );
+    const internals = el as unknown as DialogInternals;
+    // SSH signing configured, but no GPG keyring keys (the common case).
+    internals.config = makeConfig({
+      gpgFormat: 'ssh',
+      gpgAvailable: true,
+      gpgVersion: 'gpg (GnuPG) 2.2.27',
+      signingKey: '~/.ssh/id_ed25519.pub',
+    });
+    internals.keys = [];
+
+    internals.detectSetupState();
+
+    expect(internals.setupMode).to.equal(false);
+  });
+
+  it('prompts SSH users to configure a key only when none is set', async () => {
+    const el = await fixture<LvGpgDialog>(
+      html`<lv-gpg-dialog></lv-gpg-dialog>`
+    );
+    const internals = el as unknown as DialogInternals;
+    internals.config = makeConfig({ gpgFormat: 'ssh', signingKey: null });
+    internals.keys = [];
+
+    internals.detectSetupState();
+
+    expect(internals.setupMode).to.equal(true);
+    expect(internals.setupStep).to.equal('configure');
+  });
+});

--- a/src/components/dialogs/__tests__/lv-submodule-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-submodule-dialog.test.ts
@@ -20,11 +20,16 @@ const mockSubmodules: Submodule[] = [
 ];
 
 let failingCommands: Set<string> = new Set();
+let lastUpdateSubmodulesArgs: Record<string, unknown> | null = null;
 
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
 
-const mockInvoke: MockInvoke = async (command: string) => {
+const mockInvoke: MockInvoke = async (command: string, args?: unknown) => {
   if (command === 'plugin:notification|is_permission_granted') return false;
+
+  if (command === 'update_submodules') {
+    lastUpdateSubmodulesArgs = (args as Record<string, unknown>) ?? null;
+  }
 
   if (failingCommands.has(command)) {
     throw { code: 'COMMAND_ERROR', message: 'Operation failed' };
@@ -62,6 +67,7 @@ import { uiStore } from '../../../stores/ui.store.ts';
 describe('lv-submodule-dialog', () => {
   beforeEach(() => {
     failingCommands = new Set();
+    lastUpdateSubmodulesArgs = null;
     const state = uiStore.getState();
     state.toasts.forEach(t => state.removeToast(t.id));
   });
@@ -187,6 +193,23 @@ describe('lv-submodule-dialog', () => {
     const errorToast = toasts.find(t => t.type === 'error');
     expect(errorToast).to.not.be.undefined;
     expect(errorToast!.message).to.include('Operation failed');
+  });
+
+  it('single update checks out the recorded commit (no --remote)', async () => {
+    // Canonical `git submodule update <path>` checks out the commit recorded in
+    // the superproject. The per-submodule Update button must NOT pass
+    // remote:true, which would run `submodule update --remote`, advance the
+    // submodule past the recorded commit and dirty the superproject.
+    const el = await fixture<LvSubmoduleDialog>(
+      html`<lv-submodule-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-submodule-dialog>`,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleUpdate(mockSubmodules[0]);
+
+    expect(lastUpdateSubmodulesArgs).to.not.be.null;
+    expect(lastUpdateSubmodulesArgs!.submodulePaths).to.deep.equal([mockSubmodules[0].path]);
+    expect(lastUpdateSubmodulesArgs!.remote).to.not.equal(true);
   });
 
   it('shows error toast on single update failure', async () => {

--- a/src/components/dialogs/lv-cherry-pick-dialog.ts
+++ b/src/components/dialogs/lv-cherry-pick-dialog.ts
@@ -201,6 +201,7 @@ export class LvCherryPickDialog extends LitElement {
 
   @state() private commit: Commit | null = null;
   @state() private noCommit = false;
+  @state() private mainline = 1;
   @state() private isExecuting = false;
   @state() private error = '';
   @state() private isOpen = false;
@@ -218,14 +219,24 @@ export class LvCherryPickDialog extends LitElement {
   private reset(): void {
     this.commit = null;
     this.noCommit = false;
+    this.mainline = 1;
     this.isExecuting = false;
     this.error = '';
     this.isOpen = false;
   }
 
+  private get isMergeCommit(): boolean {
+    return (this.commit?.parentIds.length ?? 0) > 1;
+  }
+
   private handleNoCommitChange(e: Event): void {
     const input = e.target as HTMLInputElement;
     this.noCommit = input.checked;
+  }
+
+  private handleMainlineChange(e: Event): void {
+    const select = e.target as HTMLSelectElement;
+    this.mainline = Number(select.value);
   }
 
   private async handleCherryPick(): Promise<void> {
@@ -239,6 +250,9 @@ export class LvCherryPickDialog extends LitElement {
         path: this.repositoryPath,
         commitOid: this.commit.oid,
         noCommit: this.noCommit || undefined,
+        // A merge commit needs an explicit mainline parent (like
+        // `git cherry-pick -m`); the backend refuses otherwise.
+        mainline: this.isMergeCommit ? this.mainline : undefined,
       });
 
       if (result.success) {
@@ -335,6 +349,31 @@ export class LvCherryPickDialog extends LitElement {
           <!-- Options -->
           <div class="options-section">
             <div class="options-header">Options</div>
+
+            ${this.isMergeCommit ? html`
+              <div class="option-row">
+                <label class="option-label" for="mainline-select">
+                  <span class="option-label-main">Mainline parent</span>
+                  <span class="option-label-hint">
+                    This is a merge commit — choose which parent's changes to keep as
+                    the baseline (like <code>git cherry-pick -m</code>).
+                  </span>
+                </label>
+                <select
+                  id="mainline-select"
+                  class="mainline-select"
+                  .value=${String(this.mainline)}
+                  @change=${this.handleMainlineChange}
+                  ?disabled=${this.isExecuting}
+                >
+                  ${this.commit!.parentIds.map((parentId, i) => html`
+                    <option value=${i + 1}>
+                      Parent ${i + 1}${i === 0 ? ' (mainline)' : ''} — ${parentId.substring(0, 7)}
+                    </option>
+                  `)}
+                </select>
+              </div>
+            ` : nothing}
 
             <div class="option-row">
               <input

--- a/src/components/dialogs/lv-clean-dialog.ts
+++ b/src/components/dialogs/lv-clean-dialog.ts
@@ -9,6 +9,7 @@ import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import type { CleanEntry } from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
+import { showConfirm } from '../../services/dialog.service.ts';
 
 @customElement('lv-clean-dialog')
 export class LvCleanDialog extends LitElement {
@@ -436,10 +437,14 @@ export class LvCleanDialog extends LitElement {
     );
     if (nestedRepos.length > 0) {
       const names = nestedRepos.map(e => e.path).join(', ');
-      const confirmed = window.confirm(
+      const confirmed = await showConfirm(
+        nestedRepos.length === 1
+          ? 'Delete Nested Repository'
+          : 'Delete Nested Repositories',
         `${nestedRepos.length === 1 ? 'A nested git repository' : 'Nested git repositories'} ` +
           `(${names}) will be permanently deleted, including all its history. ` +
-          `This cannot be undone. Continue?`
+          `This cannot be undone. Continue?`,
+        'warning'
       );
       if (!confirmed) return;
     }

--- a/src/components/dialogs/lv-clean-dialog.ts
+++ b/src/components/dialogs/lv-clean-dialog.ts
@@ -247,6 +247,11 @@ export class LvCleanDialog extends LitElement {
         color: var(--color-warning);
       }
 
+      .file-badge.nested-repo {
+        background: var(--color-error-bg, rgba(192, 57, 43, 0.15));
+        color: var(--color-error);
+      }
+
       .file-size {
         font-size: var(--font-size-xs);
         color: var(--color-text-muted);
@@ -354,8 +359,12 @@ export class LvCleanDialog extends LitElement {
 
       if (result.success && result.data) {
         this.entries = result.data;
-        // Select all by default
-        this.selectedPaths = new Set(this.entries.map(e => e.path));
+        // Select all by default EXCEPT untracked nested git repositories:
+        // deleting those destroys embedded history, so they require an explicit
+        // opt-in (mirroring `git clean`'s need for a second `-f`).
+        this.selectedPaths = new Set(
+          this.entries.filter(e => !e.isNestedRepo).map(e => e.path)
+        );
       } else if (!result.success) {
         showToast(result.error?.message || 'Failed to load cleanable files', 'error');
       }
@@ -419,11 +428,28 @@ export class LvCleanDialog extends LitElement {
   private async handleClean(): Promise<void> {
     if (this.selectedPaths.size === 0) return;
 
+    // If any selected entry is an untracked nested git repository, require an
+    // explicit confirmation before force-deleting it (this destroys the nested
+    // repo's history, which `git clean` guards behind a second `-f`).
+    const nestedRepos = this.entries.filter(
+      e => this.selectedPaths.has(e.path) && e.isNestedRepo
+    );
+    if (nestedRepos.length > 0) {
+      const names = nestedRepos.map(e => e.path).join(', ');
+      const confirmed = window.confirm(
+        `${nestedRepos.length === 1 ? 'A nested git repository' : 'Nested git repositories'} ` +
+          `(${names}) will be permanently deleted, including all its history. ` +
+          `This cannot be undone. Continue?`
+      );
+      if (!confirmed) return;
+    }
+    const forceNested = nestedRepos.length > 0;
+
     this.cleaning = true;
 
     try {
       const paths = Array.from(this.selectedPaths);
-      const result = await gitService.cleanFiles(this.repositoryPath, paths);
+      const result = await gitService.cleanFiles(this.repositoryPath, paths, forceNested);
 
       if (result.success) {
         this.dispatchEvent(new CustomEvent('files-cleaned', {
@@ -484,7 +510,11 @@ export class LvCleanDialog extends LitElement {
         <div class="file-info">
           <span class="file-path" title="${entry.path}">${entry.path}</span>
           ${entry.isIgnored ? html`<span class="file-badge ignored">ignored</span>` : nothing}
-          ${entry.isDirectory ? html`<span class="file-badge directory">dir</span>` : nothing}
+          ${entry.isNestedRepo
+            ? html`<span class="file-badge nested-repo">nested repo</span>`
+            : entry.isDirectory
+              ? html`<span class="file-badge directory">dir</span>`
+              : nothing}
         </div>
         ${entry.size !== null ? html`
           <span class="file-size">${this.formatSize(entry.size)}</span>

--- a/src/components/dialogs/lv-gpg-dialog.ts
+++ b/src/components/dialogs/lv-gpg-dialog.ts
@@ -696,6 +696,19 @@ export class LvGpgDialog extends LitElement {
       return;
     }
 
+    // SSH signing (gpg.format=ssh) does not use GPG or a GPG keyring at all — git
+    // signs with the configured SSH key. A configured signing key is sufficient;
+    // never push a working SSH signer into the "generate a GPG key" flow.
+    if (this.config.gpgFormat === 'ssh') {
+      if (this.config.signingKey) {
+        this.setupMode = false;
+      } else {
+        this.setupMode = true;
+        this.setupStep = 'configure';
+      }
+      return;
+    }
+
     // Check if GPG is truly available (must have both available flag AND version)
     const gpgTrulyAvailable = this.config.gpgAvailable && !!this.config.gpgVersion;
 

--- a/src/components/dialogs/lv-submodule-dialog.ts
+++ b/src/components/dialogs/lv-submodule-dialog.ts
@@ -450,9 +450,12 @@ export class LvSubmoduleDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
+    // Canonical `git submodule update <path>`: check out the commit the
+    // superproject has recorded for this submodule, leaving the superproject
+    // clean. (Passing remote:true would run `--remote`, checking out the
+    // upstream branch tip instead and dirtying the working tree.)
     const result = await gitService.updateSubmodules(this.repositoryPath, {
       submodulePaths: [submodule.path],
-      remote: true,
     });
 
     if (result.success) {

--- a/src/components/panels/__tests__/lv-commit-details.test.ts
+++ b/src/components/panels/__tests__/lv-commit-details.test.ts
@@ -9,6 +9,7 @@ import { uiStore } from '../../../stores/ui.store.ts';
 import type { Commit } from '../../../types/git.types.ts';
 
 let failingCommands: Set<string> = new Set();
+let mockFiles: unknown[] = [];
 let cbId = 0;
 
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
@@ -21,7 +22,7 @@ const mockInvoke: MockInvoke = async (command: string) => {
   }
 
   if (command === 'get_commit_files') {
-    return [];
+    return mockFiles;
   }
 
   return null;
@@ -51,6 +52,30 @@ const mockCommit: Commit = {
 describe('lv-commit-details', () => {
   beforeEach(() => {
     failingCommands = new Set();
+    mockFiles = [];
+  });
+
+  it('shows the previous path for a renamed file', async () => {
+    mockFiles = [
+      {
+        path: 'src/new-name.ts',
+        oldPath: 'src/old-name.ts',
+        status: 'renamed',
+        additions: 3,
+        deletions: 1,
+      },
+    ];
+
+    const el = await fixture<LvCommitDetails>(
+      html`<lv-commit-details .repositoryPath=${'/test/repo'} .commit=${mockCommit}></lv-commit-details>`,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).loadFiles();
+    await el.updateComplete;
+
+    const renamedFrom = el.shadowRoot!.querySelector('.file-renamed-from');
+    expect(renamedFrom).to.not.be.null;
+    expect(renamedFrom!.textContent).to.contain('src/old-name.ts');
   });
 
   it('renders with a commit', async () => {

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -899,4 +899,99 @@ describe('lv-diff-view', () => {
       expect(statusBadge!.classList.contains('new')).to.be.true;
     });
   });
+
+  // ── Patch construction: no-newline markers and CRLF content ──────────────
+  // Regression tests for hunk/line staging producing patches that byte-match
+  // the index (findings: EOFNL markers and CR stripping).
+  describe('patch construction', () => {
+    async function bareView(): Promise<LvDiffView> {
+      const el = await fixture<LvDiffView>(html`<lv-diff-view></lv-diff-view>`);
+      await el.updateComplete;
+      return el;
+    }
+
+    it('buildHunkPatch keeps the \\r in CRLF content lines', async () => {
+      const el = await bareView();
+      const hunk = makeDiffHunk({
+        header: '@@ -1,2 +1,2 @@',
+        oldStart: 1,
+        oldLines: 2,
+        newStart: 1,
+        newLines: 2,
+        lines: [
+          makeDiffLine({ content: 'ctx\r\n', origin: 'context', oldLineNo: 1, newLineNo: 1 }),
+          makeDiffLine({ content: 'old\r\n', origin: 'deletion', oldLineNo: 2, newLineNo: null }),
+          makeDiffLine({ content: 'new\r\n', origin: 'addition', oldLineNo: null, newLineNo: 2 }),
+        ],
+      });
+      (el as unknown as { file: unknown }).file = makeStatusEntry({ path: 'f.txt' });
+      (el as unknown as { diff: unknown }).diff = makeDiffFile({ path: 'f.txt', hunks: [hunk] });
+
+      const patch = (el as unknown as { buildHunkPatch: (h: DiffHunk) => string }).buildHunkPatch(hunk);
+      const patchLines = patch.split('\n');
+      // \r is preserved (part of the file bytes); only the \n terminator is stripped.
+      expect(patchLines).to.include(' ctx\r');
+      expect(patchLines).to.include('-old\r');
+      expect(patchLines).to.include('+new\r');
+    });
+
+    it('buildSelectedLinesPatch emits "\\ No newline at end of file" markers', async () => {
+      const el = await bareView();
+      // Mirrors libgit2 output for a file whose last line lacks a trailing
+      // newline on both sides: the marker follows the annotated content line.
+      const hunk = makeDiffHunk({
+        header: '@@ -1,3 +1,3 @@',
+        oldStart: 1,
+        oldLines: 3,
+        newStart: 1,
+        newLines: 3,
+        lines: [
+          makeDiffLine({ content: 'line1\n', origin: 'context', oldLineNo: 1, newLineNo: 1 }),
+          makeDiffLine({ content: 'line2\n', origin: 'context', oldLineNo: 2, newLineNo: 2 }),
+          makeDiffLine({ content: 'last', origin: 'deletion', oldLineNo: 3, newLineNo: null }),
+          makeDiffLine({ content: '\n\\ No newline at end of file\n', origin: 'add-eofnl', oldLineNo: null, newLineNo: null }),
+          makeDiffLine({ content: 'CHANGED', origin: 'addition', oldLineNo: null, newLineNo: 3 }),
+          makeDiffLine({ content: '\n\\ No newline at end of file\n', origin: 'del-eofnl', oldLineNo: null, newLineNo: null }),
+        ],
+      });
+      (el as unknown as { file: unknown }).file = makeStatusEntry({ path: 'f.txt' });
+      (el as unknown as { diff: unknown }).diff = makeDiffFile({ path: 'f.txt', hunks: [hunk] });
+      // Select the deletion (index 2) and the addition (index 4).
+      (el as unknown as { selectedLines: Set<string> }).selectedLines = new Set(['0-2', '0-4']);
+
+      const patch = (el as unknown as { buildSelectedLinesPatch: () => string }).buildSelectedLinesPatch();
+
+      // The marker must appear immediately after both the deleted and the added
+      // last line — not be dropped.
+      expect(patch).to.contain('-last\n\\ No newline at end of file\n');
+      expect(patch).to.contain('+CHANGED\n\\ No newline at end of file');
+    });
+
+    it('buildSelectedLinesPatch skips the newline marker of an unselected addition', async () => {
+      const el = await bareView();
+      // Appending a line without a trailing newline: only the new side lacks
+      // the newline. If the addition is not selected, its marker must not leak
+      // into the patch (which would otherwise fail to apply).
+      const hunk = makeDiffHunk({
+        header: '@@ -1,1 +1,2 @@',
+        oldStart: 1,
+        oldLines: 1,
+        newStart: 1,
+        newLines: 2,
+        lines: [
+          makeDiffLine({ content: 'line1\n', origin: 'context', oldLineNo: 1, newLineNo: 1 }),
+          makeDiffLine({ content: 'new', origin: 'addition', oldLineNo: null, newLineNo: 2 }),
+          makeDiffLine({ content: '\n\\ No newline at end of file\n', origin: 'del-eofnl', oldLineNo: null, newLineNo: null }),
+        ],
+      });
+      (el as unknown as { file: unknown }).file = makeStatusEntry({ path: 'f.txt' });
+      (el as unknown as { diff: unknown }).diff = makeDiffFile({ path: 'f.txt', hunks: [hunk] });
+      // Select nothing meaningful — the addition (index 1) is NOT selected.
+      (el as unknown as { selectedLines: Set<string> }).selectedLines = new Set(['0-0']);
+
+      const patch = (el as unknown as { buildSelectedLinesPatch: () => string }).buildSelectedLinesPatch();
+      // No change selected → empty patch, and certainly no stray marker.
+      expect(patch).to.not.contain('No newline at end of file');
+    });
+  });
 });

--- a/src/components/panels/lv-commit-details.ts
+++ b/src/components/panels/lv-commit-details.ts
@@ -294,6 +294,13 @@ export class LvCommitDetails extends LitElement {
         text-align: left;
       }
 
+      .file-renamed-from {
+        margin-left: var(--spacing-sm);
+        color: var(--color-text-secondary);
+        font-size: 10px;
+        opacity: 0.85;
+      }
+
       .file-stats {
         display: flex;
         gap: var(--spacing-sm);
@@ -768,16 +775,26 @@ export class LvCommitDetails extends LitElement {
   private renderFileItem(file: CommitFileEntry) {
     const filename = file.path.split('/').pop() || file.path;
     const canBlame = file.status !== 'deleted';
+    // For a rename/copy, show where the file came from (git shows "old -> new").
+    const renamedFrom =
+      (file.status === 'renamed' || file.status === 'copied') && file.oldPath
+        ? file.oldPath
+        : null;
 
     return html`
       <li
         class="file-item ${this.selectedFilePath === file.path ? 'selected' : ''}"
         @click=${() => this.handleFileClick(file)}
         @contextmenu=${(e: MouseEvent) => this.handleFileContextMenu(e, file)}
-        title="${file.path}"
+        title="${renamedFrom ? `${renamedFrom} → ${file.path}` : file.path}"
       >
         <span class="file-status ${file.status}">${this.getStatusLabel(file.status)}</span>
-        <span class="file-name">${filename}</span>
+        <span class="file-name">
+          ${filename}
+          ${renamedFrom
+            ? html`<span class="file-renamed-from">from ${renamedFrom}</span>`
+            : nothing}
+        </span>
         <span class="file-stats">
           ${file.additions > 0 ? html`<span class="additions">+${file.additions}</span>` : nothing}
           ${file.deletions > 0 ? html`<span class="deletions">-${file.deletions}</span>` : nothing}

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -1501,7 +1501,11 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
       }
 
       // Handle "no newline at end of file" markers
-      if (line.origin === 'del-eofnl' || line.origin === 'add-eofnl') {
+      if (
+        line.origin === 'del-eofnl' ||
+        line.origin === 'add-eofnl' ||
+        line.origin === 'context-eofnl'
+      ) {
         lines.push('\\ No newline at end of file');
         continue;
       }
@@ -1511,8 +1515,10 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
       if (line.origin === 'addition') prefix = '+';
       else if (line.origin === 'deletion') prefix = '-';
 
-      // Get content and strip only trailing newline
-      const content = line.content.replace(/\n$/, '').replace(/\r$/, '');
+      // Strip only the trailing newline. A \r must be kept: in a CRLF file it
+      // is part of the file's bytes, and the patch context has to byte-match
+      // the index blob or `git apply --cached` rejects it.
+      const content = line.content.replace(/\n$/, '');
 
       lines.push(prefix + content);
     }
@@ -1640,6 +1646,13 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
       const firstOldLine = hunk.oldStart;
       const firstNewLine = hunk.newStart;
 
+      // Tracks whether the content line most recently written into this patch
+      // was actually emitted. A "\ No newline at end of file" marker annotates
+      // the line immediately before it, so it must only be emitted when that
+      // line made it into the patch (an unselected addition is skipped, so its
+      // marker must be skipped too) — otherwise `git apply` rejects the patch.
+      let lastContentEmitted = false;
+
       for (let i = 0; i < hunk.lines.length; i++) {
         const line = hunk.lines[i];
         const isSelected = selectedLineIndices.has(i);
@@ -1650,18 +1663,27 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         }
 
         // Handle "no newline at end of file" markers
-        if (line.origin === 'del-eofnl' || line.origin === 'add-eofnl') {
-          // Only include if the corresponding line is selected
+        if (
+          line.origin === 'del-eofnl' ||
+          line.origin === 'add-eofnl' ||
+          line.origin === 'context-eofnl'
+        ) {
+          if (lastContentEmitted) {
+            hunkPatchLines.push('\\ No newline at end of file');
+          }
           continue;
         }
 
-        const content = line.content.replace(/\n$/, '').replace(/\r$/, '');
+        // Strip only the trailing newline; keep \r so CRLF content byte-matches
+        // the index blob.
+        const content = line.content.replace(/\n$/, '');
 
         if (line.origin === 'context') {
           // Always include context lines
           hunkPatchLines.push(' ' + content);
           oldLineCount++;
           newLineCount++;
+          lastContentEmitted = true;
         } else if (line.origin === 'deletion') {
           if (isSelected) {
             // Include this deletion in the patch
@@ -1676,13 +1698,17 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
             oldLineCount++;
             newLineCount++;
           }
+          lastContentEmitted = true;
         } else if (line.origin === 'addition') {
           if (isSelected) {
             // Include this addition
             hunkPatchLines.push('+' + content);
             newLineCount++;
+            lastContentEmitted = true;
+          } else {
+            // Unselected additions are simply not included
+            lastContentEmitted = false;
           }
-          // Unselected additions are simply not included
         }
       }
 

--- a/src/components/sidebar/__tests__/lv-branch-list-merged-remote.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-merged-remote.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Regression tests for verified branch correctness bugs in lv-branch-list:
+ *
+ *  - Finding 13: "Delete Merged Branches" must use the backend's real merged
+ *    detection (`get_cleanup_candidates` category==='merged'), not an
+ *    ahead-of-UPSTREAM===0 heuristic that both over- and under-selects.
+ *  - Finding 14: "Create branch from here" on a REMOTE branch must pass the
+ *    full remote-tracking name ("origin/feature") as the start point, not the
+ *    stripped shorthand ("feature").
+ *  - Finding 16: drag-drop merge/rebase onto a REMOTE target must check out the
+ *    full "origin/topic" reference, not the stripped shorthand ("topic").
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeCalls: Array<{ command: string; args?: unknown }> = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeCalls.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { LvBranchList } from '../lv-branch-list.ts';
+import '../lv-branch-list.ts';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+const REPO_PATH = '/test/repo';
+
+interface MockBranch {
+  name: string;
+  shorthand: string;
+  isHead?: boolean;
+  isRemote?: boolean;
+  upstream?: string | null;
+  targetOid?: string;
+  aheadBehind?: { ahead: number; behind: number } | null;
+  isStale?: boolean;
+}
+
+function makeBranch(b: MockBranch) {
+  return {
+    isHead: false,
+    isRemote: false,
+    upstream: null,
+    targetOid: 'abc123',
+    aheadBehind: null,
+    isStale: false,
+    ...b,
+  };
+}
+
+async function createComponent(
+  branches: ReturnType<typeof makeBranch>[],
+  cleanupCandidates: Array<{ name: string; shorthand: string; category: string }> = [],
+): Promise<LvBranchList> {
+  mockInvoke = (command: string) => {
+    if (command === 'get_branches') return Promise.resolve(branches);
+    if (command === 'get_remotes') return Promise.resolve([]);
+    if (command === 'get_hidden_branches') return Promise.resolve([]);
+    if (command === 'get_branch_sort_mode') return Promise.resolve('name');
+    if (command === 'get_cleanup_candidates') return Promise.resolve(cleanupCandidates);
+    if (command === 'plugin:dialog|message') return Promise.resolve('Ok');
+    return Promise.resolve(null);
+  };
+  const el = await fixture<LvBranchList>(
+    html`<lv-branch-list .repositoryPath=${REPO_PATH}></lv-branch-list>`
+  );
+  await el.updateComplete;
+  // connectedCallback -> loadBranches is async; wait a microtask turn for it.
+  await new Promise((r) => setTimeout(r, 0));
+  await el.updateComplete;
+  return el;
+}
+
+function fakeDragEvent(altKey = false): DragEvent {
+  return { preventDefault() {}, altKey } as unknown as DragEvent;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+describe('lv-branch-list merged detection (Finding 13)', () => {
+  beforeEach(() => {
+    invokeCalls.length = 0;
+  });
+
+  it('uses backend merged detection, not the ahead-of-upstream heuristic', async () => {
+    // "merged-no-upstream": merged into HEAD but has no upstream (aheadBehind
+    //   null) — the OLD heuristic would MISS it.
+    // "pushed-unmerged": ahead-of-upstream 0 (fully pushed) but NOT merged —
+    //   the OLD heuristic would WRONGLY include it.
+    const el = await createComponent(
+      [
+        makeBranch({ name: 'main', shorthand: 'main', isHead: true }),
+        makeBranch({ name: 'merged-no-upstream', shorthand: 'merged-no-upstream', aheadBehind: null }),
+        makeBranch({
+          name: 'pushed-unmerged',
+          shorthand: 'pushed-unmerged',
+          upstream: 'origin/pushed-unmerged',
+          aheadBehind: { ahead: 0, behind: 0 },
+        }),
+      ],
+      // Backend truth: only merged-no-upstream is merged into HEAD.
+      [{ name: 'merged-no-upstream', shorthand: 'merged-no-upstream', category: 'merged' }],
+    );
+
+    const merged = (el as unknown as { getMergedBranches: () => Array<{ name: string }> }).getMergedBranches();
+    const names = merged.map((b) => b.name).sort();
+    expect(names).to.deep.equal(['merged-no-upstream']);
+  });
+});
+
+describe('lv-branch-list create-branch-from remote (Finding 14)', () => {
+  beforeEach(() => {
+    invokeCalls.length = 0;
+  });
+
+  it('passes the full remote name as the start point for a remote branch', async () => {
+    const el = await createComponent([
+      makeBranch({ name: 'main', shorthand: 'main', isHead: true }),
+    ]);
+
+    const remoteBranch = makeBranch({
+      name: 'origin/feature',
+      shorthand: 'feature',
+      isRemote: true,
+    });
+
+    // Capture what the create-branch dialog is opened with.
+    let openedWith: string | undefined;
+    const dialog = (el as unknown as { createBranchDialog: { open: (sp?: string) => void } }).createBranchDialog;
+    expect(dialog, 'create-branch dialog should be rendered').to.exist;
+    dialog.open = (sp?: string) => {
+      openedWith = sp;
+    };
+
+    (el as unknown as { contextMenu: unknown }).contextMenu = {
+      visible: true,
+      x: 0,
+      y: 0,
+      branch: remoteBranch,
+    };
+    (el as unknown as { handleCreateBranchFrom: () => void }).handleCreateBranchFrom();
+
+    expect(openedWith).to.equal('origin/feature');
+  });
+
+  it('passes the (full) local branch name for a local branch', async () => {
+    const el = await createComponent([
+      makeBranch({ name: 'main', shorthand: 'main', isHead: true }),
+    ]);
+
+    const localBranch = makeBranch({ name: 'feature/x', shorthand: 'feature/x' });
+
+    let openedWith: string | undefined;
+    const dialog = (el as unknown as { createBranchDialog: { open: (sp?: string) => void } }).createBranchDialog;
+    dialog.open = (sp?: string) => {
+      openedWith = sp;
+    };
+
+    (el as unknown as { contextMenu: unknown }).contextMenu = {
+      visible: true,
+      x: 0,
+      y: 0,
+      branch: localBranch,
+    };
+    (el as unknown as { handleCreateBranchFrom: () => void }).handleCreateBranchFrom();
+
+    expect(openedWith).to.equal('feature/x');
+  });
+});
+
+describe('lv-branch-list drop onto remote target (Finding 16)', () => {
+  beforeEach(() => {
+    invokeCalls.length = 0;
+  });
+
+  it('checks out the full remote name (origin/topic), not the shorthand', async () => {
+    const el = await createComponent([
+      makeBranch({ name: 'main', shorthand: 'main', isHead: true }),
+    ]);
+
+    mockInvoke = (command: string) => {
+      if (command === 'checkout_with_autostash') {
+        return Promise.resolve({
+          success: true,
+          stashed: false,
+          stashApplied: false,
+          stashConflict: false,
+          message: 'ok',
+        });
+      }
+      if (command === 'plugin:dialog|message') return Promise.resolve('Ok');
+      if (command === 'merge') return Promise.resolve(null);
+      return Promise.resolve(null);
+    };
+    invokeCalls.length = 0;
+
+    const source = makeBranch({ name: 'feature/source', shorthand: 'feature/source' });
+    const remoteTarget = makeBranch({ name: 'origin/topic', shorthand: 'topic', isRemote: true });
+    (el as unknown as { draggingBranch: unknown }).draggingBranch = source;
+
+    await (el as unknown as { handleDrop: (e: DragEvent, b: unknown) => Promise<void> }).handleDrop(
+      fakeDragEvent(false),
+      remoteTarget
+    );
+
+    const checkoutCall = invokeCalls.find((c) => c.command === 'checkout_with_autostash');
+    expect(checkoutCall, 'checkout_with_autostash was called').to.not.be.undefined;
+    expect((checkoutCall!.args as { refName: string }).refName).to.equal('origin/topic');
+  });
+});

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -568,6 +568,10 @@ export class LvBranchList extends LitElement {
   @state() private hiddenBranches = new Set<string>();
   @state() private showSortMenu = false;
   @state() private operationInProgress = false;
+  // Names of local branches the backend reports as merged into HEAD (real
+  // graph_descendant_of detection, including tip==HEAD). Refreshed by
+  // loadBranches; used for the "Delete Merged Branches" flow and its badge.
+  @state() private mergedBranchNames = new Set<string>();
 
   @query('lv-create-branch-dialog') private createBranchDialog!: LvCreateBranchDialog;
   @query('lv-interactive-rebase-dialog') private interactiveRebaseDialog!: LvInteractiveRebaseDialog;
@@ -690,9 +694,10 @@ export class LvBranchList extends LitElement {
     this.error = null;
 
     try {
-      const [branchesResult] = await Promise.all([
+      const [branchesResult, , cleanupResult] = await Promise.all([
         gitService.getBranches(this.repositoryPath),
         gitService.getRemotes(this.repositoryPath),
+        gitService.getCleanupCandidates(this.repositoryPath),
       ]);
 
       if (!branchesResult.success) {
@@ -808,6 +813,15 @@ export class LvBranchList extends LitElement {
         };
       });
 
+      // Track the set of branches the backend considers merged into HEAD, so
+      // the "Delete Merged Branches" flow and its badge reflect real
+      // `git branch --merged` semantics rather than an ahead-of-upstream guess.
+      // Fetched in the Promise.all above to keep loadBranches to a single await
+      // point (extra await points perturb render timing for callers).
+      this.mergedBranchNames = cleanupResult.success && cleanupResult.data
+        ? new Set(cleanupResult.data.filter(c => c.category === 'merged').map(c => c.name))
+        : new Set();
+
     } catch (err) {
       this.error = err instanceof Error ? err.message : 'Unknown error';
     } finally {
@@ -905,20 +919,18 @@ export class LvBranchList extends LitElement {
   }
 
   /**
-   * Find all local branches that are merged into HEAD
+   * Find all local branches that are merged into HEAD.
+   *
+   * Uses the backend's real merge detection (graph_descendant_of against HEAD,
+   * including tip==HEAD equality) — the same data the cleanup dialog uses —
+   * instead of an ahead-of-UPSTREAM==0 heuristic. That heuristic diverged from
+   * `git branch --merged` in both directions: it wrongly flagged fully-pushed
+   * unmerged branches (ahead-of-upstream 0 right after a push) as merged, and it
+   * missed merged branches that have no upstream at all (aheadBehind undefined).
    */
   private getMergedBranches(): Branch[] {
     const allLocal = this.localBranchGroups.flatMap(g => g.branches);
-    // A branch is considered merged if it's:
-    // 1. Not HEAD
-    // 2. Behind 0 commits (meaning HEAD contains all its commits)
-    // Note: This is a simple heuristic. For perfect accuracy,
-    // we'd need to check if HEAD is a descendant of the branch.
-    return allLocal.filter(b =>
-      !b.isHead &&
-      b.aheadBehind &&
-      b.aheadBehind.ahead === 0
-    );
+    return allLocal.filter(b => !b.isHead && this.mergedBranchNames.has(b.name));
   }
 
   /**
@@ -1279,7 +1291,10 @@ export class LvBranchList extends LitElement {
     if (!branch) return;
 
     this.contextMenu = { ...this.contextMenu, visible: false };
-    this.createBranchDialog.open(branch.shorthand);
+    // For remote branches the start point must be the full remote-tracking name
+    // (e.g. "origin/feature"); the stripped shorthand ("feature") either fails to
+    // resolve or resolves to a same-named LOCAL branch at a different commit.
+    this.createBranchDialog.open(branch.isRemote ? branch.name : branch.shorthand);
   }
 
   private async handleTrackRemoteBranch(): Promise<void> {
@@ -1626,8 +1641,11 @@ export class LvBranchList extends LitElement {
       );
       if (!confirmed) return;
 
-      // First checkout target branch (with auto-stash for uncommitted changes)
-      const checkoutResult = await gitService.checkoutWithAutoStash(this.repositoryPath, targetBranch.shorthand);
+      // First checkout target branch (with auto-stash for uncommitted changes).
+      // Use the full branch.name — for remote branches this is the full
+      // "origin/topic" reference the backend needs to create/use a local
+      // tracking branch; the stripped shorthand ("topic") cannot be resolved.
+      const checkoutResult = await gitService.checkoutWithAutoStash(this.repositoryPath, targetBranch.name);
 
       if (!checkoutResult.success || !checkoutResult.data?.success) {
         console.error('Checkout failed:', checkoutResult.data?.message || checkoutResult.error);

--- a/src/components/sidebar/lv-stash-list.ts
+++ b/src/components/sidebar/lv-stash-list.ts
@@ -270,6 +270,11 @@ export class LvStashList extends LitElement {
       });
 
       if (result.success) {
+        if (result.data === null) {
+          // Clean working tree: nothing to stash — informational, not an error.
+          showToast('No local changes to save', 'info');
+          return;
+        }
         await this.loadStashes();
         this.dispatchEvent(new CustomEvent('stash-created', {
           bubbles: true,

--- a/src/services/__tests__/advanced-search.service.test.ts
+++ b/src/services/__tests__/advanced-search.service.test.ts
@@ -88,15 +88,16 @@ describe('git.service - Advanced search operations', () => {
       expect(sentFilter.maxParents).to.equal(1);
       expect(sentFilter.noMerges).to.be.true;
       expect(sentFilter.firstParent).to.be.true;
-      expect(args.maxCount).to.equal(50);
+      expect(args.maxResults).to.equal(50);
     });
 
-    it('passes maxCount parameter', async () => {
+    it('passes the result limit as maxResults', async () => {
       mockInvoke = () => Promise.resolve([]);
 
       await filterCommits('/test/repo', {}, 200);
       const args = lastInvokedArgs as Record<string, unknown>;
-      expect(args.maxCount).to.equal(200);
+      expect(args.maxResults).to.equal(200);
+      expect(args.maxCount).to.be.undefined;
     });
 
     it('returns empty array when no matches', async () => {
@@ -167,12 +168,13 @@ describe('git.service - Advanced search operations', () => {
       expect(result.data?.length).to.equal(1);
     });
 
-    it('passes maxCount parameter', async () => {
+    it('passes the result limit as maxResults', async () => {
       mockInvoke = () => Promise.resolve([]);
 
       await getBranchDiffCommits('/test/repo', 'main', 'feature', 100);
       const args = lastInvokedArgs as Record<string, unknown>;
-      expect(args.maxCount).to.equal(100);
+      expect(args.maxResults).to.equal(100);
+      expect(args.maxCount).to.be.undefined;
     });
 
     it('returns empty array when branches are identical', async () => {

--- a/src/services/__tests__/clean.service.test.ts
+++ b/src/services/__tests__/clean.service.test.ts
@@ -33,8 +33,8 @@ describe('git.service - Clean operations', () => {
   describe('getCleanableFiles', () => {
     it('invokes get_cleanable_files command', async () => {
       const mockEntries: CleanEntry[] = [
-        { path: 'untracked.txt', isDirectory: false, isIgnored: false, size: 1024 },
-        { path: 'temp/', isDirectory: true, isIgnored: false, size: null },
+        { path: 'untracked.txt', isDirectory: false, isIgnored: false, isNestedRepo: false, size: 1024 },
+        { path: 'temp/', isDirectory: true, isIgnored: false, isNestedRepo: false, size: null },
       ];
       mockInvoke = () => Promise.resolve(mockEntries);
 
@@ -94,9 +94,9 @@ describe('git.service - Clean operations', () => {
 
     it('returns files with correct properties', async () => {
       const mockEntries: CleanEntry[] = [
-        { path: 'file1.txt', isDirectory: false, isIgnored: false, size: 1024 },
-        { path: 'file2.log', isDirectory: false, isIgnored: true, size: 2048 },
-        { path: 'temp/', isDirectory: true, isIgnored: false, size: null },
+        { path: 'file1.txt', isDirectory: false, isIgnored: false, isNestedRepo: false, size: 1024 },
+        { path: 'file2.log', isDirectory: false, isIgnored: true, isNestedRepo: false, size: 2048 },
+        { path: 'temp/', isDirectory: true, isIgnored: false, isNestedRepo: false, size: null },
       ];
       mockInvoke = () => Promise.resolve(mockEntries);
 
@@ -107,6 +107,16 @@ describe('git.service - Clean operations', () => {
       expect(result.data?.[1].isIgnored).to.be.true;
       expect(result.data?.[2].isDirectory).to.be.true;
       expect(result.data?.[2].size).to.be.null;
+    });
+
+    it('surfaces the isNestedRepo flag for nested git repositories', async () => {
+      const mockEntries: CleanEntry[] = [
+        { path: 'vendor/', isDirectory: true, isIgnored: false, isNestedRepo: true, size: null },
+      ];
+      mockInvoke = () => Promise.resolve(mockEntries);
+
+      const result = await getCleanableFiles('/test/repo', false, true);
+      expect(result.data?.[0].isNestedRepo).to.be.true;
     });
 
     it('handles error response', async () => {
@@ -136,6 +146,23 @@ describe('git.service - Clean operations', () => {
 
       const result = await cleanFiles('/test/repo', ['a.txt', 'b.txt', 'c.txt']);
       expect(result.data).to.equal(3);
+    });
+
+    it('defaults forceNested to false', async () => {
+      mockInvoke = () => Promise.resolve(0);
+
+      await cleanFiles('/test/repo', ['file.txt']);
+      const args = lastInvokedArgs as Record<string, unknown>;
+      expect(args.forceNested).to.be.false;
+    });
+
+    it('passes forceNested when removing nested repositories', async () => {
+      mockInvoke = () => Promise.resolve(1);
+
+      await cleanFiles('/test/repo', ['vendor/'], true);
+      const args = lastInvokedArgs as Record<string, unknown>;
+      expect(args.forceNested).to.be.true;
+      expect(args.paths).to.deep.equal(['vendor/']);
     });
 
     it('handles single file', async () => {

--- a/src/services/__tests__/stash.service.test.ts
+++ b/src/services/__tests__/stash.service.test.ts
@@ -148,6 +148,16 @@ describe('git.service - Stash operations', () => {
       expect(result.success).to.be.false;
       expect(result.error?.message).to.include('No local changes');
     });
+
+    it('returns a successful null result when the working tree is clean (no-op)', async () => {
+      // Backend returns null (not an error) when there is nothing to stash,
+      // mirroring `git stash push` ("No local changes to save", exit 0).
+      mockInvoke = () => Promise.resolve(null);
+
+      const result = await createStash({ path: '/test/repo' });
+      expect(result.success).to.be.true;
+      expect(result.data).to.be.null;
+    });
   });
 
   describe('applyStash', () => {

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -1302,8 +1302,10 @@ export async function getStashes(
 
 export async function createStash(
   args: CreateStashCommand,
-): Promise<CommandResult<Stash>> {
-  return invokeCommand<Stash>("create_stash", args);
+): Promise<CommandResult<Stash | null>> {
+  // Returns null when the working tree is clean (nothing to stash) — a benign
+  // no-op mirroring `git stash push` ("No local changes to save"), not an error.
+  return invokeCommand<Stash | null>("create_stash", args);
 }
 
 export async function applyStash(
@@ -1696,6 +1698,12 @@ export interface CleanEntry {
   path: string;
   isDirectory: boolean;
   isIgnored: boolean;
+  /**
+   * True when this entry is an untracked nested git repository. Deleting it
+   * destroys the embedded repo's history, so `git clean` only removes it with a
+   * second `-f`; the UI must confirm and pass `forceNested` to clean it.
+   */
+  isNestedRepo: boolean;
   size: number | null;
 }
 
@@ -1714,10 +1722,14 @@ export async function getCleanableFiles(
 export async function cleanFiles(
   repoPath: string,
   paths: string[],
+  forceNested = false,
 ): Promise<CommandResult<number>> {
+  // forceNested is required to remove untracked nested git repositories,
+  // mirroring `git clean -ff`. Without it the backend refuses to delete them.
   return invokeCommand<number>("clean_files", {
     path: repoPath,
     paths,
+    forceNested,
   });
 }
 
@@ -2112,6 +2124,8 @@ export interface GpgConfig {
   signCommits: boolean;
   signTags: boolean;
   gpgProgram: string | null;
+  /** Signature format (gpg.format): "openpgp" (default), "ssh", or "x509". */
+  gpgFormat: string | null;
 }
 
 export interface CommitSignature {
@@ -5891,7 +5905,8 @@ export async function filterCommits(
   return invokeCommand<FilteredCommit[]>("filter_commits", {
     path,
     filter,
-    maxCount: maxCount ?? 500,
+    // Rust parameter is `max_results`; Tauri maps it to the `maxResults` key.
+    maxResults: maxCount ?? 500,
   });
 }
 
@@ -5908,7 +5923,8 @@ export async function getBranchDiffCommits(
     path,
     baseBranch,
     compareBranch,
-    maxCount: maxCount ?? 500,
+    // Rust parameter is `max_results`; Tauri maps it to the `maxResults` key.
+    maxResults: maxCount ?? 500,
   });
 }
 

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -329,6 +329,12 @@ export interface CherryPickCommand {
   commitOid: string;
   /** If true, stages changes without committing (like `git cherry-pick -n`) */
   noCommit?: boolean;
+  /**
+   * For a merge commit, which parent (1-based) to cherry-pick relative to
+   * (`git cherry-pick -m`). The backend requires this when the target has more
+   * than one parent; ignored for non-merge commits.
+   */
+  mainline?: number;
 }
 
 export interface ContinueCherryPickCommand {
@@ -351,6 +357,12 @@ export interface CherryPickFromBranchCommand {
 export interface RevertCommand {
   path: string;
   commitOid: string;
+  /**
+   * For a merge commit, which parent (1-based) to revert relative to
+   * (`git revert -m`). The backend requires this when the target has more than
+   * one parent; ignored for non-merge commits.
+   */
+  mainline?: number;
 }
 
 export interface ContinueRevertCommand {

--- a/src/types/git.types.ts
+++ b/src/types/git.types.ts
@@ -318,6 +318,8 @@ export interface HunkDiffLine {
 
 export interface CommitFileEntry {
   path: string;
+  /** For a renamed/copied file, the previous path; `null` otherwise. */
+  oldPath: string | null;
   status: FileStatus;
   additions: number;
   deletions: number;


### PR DESCRIPTION
## Summary

This PR grew from the original merge/squash safety work into a **full correctness audit of every git feature in the app**, using the real `git` 2.43 CLI as the oracle. Each of the ~50 git-facing Tauri command modules was audited against canonical git behavior (man-page semantics), every finding was independently adversarially verified, and each confirmed bug was fixed **test-first** with a regression test that encodes what canonical git does.

**113 confirmed divergences from canonical git were found and fixed**, across 14 feature areas.

### Severity breakdown

| Severity | Count | Meaning |
|---|---:|---|
| 🔴 **data-loss** | 17 | destroyed uncommitted changes / dropped commits or stashes git would keep |
| 🟠 wrong-result | 72 | produced output diverging from canonical git |
| 🟡 wrong-error | 18 | silently succeeded/corrupted where git refuses (or vice-versa) |
| ⚪ cosmetic | 6 | message/decoration divergence, no data or result impact |

### Method

- **Oracle = real git**, not intuition: for each behavior, a scenario repo was built and the operation run through both the app's code path and the `git` CLI, comparing resulting HEAD / refs / index / working tree / reflog / state files.
- **Adversarial verification**: every finding was re-checked by an independent reviewer instructed to *refute* it (reproduce git's behavior + re-trace the code); only reproducible divergences survived.
- **Test-first fixes**: each fix began with a failing regression test encoding canonical git behavior. Data-loss bugs were fixed to **refuse with a clear, git-style error** rather than destroy.

## 🔴 Data-loss fixes (17) — highest priority

Every one of these previously destroyed user work that canonical git protects; all now refuse like git:

- **staging.rs** — discard_changes wiped staged content: restored worktree AND index from HEAD instead of restoring worktree from the index
- **merge.rs** — Fast-forward merge force-checkout silently destroyed uncommitted changes and untracked files git refuses to overwrite
- **merge.rs** — abort_merge destroyed uncommitted changes unrelated to the merge, which `git merge --abort` preserves
- **merge.rs** — abort_merge with no merge in progress silently hard-reset index and working tree instead of erroring
- **squash.rs** — squash_commits silently discarded every commit after the target when it was not the branch head
- **squash.rs** — fixup_commit's final force checkout wiped unstaged working-tree changes
- **rewrite.rs** — Aborting a cherry-pick/revert force-checked-out HEAD, destroying unrelated uncommitted changes git preserves
- **rewrite.rs** — abort_cherry_pick/abort_revert with nothing in progress silently hard-reset the working tree
- **undo.rs** — undo_last_action "undid" a checkout by mixed-resetting the branch to the pre-checkout commit, orphaning its commits
- **clean.rs** — Clean deleted untracked nested git repositories that `git clean -fd` refuses to touch
- **clean.rs** — "Include directories" unchecked still deleted files inside untracked directories, unlike `git clean` without `-d`
- **clean.rs** — clean_files deleted any path given — including tracked files and `../` paths outside the repo — with no validation
- **patch.rs** — apply_patch "check only" mode actually applied the patch to the working tree
- **encoding.rs** — convert_file_encoding to UTF-16LE/BE wrote UTF-8 bytes behind a UTF-16 BOM, corrupting the file
- **tags.rs** — edit_tag_message deleted the tag before recreating it, losing the tag permanently if re-creation failed
- **remote.rs** — Fast-forward pull force-checked-out HEAD, silently destroying all uncommitted changes (incl. deleting staged new files)
- **submodule.rs** — remove_submodule permanently destroyed unpushed submodule commits that `git rm` preserves

## Fixes by feature area

### Merge & squash (8) — _5×data-loss, 1×wrong-result, 1×wrong-error, 1×cosmetic_
Safe fast-forward checkout, `git merge --abort` / `git reset --merge` semantics, in-progress-merge guard, mid-history squash that replays descendants, `fixup` dirty-tree refusal, canonical `MERGE_MSG` default message (incl. git's `into <branch>` subject rule), and merge-commit hook invocation.

### Rebase / cherry-pick / revert (7) — _2×data-loss, 4×wrong-result, 1×wrong-error_
Abort no longer force-checkouts HEAD, empty-pick stops like git, merge-commit picks require `-m`, real sequencer state for multi-commit ranges (abort rewinds the whole range even after an empty mid-pick), worktree-aware state paths, and prepare-commit-msg/post-commit hooks.

### Commit & staging (11) — _1×data-loss, 5×wrong-result, 4×wrong-error, 1×cosmetic_
discard_changes restores from index (not HEAD), amend/reword fixed, hunk/line staging preserves `\ No newline at end of file` and CRLF, symlink and unborn-HEAD handling, cherry-pick author preserved, message cleanup, and full pre-commit/commit-msg/post-commit hook coverage on the default path.

### Stash, clean & restore (7) — _3×data-loss, 1×wrong-result, 1×wrong-error, 2×cosmetic_
`git clean` `-d`/`-x` and nested-repo safety (with the app's own confirm dialog), path containment validation, smudge-filter-aware file checkout, clean-tree stash as a no-op, empty-dir removal, and post-checkout hook.

### Remote & pull (6) — _1×data-loss, 4×wrong-result, 1×wrong-error_
Safe fast-forward pull, real non-fast-forward push-rejection reporting, token auth for force/tags pushes, `branch.<name>.remote`/`.merge` honored, detached-HEAD pull refusal, and pre-push hook.

### Branches (12) — _9×wrong-result, 3×wrong-error_
`origin/HEAD` checkout, `-d`/`-D` merged-check parity with `git branch`, tip==HEAD deletion, cleanup-dialog "gone"-branch labeling, remote-branch start points + upstream tracking, orphan-branch creation, drag-and-drop merge/rebase targets, and post-checkout hook.

### Undo & reflog (4) — _1×data-loss, 3×wrong-result_
Undo no longer rewrites the branch on checkout-undo, reset/undo/redo preserve in-progress rebase/bisect/sequencer state, and record/redo semantics fixed.

### Repository, config & refs (9) — _6×wrong-result, 3×wrong-error_
No auth token persisted in `remote.origin.url`, effective identity/alias resolution across scopes + includeIf, multiline config via `--null`, `core.quotePath` decoding, local-path clone sources, `..`-in-filename validation, unset error surfacing, and clone template/hook parity + timeout handling.

### Diff & patch (10) — _2×data-loss, 8×wrong-result_
apply-check no longer applies, correct UTF-16 conversion, rename/copy detection (surfaced in commit details as "renamed from"), parent-vs-commit external difftool, blame accuracy, unborn-HEAD staged diff, GIT binary patches, non-UTF8 diff bytes, binary override, and fuzzy-fallback correctness.

### Tags, notes, describe, archive & bundle (10) — _1×data-loss, 9×wrong-result_
Non-destructive tag re-message, `git bundle unbundle` ref handling and prerequisites, `.mailmap`/name-based shortlog with three-dot ranges, archive exec-bit/symlink/`export-ignore` fidelity, and pre-push hook on tag push.

### Worktree, submodule & sparse-checkout (3) — _1×data-loss, 2×wrong-result_
Submodule removal preserves unpushed commits, sparse-checkout cone/non-cone honored, and canonical `submodule update` semantics.

### gitignore, gitattributes & hooks (7) — _7×wrong-result_
`check-ignore` parity for tracked/non-ASCII paths, quoted-pattern gitattributes parsing, `core.hooksPath` + linked-worktree hook resolution, and a representable disabled-hook state.

### Bisect & signing (GPG/SSH) (8) — _1×wrong-error, 7×wrong-result_
Non-zero-exit bisect errors surfaced, progress counts, worktree-aware state, custom terms, `gpg.format=ssh`/`gpg.program` capability detection, tag/commit signing honoring `commit.gpgsign`/`tag.gpgsign`, and SSH-signature display.

### Graph, search & stats (11) — _11×wrong-result_
Rename-aware/first-parent-correct churn, `.mailmap` identity, author-timezone activity buckets, `|`-in-subject parsing, literal vs regex search (`-F`, `--grep`, pickaxe), deleted-file diff attribution, case-sensitivity, the `maxCount`→`maxResults` FE/BE parameter mismatch, and detached-HEAD graph decoration.

## Cross-cutting: silent hook bypass

The app is git2/libgit2-based, which runs **no hooks**. Default write paths (commit, merge, rebase/cherry-pick/revert, checkout, push, clone) silently skipped `pre-commit`/`commit-msg`/`pre-push`/`post-checkout`/etc. — inconsistently, since CLI-fallback paths *did* run them. A centralized hook runner was added that resolves `core.hooksPath`/commondir exactly as git does (which also fixed the linked-worktree hook bugs), wired into the git2 write paths with correct blocking/non-blocking semantics per `githooks(5)`. Blocking hooks (pre-merge-commit, commit-msg) leave the operation resumable on veto, matching git.

## Merged `main` + dependency security fix

- Merged latest `main` (multi-repo overhaul #250 + dep bumps); resolved one conflict in `lv-branch-list.ts` by combining main's load-race fix (captured `loadedPath`) with this branch's `getCleanupCandidates()` fetch.
- Bumped `crossbeam-epoch` 0.9.18 → 0.9.20 (lockfile-only) to fix **RUSTSEC-2026-0204** (published 2026-07-06), clearing the Security Audit check.

## Review

The accumulated diff went through the project's mandated **three-reviewer, multi-model, recursive review** (Opus / Sonnet / Haiku, each reviewing the entire changed surface holistically against real git). It ran to convergence over 6 rounds — each round's findings (a merge-commit cherry-pick/revert regression, the `into <branch>` subject rule, rebase-replay hook semantics, `pre-merge-commit`/`commit-msg` resumability, cherry-pick range abort, and post-commit-per-batch-rewrite) were fixed test-first — until all three reviewers returned **NO ISSUES FOUND** in the same round.

## Tests

- **143 new Rust regression tests** (`#[cfg(test)]` with `TestRepo` + real git2 ops), each encoding the canonical git behavior it guards.
- **New/extended TypeScript unit tests** for the frontend/cross-stack findings (hunk/line staging CR handling, `maxCount`→`maxResults`, merged-remote branch labels, GPG/submodule dialogs, cherry-pick mainline selector, clean-dialog confirm, commit-details rename display).

## Verification

Full gate green: `eslint`, `tsc`, JS unit tests, `cargo fmt --check`, `cargo clippy -D warnings`, the Rust suite, and `cargo audit` (0 vulnerabilities). **All 14 CI checks pass** (backend/frontend/E2E tests, lint, Security Audit, CodeQL, multi-OS builds).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)