### PR TITLE
Fix git signing config and improve error handling across providers

### DIFF
--- a/src-tauri/src/commands/azure_devops.rs
+++ b/src-tauri/src/commands/azure_devops.rs
@@ -154,6 +154,16 @@ fn build_api_url_with_params(
     )
 }
 
+/// Build the `searchCriteria.status` query fragment for a PR status filter.
+///
+/// Azure DevOps returns pull requests in *all* states when
+/// `searchCriteria.status` is omitted. A `None` status therefore means "All"
+/// and must not append any status filter (previously this defaulted to
+/// `active`, hiding completed/abandoned PRs from the "All" filter).
+fn ado_pr_status_param(status: Option<&str>) -> Option<String> {
+    status.map(|s| format!("searchCriteria.status={}", s))
+}
+
 // ============================================================================
 // Connection Commands
 // ============================================================================
@@ -486,13 +496,11 @@ pub async fn list_ado_pull_requests(
 ) -> Result<Vec<AdoPullRequest>> {
     let token = resolve_ado_token(token)?;
 
-    let status_param = status.unwrap_or_else(|| "active".to_string());
-    let url = build_api_url_with_params(
-        &organization,
-        &project,
-        &format!("git/repositories/{}/pullrequests", repository),
-        &format!("searchCriteria.status={}", status_param),
-    );
+    let path = format!("git/repositories/{}/pullrequests", repository);
+    let url = match ado_pr_status_param(status.as_deref()) {
+        Some(params) => build_api_url_with_params(&organization, &project, &path, &params),
+        None => build_api_url(&organization, &project, &path),
+    };
 
     let client = reqwest::Client::new();
     let response = client
@@ -1120,6 +1128,21 @@ pub async fn list_ado_pipeline_runs(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_ado_pr_status_param() {
+        // A concrete status yields the searchCriteria fragment.
+        assert_eq!(
+            ado_pr_status_param(Some("active")).as_deref(),
+            Some("searchCriteria.status=active")
+        );
+        assert_eq!(
+            ado_pr_status_param(Some("completed")).as_deref(),
+            Some("searchCriteria.status=completed")
+        );
+        // "All" (None) omits the filter so every PR state is returned.
+        assert_eq!(ado_pr_status_param(None), None);
+    }
 
     #[test]
     fn test_parse_ado_url_https_standard() {

--- a/src-tauri/src/commands/bitbucket.rs
+++ b/src-tauri/src/commands/bitbucket.rs
@@ -828,8 +828,18 @@ pub async fn list_bitbucket_issues(
         .map_err(|e| LeviathanError::OperationFailed(format!("Failed to fetch issues: {}", e)))?;
 
     if !response.status().is_success() {
-        // Issues might not be enabled, return empty list
-        return Ok(vec![]);
+        // A 404 means the issue tracker is not enabled for this repo — treat as empty.
+        // Other failures (401/403/500…) are real errors and must be surfaced, not
+        // silently swallowed as "no issues".
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(vec![]);
+        }
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(LeviathanError::OperationFailed(format!(
+            "Bitbucket API error {}: {}",
+            status, body
+        )));
     }
 
     #[derive(Deserialize)]
@@ -1093,8 +1103,18 @@ pub async fn list_bitbucket_pipelines(
         })?;
 
     if !response.status().is_success() {
-        // Pipelines might not be enabled
-        return Ok(vec![]);
+        // A 404 means Pipelines is not enabled for this repo — treat as empty.
+        // Other failures (401/403/500…) are real errors and must be surfaced, not
+        // silently swallowed as "no pipelines".
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(vec![]);
+        }
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(LeviathanError::OperationFailed(format!(
+            "Bitbucket API error {}: {}",
+            status, body
+        )));
     }
 
     #[derive(Deserialize)]

--- a/src-tauri/src/commands/branch.rs
+++ b/src-tauri/src/commands/branch.rs
@@ -161,7 +161,11 @@ pub async fn delete_branch(path: String, name: String, force: Option<bool>) -> R
         // Check if branch is merged before deleting
         let head = repo.head()?;
         if let (Some(head_oid), Some(branch_oid)) = (head.target(), branch.get().target()) {
-            if repo.graph_descendant_of(head_oid, branch_oid)? {
+            // A branch is fully merged into HEAD when HEAD is at or descends
+            // from the branch tip. The equality case matters: `git branch -d`
+            // deletes a branch that points at the same commit as HEAD, but
+            // graph_descendant_of returns false for equal oids.
+            if head_oid == branch_oid || repo.graph_descendant_of(head_oid, branch_oid)? {
                 branch.delete()?;
             } else {
                 return Err(LeviathanError::OperationFailed(
@@ -1018,6 +1022,26 @@ mod tests {
         let git_repo = repo.repo();
         let branch = git_repo.find_branch("to-delete", git2::BranchType::Local);
         assert!(branch.is_err());
+    }
+
+    // A branch pointing at the same commit as HEAD is fully merged, so a
+    // non-force delete must succeed (matching `git branch -d`).
+    #[tokio::test]
+    async fn test_delete_branch_at_head_non_force_succeeds() {
+        let repo = TestRepo::with_initial_commit();
+        // Branch created at HEAD points to the same commit as HEAD.
+        repo.create_branch("at-head");
+
+        let result = delete_branch(repo.path_str(), "at-head".to_string(), Some(false)).await;
+        assert!(
+            result.is_ok(),
+            "deleting a branch at HEAD should succeed without force"
+        );
+
+        let git_repo = repo.repo();
+        assert!(git_repo
+            .find_branch("at-head", git2::BranchType::Local)
+            .is_err());
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/gitlab.rs
+++ b/src-tauri/src/commands/gitlab.rs
@@ -907,7 +907,17 @@ pub async fn get_gitlab_labels(
     let response = gitlab_get(&url, &token).await?;
 
     if !response.status().is_success() {
-        return Ok(vec![]);
+        // Only a missing project means "no labels"; a bad token or server error
+        // must surface, not silently render an empty labels dropdown.
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(vec![]);
+        }
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(LeviathanError::OperationFailed(format!(
+            "GitLab API error {}: {}",
+            status, body
+        )));
     }
 
     #[derive(Deserialize)]

--- a/src-tauri/src/commands/gitlab.rs
+++ b/src-tauri/src/commands/gitlab.rs
@@ -194,6 +194,19 @@ fn url_encode(s: &str) -> String {
     urlencoding::encode(s).into_owned()
 }
 
+/// Build the `&state=<x>` query fragment for a MR/issue state filter.
+///
+/// GitLab's REST API returns items in *all* states when the `state` query
+/// parameter is omitted. A `None` state therefore means "All" and must not
+/// append any `state` param (previously this defaulted to `opened`, hiding
+/// closed/merged items from the "All" filter).
+fn state_query_param(state: Option<&str>) -> String {
+    match state {
+        Some(s) => format!("&state={}", s),
+        None => String::new(),
+    }
+}
+
 // ============================================================================
 // Connection Commands
 // ============================================================================
@@ -368,14 +381,13 @@ pub async fn list_gitlab_merge_requests(
     let token = resolve_token(token)?;
 
     let encoded_path = url_encode(&project_path);
-    let state_param = state.unwrap_or_else(|| "opened".to_string());
     let url = format!(
-        "{}?state={}&per_page=30",
+        "{}?per_page=30{}",
         build_api_url(
             &instance_url,
             &format!("projects/{}/merge_requests", encoded_path)
         ),
-        state_param
+        state_query_param(state.as_deref())
     );
 
     let response = gitlab_get(&url, &token).await?;
@@ -630,11 +642,10 @@ pub async fn list_gitlab_issues(
     let token = resolve_token(token)?;
 
     let encoded_path = url_encode(&project_path);
-    let state_param = state.unwrap_or_else(|| "opened".to_string());
     let mut url = format!(
-        "{}?state={}&per_page=30",
+        "{}?per_page=30{}",
         build_api_url(&instance_url, &format!("projects/{}/issues", encoded_path)),
-        state_param
+        state_query_param(state.as_deref())
     );
 
     if let Some(label_str) = labels {
@@ -928,6 +939,16 @@ mod tests {
             build_api_url("https://gitlab.example.com", "projects/123"),
             "https://gitlab.example.com/api/v4/projects/123"
         );
+    }
+
+    #[test]
+    fn test_state_query_param() {
+        // A concrete state appends the filter.
+        assert_eq!(state_query_param(Some("opened")), "&state=opened");
+        assert_eq!(state_query_param(Some("closed")), "&state=closed");
+        assert_eq!(state_query_param(Some("merged")), "&state=merged");
+        // "All" (None) omits the param entirely so GitLab returns every state.
+        assert_eq!(state_query_param(None), "");
     }
 
     #[test]

--- a/src-tauri/src/commands/gpg.rs
+++ b/src-tauri/src/commands/gpg.rs
@@ -152,15 +152,25 @@ fn expand_tilde(p: &str) -> String {
     p.to_string()
 }
 
-/// Whether a configured SSH signing key is usable: either a literal public key
-/// ("ssh-..." or "key::...") or a path to an existing key file. SSH signing does
-/// not involve the gpg binary at all.
+/// Whether `key` is an inline OpenSSH signing-key literal (any key type git
+/// accepts for `user.signingkey` when `gpg.format=ssh`), as opposed to a path to
+/// a key file. Single source of truth for SSH key-shape detection, shared with
+/// `unified_profiles::detect_gpg_format` so the two can't drift.
+pub(crate) fn is_ssh_literal_key(key: &str) -> bool {
+    const SSH_PREFIXES: &[&str] = &["ssh-", "ecdsa-sha2-", "sk-ssh-", "sk-ecdsa-", "key::"];
+    let key = key.trim();
+    SSH_PREFIXES.iter().any(|p| key.starts_with(p))
+}
+
+/// Whether a configured SSH signing key is usable: either an inline public key
+/// literal (see `is_ssh_literal_key`) or a path to an existing key file. SSH
+/// signing does not involve the gpg binary at all.
 fn ssh_key_is_usable(key: &str) -> bool {
     let key = key.trim();
     if key.is_empty() {
         return false;
     }
-    if key.starts_with("ssh-") || key.starts_with("key::") {
+    if is_ssh_literal_key(key) {
         return true;
     }
     Path::new(&expand_tilde(key)).exists()
@@ -982,6 +992,42 @@ mod tests {
         assert!(
             status.can_sign,
             "a literal SSH public key must be reported as usable"
+        );
+    }
+
+    #[test]
+    fn test_is_ssh_literal_key_covers_all_shapes() {
+        assert!(is_ssh_literal_key("ssh-ed25519 AAAA..."));
+        assert!(is_ssh_literal_key("ssh-rsa AAAA..."));
+        assert!(is_ssh_literal_key("ecdsa-sha2-nistp256 AAAA..."));
+        assert!(is_ssh_literal_key("sk-ssh-ed25519@openssh.com AAAA..."));
+        assert!(is_ssh_literal_key(
+            "sk-ecdsa-sha2-nistp256@openssh.com AAAA..."
+        ));
+        assert!(is_ssh_literal_key("key::ssh-ed25519 AAAA..."));
+        assert!(!is_ssh_literal_key("ABCDEF1234567890")); // OpenPGP key id
+        assert!(!is_ssh_literal_key("/home/me/.ssh/id.pub")); // a path, not a literal
+    }
+
+    #[tokio::test]
+    async fn test_get_signing_status_ecdsa_literal_key() {
+        // An inline ECDSA SSH key must be reported usable, not misread as a path.
+        let repo = TestRepo::with_initial_commit();
+        run_git_command(&repo.path, &["config", "gpg.format", "ssh"]).unwrap();
+        run_git_command(
+            &repo.path,
+            &[
+                "config",
+                "user.signingkey",
+                "ecdsa-sha2-nistp256 AAAAE2ECDSA",
+            ],
+        )
+        .unwrap();
+
+        let status = get_signing_status(repo.path_str()).await.unwrap();
+        assert!(
+            status.can_sign,
+            "an inline ECDSA SSH public key must be reported as usable"
         );
     }
 

--- a/src-tauri/src/commands/jira.rs
+++ b/src-tauri/src/commands/jira.rs
@@ -119,13 +119,21 @@ fn generate_branch_name(issue_key: &str, summary: &str, branch_type: Option<&str
     }
     let result = result.trim_matches('-');
 
-    // Truncate to reasonable length
+    // Truncate to reasonable length. `result` may contain multi-byte Unicode
+    // (CJK/accented letters survive `is_alphanumeric`), so we must cut on a char
+    // boundary — slicing at a raw byte index would panic mid-codepoint.
     let max_summary_len = 50;
     let truncated = if result.len() > max_summary_len {
-        // Try to cut at a dash boundary
-        match result[..max_summary_len].rfind('-') {
+        // Largest char boundary <= max_summary_len (equals max_summary_len for ASCII).
+        let byte_limit = (0..=max_summary_len)
+            .rev()
+            .find(|&i| result.is_char_boundary(i))
+            .unwrap_or(0);
+        let head = &result[..byte_limit];
+        // Prefer cutting at a dash boundary, mirroring the original ASCII behavior.
+        match head.rfind('-') {
             Some(pos) if pos > 10 => &result[..pos],
-            _ => &result[..max_summary_len],
+            _ => head,
         }
     } else {
         result
@@ -682,6 +690,26 @@ mod tests {
         assert!(name.starts_with("feature/PROJ-100-"));
         // Total length should be reasonable (prefix + key + truncated summary)
         assert!(name.len() < 80);
+    }
+
+    #[test]
+    fn test_generate_branch_name_unicode_no_panic() {
+        // CJK characters are alphanumeric and survive sanitization as multi-byte
+        // codepoints; truncation must not panic on a non-char-boundary byte index.
+        let long_cjk = "件".repeat(40); // 40 chars * 3 bytes = 120 bytes, well over 50
+        let name = generate_branch_name("PROJ-999", &long_cjk, None);
+        assert!(name.starts_with("feature/PROJ-999-"));
+        // The multi-byte summary was preserved (not stripped) and truncated safely.
+        assert!(name.contains('件'));
+    }
+
+    #[test]
+    fn test_generate_branch_name_mixed_unicode_boundary() {
+        // A summary whose 50th byte lands in the middle of a multi-byte char.
+        let summary = "café ".repeat(15); // 'é' is 2 bytes, shifts boundaries
+        let name = generate_branch_name("PROJ-1", &summary, None);
+        assert!(name.starts_with("feature/PROJ-1-"));
+        assert!(name.contains("caf"));
     }
 
     #[test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -470,17 +470,26 @@ pub async fn rebase(path: String, onto: String) -> Result<()> {
             "Another operation is in progress".to_string(),
         ));
     }
-    let statuses = repo.statuses(None)?;
-    if !statuses.is_empty() {
-        let has_changes = statuses
-            .iter()
-            .any(|s| s.status() != git2::Status::IGNORED && s.status() != git2::Status::CURRENT);
-        if has_changes {
-            return Err(LeviathanError::OperationFailed(
-                "Working directory has uncommitted changes. Commit or stash them first."
-                    .to_string(),
-            ));
-        }
+    // Match canonical `git rebase`: staged changes and modifications to tracked
+    // files abort the rebase, but untracked (WT_NEW) and ignored files do not.
+    let blocking = git2::Status::INDEX_NEW
+        | git2::Status::INDEX_MODIFIED
+        | git2::Status::INDEX_DELETED
+        | git2::Status::INDEX_RENAMED
+        | git2::Status::INDEX_TYPECHANGE
+        | git2::Status::WT_MODIFIED
+        | git2::Status::WT_DELETED
+        | git2::Status::WT_TYPECHANGE
+        | git2::Status::WT_RENAMED
+        | git2::Status::CONFLICTED;
+    let has_changes = repo
+        .statuses(None)?
+        .iter()
+        .any(|s| s.status().intersects(blocking));
+    if has_changes {
+        return Err(LeviathanError::OperationFailed(
+            "Working directory has uncommitted changes. Commit or stash them first.".to_string(),
+        ));
     }
 
     // Find the onto commit
@@ -1563,8 +1572,8 @@ mod tests {
         assert_ne!(parent.id(), initial_oid);
     }
 
-    // Like `git rebase`, a dirty working tree must abort the rebase up front,
-    // leaving no in-progress rebase state behind.
+    // Like `git rebase`, a modification to a tracked file must abort the rebase
+    // up front, leaving no in-progress rebase state behind.
     #[tokio::test]
     async fn test_rebase_dirty_working_tree_rejected() {
         let repo = TestRepo::with_initial_commit();
@@ -1580,13 +1589,13 @@ mod tests {
 
         repo.checkout_branch("feature");
 
-        // Introduce an uncommitted change.
-        repo.create_file("dirty.txt", "uncommitted");
+        // Modify a TRACKED file (feature.txt) — canonical git refuses this.
+        repo.create_file("feature.txt", "uncommitted change");
 
         let result = rebase(repo.path_str(), initial_branch.clone()).await;
         assert!(
             result.is_err(),
-            "rebase must be rejected when the working tree is dirty"
+            "rebase must be rejected when a tracked file has uncommitted changes"
         );
 
         // No rebase state should have been created.
@@ -1594,6 +1603,34 @@ mod tests {
         assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
         assert!(!repo.path.join(".git/rebase-merge").exists());
         assert!(!repo.path.join(".git/rebase-apply").exists());
+    }
+
+    // Canonical `git rebase` proceeds when only untracked files are present — the
+    // dirty-tree guard must not block on them.
+    #[tokio::test]
+    async fn test_rebase_allows_untracked_files() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature commit", &[("feature.txt", "feature")]);
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main commit", &[("main.txt", "main")]);
+
+        repo.checkout_branch("feature");
+
+        // A brand-new untracked file must NOT block the rebase.
+        repo.create_file("scratch.txt", "untracked");
+
+        let result = rebase(repo.path_str(), initial_branch.clone()).await;
+        assert!(
+            result.is_ok(),
+            "rebase must not be blocked by an untracked file: {result:?}"
+        );
+        // The untracked file survives the rebase.
+        assert!(repo.path.join("scratch.txt").exists());
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -462,6 +462,27 @@ async fn commit_merge_signed(path: &str, message: &str, is_squash: bool) -> Resu
 pub async fn rebase(path: String, onto: String) -> Result<()> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
+    // Like canonical `git rebase`, refuse up front if another operation is in
+    // progress or the working tree is dirty, instead of starting the rebase
+    // and failing partway through with a misleading libgit2 error.
+    if repo.state() != git2::RepositoryState::Clean {
+        return Err(LeviathanError::OperationFailed(
+            "Another operation is in progress".to_string(),
+        ));
+    }
+    let statuses = repo.statuses(None)?;
+    if !statuses.is_empty() {
+        let has_changes = statuses
+            .iter()
+            .any(|s| s.status() != git2::Status::IGNORED && s.status() != git2::Status::CURRENT);
+        if has_changes {
+            return Err(LeviathanError::OperationFailed(
+                "Working directory has uncommitted changes. Commit or stash them first."
+                    .to_string(),
+            ));
+        }
+    }
+
     // Find the onto commit
     let onto_ref = repo
         .find_reference(&format!("refs/heads/{}", onto))
@@ -1540,6 +1561,39 @@ mod tests {
 
         assert_eq!(parent.id(), main_oid);
         assert_ne!(parent.id(), initial_oid);
+    }
+
+    // Like `git rebase`, a dirty working tree must abort the rebase up front,
+    // leaving no in-progress rebase state behind.
+    #[tokio::test]
+    async fn test_rebase_dirty_working_tree_rejected() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        // Create a feature branch that diverges so a real rebase would run.
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature commit", &[("feature.txt", "feature")]);
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main commit", &[("main.txt", "main")]);
+
+        repo.checkout_branch("feature");
+
+        // Introduce an uncommitted change.
+        repo.create_file("dirty.txt", "uncommitted");
+
+        let result = rebase(repo.path_str(), initial_branch.clone()).await;
+        assert!(
+            result.is_err(),
+            "rebase must be rejected when the working tree is dirty"
+        );
+
+        // No rebase state should have been created.
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        assert!(!repo.path.join(".git/rebase-merge").exists());
+        assert!(!repo.path.join(".git/rebase-apply").exists());
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/tags.rs
+++ b/src-tauri/src/commands/tags.rs
@@ -44,10 +44,24 @@ fn tag_signing_enabled(repo: &git2::Repository) -> bool {
 /// libgit2's `Repository::tag` cannot sign, so honoring tag.gpgsign requires
 /// shelling out. Errors (e.g. no signing key) surface to the user, exactly as
 /// `git tag -s` would refuse.
-fn create_signed_tag_cli(path: &str, name: &str, target: &str, message: &str) -> Result<()> {
+fn create_signed_tag_cli(
+    path: &str,
+    name: &str,
+    target: &str,
+    message: &str,
+    force: bool,
+) -> Result<()> {
+    // `force` (`-f`) is only for editing an existing tag in place (atomic
+    // replace). Creating a tag must NOT force, so a duplicate name errors just
+    // like the unsigned path and canonical `git tag`.
+    let mut args = vec!["tag", "-s"];
+    if force {
+        args.push("-f");
+    }
+    args.extend(["-m", message, name, target]);
     let output = crate::utils::create_command("git")
         .current_dir(path)
-        .args(["tag", "-s", "-f", "-m", message, name, target])
+        .args(&args)
         .output()
         .map_err(|e| LeviathanError::OperationFailed(format!("Failed to run git tag: {}", e)))?;
     if !output.status.success() {
@@ -182,7 +196,7 @@ pub async fn create_tag(
         // must shell out to `git tag -s` to honor the configured signing.
         let signature = repo.signature()?;
         if tag_signing_enabled(&repo) {
-            create_signed_tag_cli(&path, &name, &target_oid.to_string(), msg)?;
+            create_signed_tag_cli(&path, &name, &target_oid.to_string(), msg, false)?;
         } else {
             repo.tag(&name, &target_obj, &signature, msg, false)?;
         }
@@ -250,8 +264,9 @@ pub async fn push_tag(
     Ok(())
 }
 
-/// Edit an annotated tag's message
-/// This works by deleting the old tag and creating a new one with the updated message
+/// Edit an annotated tag's message.
+/// The tag is overwritten in place (force) so the operation is atomic: a signing
+/// failure can't leave the old tag deleted and unrecoverable (tags have no reflog).
 #[command]
 pub async fn edit_tag_message(path: String, name: String, message: String) -> Result<TagDetails> {
     let repo = git2::Repository::open(Path::new(&path))?;
@@ -280,7 +295,7 @@ pub async fn edit_tag_message(path: String, name: String, message: String) -> Re
     // `git tag -s` when signing is enabled).
     let signature = repo.signature()?;
     let new_tag_oid = if tag_signing_enabled(&repo) {
-        create_signed_tag_cli(&path, &name, &target_oid.to_string(), &message)?;
+        create_signed_tag_cli(&path, &name, &target_oid.to_string(), &message, true)?;
         repo.refname_to_id(&format!("refs/tags/{}", name))?
     } else {
         repo.tag(&name, &target_obj, &signature, &message, true)?

--- a/src-tauri/src/commands/tags.rs
+++ b/src-tauri/src/commands/tags.rs
@@ -47,7 +47,7 @@ fn tag_signing_enabled(repo: &git2::Repository) -> bool {
 fn create_signed_tag_cli(path: &str, name: &str, target: &str, message: &str) -> Result<()> {
     let output = crate::utils::create_command("git")
         .current_dir(path)
-        .args(["tag", "-s", "-m", message, name, target])
+        .args(["tag", "-s", "-f", "-m", message, name, target])
         .output()
         .map_err(|e| LeviathanError::OperationFailed(format!("Failed to run git tag: {}", e)))?;
     if !output.status.success() {
@@ -272,17 +272,18 @@ pub async fn edit_tag_message(path: String, name: String, message: String) -> Re
     let target_oid = tag.target_id();
     let target_obj = repo.find_object(target_oid, None)?;
 
-    // Delete the old tag
-    repo.tag_delete(&name)?;
-
-    // Create new tag with updated message, honoring tag.gpgsign (libgit2 cannot
-    // sign, so fall back to `git tag -s` when signing is enabled).
+    // Replace the tag in place atomically. We do NOT delete the old tag first:
+    // annotated tags have no reflog, so a failure (e.g. signing refused) after
+    // deletion would be unrecoverable data loss. The force flag / `git tag -f`
+    // overwrites the existing tag only once the replacement is successfully
+    // created, honoring tag.gpgsign (libgit2 cannot sign, so fall back to
+    // `git tag -s` when signing is enabled).
     let signature = repo.signature()?;
     let new_tag_oid = if tag_signing_enabled(&repo) {
         create_signed_tag_cli(&path, &name, &target_oid.to_string(), &message)?;
         repo.refname_to_id(&format!("refs/tags/{}", name))?
     } else {
-        repo.tag(&name, &target_obj, &signature, &message, false)?
+        repo.tag(&name, &target_obj, &signature, &message, true)?
     };
 
     // Return the updated tag details
@@ -560,6 +561,47 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(fetched.message, Some("Updated message".to_string()));
+    }
+
+    // Editing must be atomic: the annotated tag must never be deleted before
+    // its replacement exists (tags have no reflog, so a failed re-create would
+    // be unrecoverable). Verify the tag survives, keeps its target, and carries
+    // the new message.
+    #[tokio::test]
+    async fn test_edit_tag_message_is_atomic() {
+        let repo = TestRepo::with_initial_commit();
+        let head_oid = repo.head_oid();
+
+        create_tag(
+            repo.path_str(),
+            "v1.0.0".to_string(),
+            None,
+            Some("Original message".to_string()),
+        )
+        .await
+        .unwrap();
+
+        edit_tag_message(
+            repo.path_str(),
+            "v1.0.0".to_string(),
+            "Updated message".to_string(),
+        )
+        .await
+        .unwrap();
+
+        // The tag reference must still exist after the edit.
+        let git_repo = repo.repo();
+        let ref_oid = git_repo
+            .refname_to_id("refs/tags/v1.0.0")
+            .expect("tag must still exist after editing its message");
+        let tag = git_repo
+            .find_tag(ref_oid)
+            .expect("tag must still be an annotated tag");
+
+        // It must still point at the original target commit...
+        assert_eq!(tag.target_id(), head_oid);
+        // ...and carry the new message.
+        assert_eq!(tag.message().unwrap(), Some("Updated message"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -174,7 +174,6 @@ pub async fn open_in_editor(file_path: String) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::TestRepo;
 
     #[tokio::test]
     async fn test_open_terminal_invalid_path() {

--- a/src-tauri/src/commands/unified_profiles.rs
+++ b/src-tauri/src/commands/unified_profiles.rs
@@ -575,10 +575,9 @@ pub async fn unassign_unified_profile_from_repository(path: String) -> Result<()
 /// should be used (and any stale local `gpg.format` cleared).
 fn detect_gpg_format(signing_key: &str) -> Option<&'static str> {
     let key = signing_key.trim();
-    // Mirrors the SSH key-shape prefixes git accepts for `user.signingkey`
-    // when `gpg.format=ssh`. Keep in sync with gpg.rs::ssh_key_is_usable.
-    const SSH_PREFIXES: &[&str] = &["ssh-", "ecdsa-sha2-", "sk-ssh-", "sk-ecdsa-", "key::"];
-    if SSH_PREFIXES.iter().any(|p| key.starts_with(p)) || key.ends_with(".pub") {
+    // Reuse gpg.rs's single source of truth for SSH key-shape detection, plus a
+    // `.pub` path (a public-key file also implies ssh format).
+    if crate::commands::gpg::is_ssh_literal_key(key) || key.ends_with(".pub") {
         Some("ssh")
     } else {
         None

--- a/src-tauri/src/commands/unified_profiles.rs
+++ b/src-tauri/src/commands/unified_profiles.rs
@@ -566,18 +566,34 @@ pub async fn unassign_unified_profile_from_repository(path: String) -> Result<()
     Ok(())
 }
 
-/// Apply a profile to a repository (set git config)
-#[command]
-pub async fn apply_unified_profile(path: String, profile_id: String) -> Result<()> {
-    let mut config = load_unified_profiles_config()?;
+/// Detect the `gpg.format` git should use for a given signing key.
+///
+/// Returns `Some("ssh")` when the key looks like an SSH signing key — either an
+/// inline OpenSSH public key (e.g. `ssh-ed25519 ...`, `ssh-rsa ...`) or a path
+/// to a `.pub` file. Returns `None` otherwise, meaning git's default `openpgp`
+/// format should be used (and any stale local `gpg.format` cleared).
+fn detect_gpg_format(signing_key: &str) -> Option<&'static str> {
+    let key = signing_key.trim();
+    if key.starts_with("ssh-") || key.ends_with(".pub") {
+        Some("ssh")
+    } else {
+        None
+    }
+}
 
-    let profile = config
-        .get_profile(&profile_id)
-        .ok_or_else(|| LeviathanError::OperationFailed("Profile not found".to_string()))?
-        .clone();
-
-    let repo_path = Path::new(&path);
-
+/// Apply a profile's git identity (name, email, signing config) to a
+/// repository's local git config.
+///
+/// Signing behaviour:
+/// - With a non-empty signing key: sets `user.signingkey`, sets `gpg.format`
+///   locally to match the key type (`ssh` for SSH keys, otherwise `openpgp`),
+///   and enables `commit.gpgsign`. Without setting `gpg.format=ssh`, an SSH
+///   signing key would apply `gpgsign=true` while the format stayed `openpgp`,
+///   making subsequent commits fail to sign.
+/// - Without a signing key: clears the local `user.signingkey`/`gpg.format`
+///   and explicitly sets `commit.gpgsign=false` so a globally-enabled
+///   `commit.gpgsign=true` cannot force commits to sign with a missing key.
+fn apply_profile_git_config(repo_path: &Path, profile: &UnifiedProfile) -> Result<()> {
     // Set user.name
     run_git_config(
         Some(repo_path),
@@ -590,20 +606,47 @@ pub async fn apply_unified_profile(path: String, profile_id: String) -> Result<(
         &["--local", "user.email", &profile.git_email],
     )?;
 
-    // Set signing key if specified
-    if let Some(ref signing_key) = profile.signing_key {
-        if !signing_key.is_empty() {
+    match profile.signing_key.as_deref() {
+        Some(signing_key) if !signing_key.is_empty() => {
             run_git_config(
                 Some(repo_path),
                 &["--local", "user.signingkey", signing_key],
             )?;
+            // Set gpg.format explicitly so the key signs correctly. Git's
+            // default is openpgp, so an SSH key with gpgsign=true would fail to
+            // sign without gpg.format=ssh. We write it locally in both cases so
+            // a globally-configured gpg.format cannot mismatch the profile's
+            // key (e.g. a global gpg.format=ssh would break an OpenPGP key).
+            let fmt = detect_gpg_format(signing_key).unwrap_or("openpgp");
+            run_git_config(Some(repo_path), &["--local", "gpg.format", fmt])?;
             run_git_config(Some(repo_path), &["--local", "commit.gpgsign", "true"])?;
         }
-    } else {
-        // Unset signing key if not specified
-        let _ = run_git_config(Some(repo_path), &["--local", "--unset", "user.signingkey"]);
-        let _ = run_git_config(Some(repo_path), &["--local", "--unset", "commit.gpgsign"]);
+        _ => {
+            // No signing key: unset the local key/format and explicitly disable
+            // signing so a globally-enabled commit.gpgsign=true does not force
+            // commits to sign with a missing local key.
+            let _ = run_git_config(Some(repo_path), &["--local", "--unset", "user.signingkey"]);
+            let _ = run_git_config(Some(repo_path), &["--local", "--unset", "gpg.format"]);
+            run_git_config(Some(repo_path), &["--local", "commit.gpgsign", "false"])?;
+        }
     }
+
+    Ok(())
+}
+
+/// Apply a profile to a repository (set git config)
+#[command]
+pub async fn apply_unified_profile(path: String, profile_id: String) -> Result<()> {
+    let mut config = load_unified_profiles_config()?;
+
+    let profile = config
+        .get_profile(&profile_id)
+        .ok_or_else(|| LeviathanError::OperationFailed("Profile not found".to_string()))?
+        .clone();
+
+    let repo_path = Path::new(&path);
+
+    apply_profile_git_config(repo_path, &profile)?;
 
     // Save the assignment
     config.assign_profile(path, profile_id);
@@ -1206,6 +1249,204 @@ mod tests {
     use crate::models::{
         workflow::GitProfile, IntegrationAccountsConfig, IntegrationConfig, ProfilesConfig,
     };
+    use crate::test_utils::TestRepo;
+
+    // =========================================================================
+    // Signing config application (gpg.format / commit.gpgsign)
+    // =========================================================================
+
+    #[test]
+    fn test_detect_gpg_format() {
+        assert_eq!(detect_gpg_format("ssh-ed25519 AAAAC3..."), Some("ssh"));
+        assert_eq!(detect_gpg_format("ssh-rsa AAAAB3..."), Some("ssh"));
+        assert_eq!(
+            detect_gpg_format("/home/me/.ssh/id_ed25519.pub"),
+            Some("ssh")
+        );
+        assert_eq!(detect_gpg_format("  ssh-ed25519 key  "), Some("ssh"));
+        // OpenPGP-style key IDs are not SSH.
+        assert_eq!(detect_gpg_format("ABCDEF1234567890"), None);
+        assert_eq!(detect_gpg_format(""), None);
+    }
+
+    #[test]
+    fn test_apply_profile_ssh_signing_sets_gpg_format_ssh() {
+        let repo = TestRepo::with_initial_commit();
+        let mut profile = UnifiedProfile::new(
+            "Work".to_string(),
+            "Alice".to_string(),
+            "alice@work.com".to_string(),
+        );
+        profile.signing_key = Some("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAExampleKey".to_string());
+
+        apply_profile_git_config(repo.path.as_path(), &profile).expect("apply should succeed");
+
+        // SSH key -> gpg.format=ssh and gpgsign enabled.
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "gpg.format"]
+            )
+            .unwrap(),
+            "ssh"
+        );
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "commit.gpgsign"]
+            )
+            .unwrap(),
+            "true"
+        );
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "user.signingkey"]
+            )
+            .unwrap(),
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAExampleKey"
+        );
+    }
+
+    #[test]
+    fn test_apply_profile_pub_path_sets_gpg_format_ssh() {
+        let repo = TestRepo::with_initial_commit();
+        let mut profile = UnifiedProfile::new(
+            "Work".to_string(),
+            "Alice".to_string(),
+            "alice@work.com".to_string(),
+        );
+        profile.signing_key = Some("/home/alice/.ssh/id_ed25519.pub".to_string());
+
+        apply_profile_git_config(repo.path.as_path(), &profile).expect("apply should succeed");
+
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "gpg.format"]
+            )
+            .unwrap(),
+            "ssh"
+        );
+    }
+
+    #[test]
+    fn test_apply_profile_openpgp_key_leaves_format_default() {
+        let repo = TestRepo::with_initial_commit();
+        let mut profile = UnifiedProfile::new(
+            "Work".to_string(),
+            "Alice".to_string(),
+            "alice@work.com".to_string(),
+        );
+        profile.signing_key = Some("ABCDEF1234567890".to_string());
+
+        apply_profile_git_config(repo.path.as_path(), &profile).expect("apply should succeed");
+
+        // Non-SSH key -> gpg.format set explicitly to openpgp locally, signing on.
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "gpg.format"]
+            )
+            .unwrap(),
+            "openpgp"
+        );
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "commit.gpgsign"]
+            )
+            .unwrap(),
+            "true"
+        );
+    }
+
+    #[test]
+    fn test_apply_profile_no_signing_disables_gpgsign() {
+        let repo = TestRepo::with_initial_commit();
+        let profile = UnifiedProfile::new(
+            "Personal".to_string(),
+            "Alice".to_string(),
+            "alice@home.com".to_string(),
+        );
+        // No signing key on this profile.
+        assert!(profile.signing_key.is_none());
+
+        apply_profile_git_config(repo.path.as_path(), &profile).expect("apply should succeed");
+
+        // Explicit local override so a globally-enabled gpgsign cannot sign.
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "commit.gpgsign"]
+            )
+            .unwrap(),
+            "false"
+        );
+        // Local signing key and format cleared.
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "user.signingkey"]
+            )
+            .unwrap(),
+            ""
+        );
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "gpg.format"]
+            )
+            .unwrap(),
+            ""
+        );
+    }
+
+    #[test]
+    fn test_apply_profile_switch_ssh_to_none_clears_ssh_format() {
+        // Applying an SSH profile then a no-signing profile must clear the
+        // stale gpg.format=ssh and disable signing.
+        let repo = TestRepo::with_initial_commit();
+
+        let mut ssh_profile = UnifiedProfile::new(
+            "Work".to_string(),
+            "Alice".to_string(),
+            "alice@work.com".to_string(),
+        );
+        ssh_profile.signing_key = Some("ssh-ed25519 AAAAExampleKey".to_string());
+        apply_profile_git_config(repo.path.as_path(), &ssh_profile).unwrap();
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "gpg.format"]
+            )
+            .unwrap(),
+            "ssh"
+        );
+
+        let none_profile = UnifiedProfile::new(
+            "Personal".to_string(),
+            "Alice".to_string(),
+            "alice@home.com".to_string(),
+        );
+        apply_profile_git_config(repo.path.as_path(), &none_profile).unwrap();
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "gpg.format"]
+            )
+            .unwrap(),
+            ""
+        );
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "commit.gpgsign"]
+            )
+            .unwrap(),
+            "false"
+        );
+    }
 
     // Helper: build a minimal GitProfile for use in migration tests.
     fn make_git_profile(id: &str, name: &str) -> GitProfile {

--- a/src-tauri/src/commands/unified_profiles.rs
+++ b/src-tauri/src/commands/unified_profiles.rs
@@ -568,13 +568,17 @@ pub async fn unassign_unified_profile_from_repository(path: String) -> Result<()
 
 /// Detect the `gpg.format` git should use for a given signing key.
 ///
-/// Returns `Some("ssh")` when the key looks like an SSH signing key — either an
-/// inline OpenSSH public key (e.g. `ssh-ed25519 ...`, `ssh-rsa ...`) or a path
-/// to a `.pub` file. Returns `None` otherwise, meaning git's default `openpgp`
-/// format should be used (and any stale local `gpg.format` cleared).
+/// Returns `Some("ssh")` when the key looks like an SSH signing key — an inline
+/// OpenSSH public key of any type (`ssh-ed25519`, `ssh-rsa`, `ecdsa-sha2-*`,
+/// FIDO2 `sk-ssh-*`/`sk-ecdsa-*`), git's `key::<literal>` form, or a path to a
+/// `.pub` file. Returns `None` otherwise, meaning git's default `openpgp` format
+/// should be used (and any stale local `gpg.format` cleared).
 fn detect_gpg_format(signing_key: &str) -> Option<&'static str> {
     let key = signing_key.trim();
-    if key.starts_with("ssh-") || key.ends_with(".pub") {
+    // Mirrors the SSH key-shape prefixes git accepts for `user.signingkey`
+    // when `gpg.format=ssh`. Keep in sync with gpg.rs::ssh_key_is_usable.
+    const SSH_PREFIXES: &[&str] = &["ssh-", "ecdsa-sha2-", "sk-ssh-", "sk-ecdsa-", "key::"];
+    if SSH_PREFIXES.iter().any(|p| key.starts_with(p)) || key.ends_with(".pub") {
         Some("ssh")
     } else {
         None
@@ -1264,6 +1268,20 @@ mod tests {
             Some("ssh")
         );
         assert_eq!(detect_gpg_format("  ssh-ed25519 key  "), Some("ssh"));
+        // ECDSA, FIDO2/security-key, and git's key:: literal forms are all SSH.
+        assert_eq!(
+            detect_gpg_format("ecdsa-sha2-nistp256 AAAAE2..."),
+            Some("ssh")
+        );
+        assert_eq!(
+            detect_gpg_format("sk-ssh-ed25519@openssh.com AAAA..."),
+            Some("ssh")
+        );
+        assert_eq!(
+            detect_gpg_format("sk-ecdsa-sha2-nistp256@openssh.com AAAA..."),
+            Some("ssh")
+        );
+        assert_eq!(detect_gpg_format("key::ssh-ed25519 AAAA..."), Some("ssh"));
         // OpenPGP-style key IDs are not SSH.
         assert_eq!(detect_gpg_format("ABCDEF1234567890"), None);
         assert_eq!(detect_gpg_format(""), None);

--- a/src-tauri/src/services/ai/mod.rs
+++ b/src-tauri/src/services/ai/mod.rs
@@ -79,7 +79,7 @@ impl AiProviderType {
             AiProviderType::Ollama => "llama3.2",
             AiProviderType::LmStudio => "local-model",
             AiProviderType::OpenAi => "gpt-4o-mini",
-            AiProviderType::Anthropic => "claude-sonnet-4-20250514",
+            AiProviderType::Anthropic => "claude-haiku-4-5",
             AiProviderType::GithubCopilot => "gpt-4o",
             AiProviderType::GoogleGemini => "gemini-2.0-flash",
             AiProviderType::LocalInference => "local",
@@ -733,13 +733,17 @@ impl AiService {
             }
         }
 
-        // Fall back to any other available provider
-        for (pt, provider) in &self.providers {
-            if *pt == AiProviderType::LocalInference {
+        // Fall back to any other available provider, in a deterministic order.
+        // Iterating `self.providers` (a HashMap) directly would pick an
+        // unpredictable provider across runs when several have keys configured.
+        for pt in AiProviderType::all() {
+            if pt == AiProviderType::LocalInference {
                 continue; // Already checked above
             }
-            if provider.is_available().await {
-                return Some((provider.as_ref(), *pt));
+            if let Some(provider) = self.providers.get(&pt) {
+                if provider.is_available().await {
+                    return Some((provider.as_ref(), pt));
+                }
             }
         }
 

--- a/src-tauri/src/services/ai/providers/anthropic.rs
+++ b/src-tauri/src/services/ai/providers/anthropic.rs
@@ -38,12 +38,7 @@ struct ContentBlock {
 }
 
 /// Available Anthropic models
-const ANTHROPIC_MODELS: &[&str] = &[
-    "claude-sonnet-4-20250514",
-    "claude-3-5-sonnet-20241022",
-    "claude-3-5-haiku-20241022",
-    "claude-3-opus-20240229",
-];
+const ANTHROPIC_MODELS: &[&str] = &["claude-sonnet-5", "claude-opus-4-8", "claude-haiku-4-5"];
 
 /// Anthropic Claude provider implementation
 pub struct AnthropicProvider {
@@ -261,8 +256,19 @@ mod tests {
 
     #[test]
     fn test_anthropic_models() {
-        assert!(ANTHROPIC_MODELS.contains(&"claude-sonnet-4-20250514"));
-        assert!(ANTHROPIC_MODELS.contains(&"claude-3-5-sonnet-20241022"));
+        assert!(ANTHROPIC_MODELS.contains(&"claude-sonnet-5"));
+        assert!(ANTHROPIC_MODELS.contains(&"claude-opus-4-8"));
+        // Guard against regressions to retired model ids that 404 at the API.
+        assert!(!ANTHROPIC_MODELS.contains(&"claude-sonnet-4-20250514"));
+    }
+
+    #[test]
+    fn test_default_model_is_current() {
+        // The default must be a non-retired id, since there is no model-selection UI.
+        assert_eq!(
+            AiProviderType::Anthropic.default_model(),
+            "claude-haiku-4-5"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/credentials_service.rs
+++ b/src-tauri/src/services/credentials_service.rs
@@ -99,10 +99,14 @@ fn keyring_get(service: &str, account: &str) -> Option<String> {
 }
 
 /// Store a password in the keyring.
-/// On macOS uses the `security` CLI with `-A` to allow any application to access
-/// the item without triggering authorization prompts. The password is sent on
-/// stdin (via `-w` with no value) so it does NOT appear in the process argv,
-/// where any other process under the same user could read it via `ps`.
+/// On macOS uses the `security` CLI. In **debug** builds `-A` (allow any
+/// application) is added for development convenience so frequent rebuilds don't
+/// trigger authorization prompts; in **release** builds it is omitted so the
+/// keychain entry is scoped to the signed application bundle (per-app
+/// isolation), mirroring `credentials::build_security_add_args`. The password
+/// is sent on stdin (via `-w` with no value) so it does NOT appear in the
+/// process argv, where any other process under the same user could read it via
+/// `ps`.
 fn keyring_set(service: &str, account: &str, password: &str) -> bool {
     #[cfg(target_os = "macos")]
     {
@@ -114,18 +118,32 @@ fn keyring_set(service: &str, account: &str, password: &str) -> bool {
             .args(["delete-generic-password", "-s", service, "-a", account])
             .output();
 
+        // `-A` allows any application without a prompt — debug builds only.
+        #[cfg(debug_assertions)]
+        let args: &[&str] = &[
+            "add-generic-password",
+            "-s",
+            service,
+            "-a",
+            account,
+            "-A",
+            "-U",
+            "-w",
+        ];
+        #[cfg(not(debug_assertions))]
+        let args: &[&str] = &[
+            "add-generic-password",
+            "-s",
+            service,
+            "-a",
+            account,
+            "-U",
+            "-w",
+        ];
+
         // `-w` last with no argument => read password from stdin.
         let mut child = match std::process::Command::new("security")
-            .args([
-                "add-generic-password",
-                "-s",
-                service,
-                "-a",
-                account,
-                "-A", // Allow any application to access without prompt
-                "-U",
-                "-w",
-            ])
+            .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/src-tauri/src/services/github_app.rs
+++ b/src-tauri/src/services/github_app.rs
@@ -34,7 +34,11 @@ pub struct InstallationToken {
 pub struct AppInstallation {
     pub id: u64,
     pub account: AppInstallationAccount,
+    // GitHub's API returns snake_case; keep camelCase for the FE (Serialize) but
+    // accept the API's snake_case on deserialize via aliases, or parsing fails.
+    #[serde(alias = "app_id")]
     pub app_id: u64,
+    #[serde(alias = "target_type")]
     pub target_type: String,
     pub permissions: serde_json::Value,
 }
@@ -47,6 +51,7 @@ pub struct AppInstallationAccount {
     pub id: u64,
     #[serde(rename = "type")]
     pub account_type: String,
+    #[serde(alias = "avatar_url")]
     pub avatar_url: Option<String>,
 }
 
@@ -247,6 +252,30 @@ mod tests {
         assert!(json.contains("12345"));
         assert!(json.contains("1000"));
         assert!(json.contains("1600"));
+    }
+
+    #[test]
+    fn test_app_installation_parses_github_snake_case() {
+        // GitHub's REST API returns snake_case; deserialization must accept it.
+        let body = r#"{
+            "id": 42,
+            "account": {"login": "octocat", "id": 1, "type": "User", "avatar_url": "https://x/y.png"},
+            "app_id": 99,
+            "target_type": "Organization",
+            "permissions": {"contents": "read"}
+        }"#;
+        let install: AppInstallation = serde_json::from_str(body).unwrap();
+        assert_eq!(install.app_id, 99);
+        assert_eq!(install.target_type, "Organization");
+        assert_eq!(
+            install.account.avatar_url.as_deref(),
+            Some("https://x/y.png")
+        );
+
+        // And it still serializes to camelCase for the frontend.
+        let json = serde_json::to_string(&install).unwrap();
+        assert!(json.contains("appId"));
+        assert!(json.contains("targetType"));
     }
 
     #[test]

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -841,4 +841,42 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
   });
+
+  describe('handleRefresh tab-switch race', () => {
+    it('does not write refreshed data into a different tab if the user switches during the IPC await', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
+      repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+      repositoryStore.getState().setActiveIndex(0);
+
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        (el as any).activeRepository = { repository: mockRepo('/repo/a', 'a') };
+
+        // Defer the open_repository resolution so we can switch tabs mid-flight.
+        let resolveOpen: (v: unknown) => void = () => {};
+        mockResponses['open_repository'] = () =>
+          new Promise((res) => {
+            resolveOpen = res;
+          });
+
+        const refreshPromise = (el as any).handleRefresh();
+        await new Promise((r) => setTimeout(r, 0));
+
+        // User switches to repo B while repo A's refresh is still in flight.
+        repositoryStore.getState().setActiveIndex(1);
+
+        // Repo A's fetch now resolves with (stale-for-B) repo A data.
+        resolveOpen(mockRepo('/repo/a', 'a-refreshed'));
+        await refreshPromise;
+
+        // Repo B's tab slot must still hold repo B — not repo A's identity.
+        const repoB = repositoryStore.getState().openRepositories[1];
+        expect(repoB.repository.path).to.equal('/repo/b');
+        expect(repoB.repository.name).to.equal('b');
+      } finally {
+        el.remove();
+      }
+    });
+  });
 });

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2125,9 +2125,17 @@ export class AppShell extends LitElement {
     try {
       // Refresh the repository state (e.g., after cherry-pick, merge, rebase)
       if (this.activeRepository) {
-        const result = await gitService.openRepository({ path: this.activeRepository.repository.path });
+        // Capture the path before awaiting: if the user switches tabs during the
+        // IPC round-trip, updateActiveRepository would otherwise write repo A's
+        // data into repo B's (now-active) tab slot, corrupting its identity.
+        const refreshingPath = this.activeRepository.repository.path;
+        const result = await gitService.openRepository({ path: refreshingPath });
         if (result.success && result.data) {
-          repositoryStore.getState().updateActiveRepository(result.data);
+          if (
+            repositoryStore.getState().getActiveRepository()?.repository.path === refreshingPath
+          ) {
+            repositoryStore.getState().updateActiveRepository(result.data);
+          }
         } else if (!result.success) {
           showToast(result.error?.message ?? 'Failed to refresh repository', 'error');
         }

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -1065,4 +1065,28 @@ describe('lv-azure-devops-dialog', () => {
       expect(deleteBtn!.disabled).to.equal(true);
     });
   });
+
+  describe('load-failure feedback', () => {
+    it('surfaces an error banner when loading work items fails (parity with other providers)', async () => {
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dialog = el as any;
+      dialog.detectedRepo = { organization: 'org', project: 'proj', repo: 'r' };
+      dialog.connectionStatus = { connected: true };
+      dialog.error = null;
+
+      mockInvoke = async (command: string) => {
+        if (command === 'query_ado_work_items') throw new Error('unauthorized');
+        return null;
+      };
+
+      await dialog.loadWorkItems('tok');
+
+      expect(dialog.error, 'a failed work-items load is surfaced').to.contain('unauthorized');
+    });
+  });
 });

--- a/src/components/dialogs/__tests__/lv-github-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-github-dialog.test.ts
@@ -1071,4 +1071,32 @@ describe('lv-github-dialog', () => {
       expect((el as unknown as { isAddingAccount: boolean }).isAddingAccount).to.equal(false);
     });
   });
+
+  describe('load-failure feedback', () => {
+    it('surfaces a toast when loading issues fails instead of silently swallowing it', async () => {
+      const el = await fixture<LvGitHubDialog>(html`
+        <lv-github-dialog .open=${true}></lv-github-dialog>
+      `);
+      await waitForLoad(el);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dialog = el as any;
+      dialog.detectedRepo = { owner: 'octocat', repo: 'hello' };
+      dialog.connectionStatus = { connected: true };
+
+      mockInvoke = async (command: string) => {
+        if (command === 'list_issues' || command === 'list_github_issues') {
+          throw new Error('rate limit exceeded');
+        }
+        return null;
+      };
+      uiStore.setState({ toasts: [] });
+
+      await dialog.loadIssues('tok');
+
+      const errorToast = uiStore.getState().toasts.find((t) => t.type === 'error');
+      expect(errorToast, 'a failed issues load is surfaced').to.exist;
+      expect(errorToast!.message).to.contain('rate limit exceeded');
+    });
+  });
 });

--- a/src/components/dialogs/__tests__/lv-github-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-github-dialog.test.ts
@@ -1073,7 +1073,7 @@ describe('lv-github-dialog', () => {
   });
 
   describe('load-failure feedback', () => {
-    it('surfaces a toast when loading issues fails instead of silently swallowing it', async () => {
+    it('surfaces an error banner when loading issues fails instead of silently swallowing it', async () => {
       const el = await fixture<LvGitHubDialog>(html`
         <lv-github-dialog .open=${true}></lv-github-dialog>
       `);
@@ -1083,6 +1083,7 @@ describe('lv-github-dialog', () => {
       const dialog = el as any;
       dialog.detectedRepo = { owner: 'octocat', repo: 'hello' };
       dialog.connectionStatus = { connected: true };
+      dialog.error = null;
 
       mockInvoke = async (command: string) => {
         if (command === 'list_issues' || command === 'list_github_issues') {
@@ -1090,13 +1091,12 @@ describe('lv-github-dialog', () => {
         }
         return null;
       };
-      uiStore.setState({ toasts: [] });
 
       await dialog.loadIssues('tok');
 
-      const errorToast = uiStore.getState().toasts.find((t) => t.type === 'error');
-      expect(errorToast, 'a failed issues load is surfaced').to.exist;
-      expect(errorToast!.message).to.contain('rate limit exceeded');
+      // Surfaced via the shared error banner (not a toast), so batched load
+      // failures collapse to a single message rather than stacking.
+      expect(dialog.error, 'a failed issues load is surfaced').to.contain('rate limit exceeded');
     });
   });
 });

--- a/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
@@ -1691,6 +1691,30 @@ describe('lv-profile-manager-dialog', () => {
       expect((applyCalls[0].args as { path: string; profileId: string }).path).to.equal('/test/repo');
       expect((applyCalls[0].args as { path: string; profileId: string }).profileId).to.equal('profile-1');
     });
+
+    it('dispatches repository-refresh after a successful apply', async () => {
+      const el = await renderDialog({ repoPath: '/test/repo' });
+
+      let refreshed = false;
+      const listener = () => { refreshed = true; };
+      window.addEventListener('repository-refresh', listener);
+
+      try {
+        const firstItem = el.shadowRoot!.querySelectorAll('.profile-item')[0];
+        const applyBtn = Array.from(firstItem.querySelectorAll('.action-btn')).find(
+          (btn) => btn.getAttribute('title') === 'Apply to current repository'
+        ) as HTMLButtonElement;
+        applyBtn.click();
+        await new Promise((r) => setTimeout(r, 100));
+        await el.updateComplete;
+
+        // Without the refresh event the displayed git identity would be stale
+        // until the tab is re-switched.
+        expect(refreshed).to.be.true;
+      } finally {
+        window.removeEventListener('repository-refresh', listener);
+      }
+    });
   });
 
   // ── Default checkbox ───────────────────────────────────────────────────

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -993,9 +993,11 @@ export class LvAzureDevOpsDialog extends LitElement {
 
       if (result.success && result.data) {
         this.workItems = result.data;
+      } else if (!result.success) {
+        this.error = result.error?.message ?? 'Failed to load work items';
       }
-    } catch {
-      // Silent fail for work items
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load work items';
     }
   }
 
@@ -1013,9 +1015,11 @@ export class LvAzureDevOpsDialog extends LitElement {
 
       if (result.success && result.data) {
         this.pipelineRuns = result.data;
+      } else if (!result.success) {
+        this.error = result.error?.message ?? 'Failed to load pipeline runs';
       }
-    } catch {
-      // Silent fail for pipelines
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load pipeline runs';
     }
   }
 

--- a/src/components/dialogs/lv-bitbucket-dialog.ts
+++ b/src/components/dialogs/lv-bitbucket-dialog.ts
@@ -1006,9 +1006,13 @@ export class LvBitbucketDialog extends LitElement {
 
       if (result.success && result.data) {
         this.issues = result.data;
+      } else if (!result.success) {
+        // The backend returns an empty list when issues are disabled (404); a
+        // non-404 error (bad token/server) is surfaced rather than swallowed.
+        this.error = result.error?.message ?? 'Failed to load issues';
       }
-    } catch {
-      // Silent fail - issues might not be enabled
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load issues';
     }
   }
 
@@ -1024,9 +1028,11 @@ export class LvBitbucketDialog extends LitElement {
 
       if (result.success && result.data) {
         this.pipelines = result.data;
+      } else if (!result.success) {
+        this.error = result.error?.message ?? 'Failed to load pipelines';
       }
-    } catch {
-      // Silent fail - pipelines might not be enabled
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load pipelines';
     }
   }
 

--- a/src/components/dialogs/lv-github-dialog.ts
+++ b/src/components/dialogs/lv-github-dialog.ts
@@ -1130,9 +1130,11 @@ export class LvGitHubDialog extends LitElement {
 
       if (result.success && result.data) {
         this.workflowRuns = result.data;
+      } else if (!result.success) {
+        showToast(result.error?.message ?? 'Failed to load workflow runs', 'error');
       }
-    } catch {
-      // Silently fail for workflow runs
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to load workflow runs', 'error');
     }
   }
 
@@ -1152,9 +1154,11 @@ export class LvGitHubDialog extends LitElement {
 
       if (result.success && result.data) {
         this.issues = result.data;
+      } else if (!result.success) {
+        showToast(result.error?.message ?? 'Failed to load issues', 'error');
       }
-    } catch {
-      // Silently fail for issues
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to load issues', 'error');
     }
   }
 
@@ -1172,9 +1176,11 @@ export class LvGitHubDialog extends LitElement {
 
       if (result.success && result.data) {
         this.repoLabels = result.data;
+      } else if (!result.success) {
+        showToast(result.error?.message ?? 'Failed to load labels', 'error');
       }
-    } catch {
-      // Silently fail for labels
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to load labels', 'error');
     }
   }
 
@@ -1192,9 +1198,11 @@ export class LvGitHubDialog extends LitElement {
 
       if (result.success && result.data) {
         this.releases = result.data;
+      } else if (!result.success) {
+        showToast(result.error?.message ?? 'Failed to load releases', 'error');
       }
-    } catch {
-      // Silently fail for releases
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to load releases', 'error');
     }
   }
 

--- a/src/components/dialogs/lv-github-dialog.ts
+++ b/src/components/dialogs/lv-github-dialog.ts
@@ -1131,10 +1131,13 @@ export class LvGitHubDialog extends LitElement {
       if (result.success && result.data) {
         this.workflowRuns = result.data;
       } else if (!result.success) {
-        showToast(result.error?.message ?? 'Failed to load workflow runs', 'error');
+        // Use the shared error banner (like loadPullRequests) rather than a
+        // toast, so a shared failure across the batched loads doesn't stack
+        // four near-identical toasts on open.
+        this.error = result.error?.message ?? 'Failed to load workflow runs';
       }
     } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to load workflow runs', 'error');
+      this.error = err instanceof Error ? err.message : 'Failed to load workflow runs';
     }
   }
 
@@ -1155,10 +1158,10 @@ export class LvGitHubDialog extends LitElement {
       if (result.success && result.data) {
         this.issues = result.data;
       } else if (!result.success) {
-        showToast(result.error?.message ?? 'Failed to load issues', 'error');
+        this.error = result.error?.message ?? 'Failed to load issues';
       }
     } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to load issues', 'error');
+      this.error = err instanceof Error ? err.message : 'Failed to load issues';
     }
   }
 
@@ -1177,10 +1180,10 @@ export class LvGitHubDialog extends LitElement {
       if (result.success && result.data) {
         this.repoLabels = result.data;
       } else if (!result.success) {
-        showToast(result.error?.message ?? 'Failed to load labels', 'error');
+        this.error = result.error?.message ?? 'Failed to load labels';
       }
     } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to load labels', 'error');
+      this.error = err instanceof Error ? err.message : 'Failed to load labels';
     }
   }
 
@@ -1199,10 +1202,10 @@ export class LvGitHubDialog extends LitElement {
       if (result.success && result.data) {
         this.releases = result.data;
       } else if (!result.success) {
-        showToast(result.error?.message ?? 'Failed to load releases', 'error');
+        this.error = result.error?.message ?? 'Failed to load releases';
       }
     } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to load releases', 'error');
+      this.error = err instanceof Error ? err.message : 'Failed to load releases';
     }
   }
 

--- a/src/components/dialogs/lv-gitlab-dialog.ts
+++ b/src/components/dialogs/lv-gitlab-dialog.ts
@@ -954,9 +954,11 @@ export class LvGitLabDialog extends LitElement {
 
       if (result.success && result.data) {
         this.issues = result.data;
+      } else if (!result.success) {
+        this.error = result.error?.message ?? 'Failed to load issues';
       }
-    } catch {
-      // Silent fail
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load issues';
     }
   }
 
@@ -974,9 +976,11 @@ export class LvGitLabDialog extends LitElement {
 
       if (result.success && result.data) {
         this.pipelines = result.data;
+      } else if (!result.success) {
+        this.error = result.error?.message ?? 'Failed to load pipelines';
       }
-    } catch {
-      // Silent fail
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load pipelines';
     }
   }
 
@@ -993,9 +997,11 @@ export class LvGitLabDialog extends LitElement {
 
       if (result.success && result.data) {
         this.labels = result.data;
+      } else if (!result.success) {
+        this.error = result.error?.message ?? 'Failed to load labels';
       }
-    } catch {
-      // Silent fail
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load labels';
     }
   }
 

--- a/src/components/dialogs/lv-profile-manager-dialog.ts
+++ b/src/components/dialogs/lv-profile-manager-dialog.ts
@@ -1067,6 +1067,10 @@ export class LvProfileManagerDialog extends LitElement {
     try {
       await unifiedProfileService.applyUnifiedProfile(this.repoPath, profile.id);
       showToast(`Applied profile "${profile.name}"`, 'success');
+      // The applied git identity (footer/commit panel) is sourced from
+      // get_current_git_identity — refresh so it reflects the change now
+      // instead of only after the tab is re-switched.
+      window.dispatchEvent(new CustomEvent('repository-refresh'));
     } catch (error) {
       showToast(`Failed to apply profile: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error');
     }

--- a/src/components/dialogs/lv-profile-manager-dialog.ts
+++ b/src/components/dialogs/lv-profile-manager-dialog.ts
@@ -1067,8 +1067,9 @@ export class LvProfileManagerDialog extends LitElement {
     try {
       await unifiedProfileService.applyUnifiedProfile(this.repoPath, profile.id);
       showToast(`Applied profile "${profile.name}"`, 'success');
-      // The applied git identity (footer/commit panel) is sourced from
-      // get_current_git_identity — refresh so it reflects the change now
+      // Applying a profile rewrites the repo's local git identity/signing
+      // config. Refresh so listeners re-read it now (e.g. the commit panel
+      // reloads the author used for the {{author}} template placeholder)
       // instead of only after the tab is re-switched.
       window.dispatchEvent(new CustomEvent('repository-refresh'));
     } catch (error) {

--- a/src/components/sidebar/__tests__/lv-commit-panel.test.ts
+++ b/src/components/sidebar/__tests__/lv-commit-panel.test.ts
@@ -780,6 +780,24 @@ describe('lv-commit-panel', () => {
       expect(internal.generationError).to.be.null;
     });
 
+    it('reloads the author identity on repository-refresh (e.g. after a profile is applied)', async () => {
+      const el = await renderCommitPanel();
+      const internal = el as unknown as { cachedAuthor: string };
+
+      // Simulate applying a profile that rewrote the repo git identity.
+      mockInvoke = async (command: string) => {
+        if (command === 'get_user_identity') {
+          return { name: 'New Identity', email: 'new@example.com' };
+        }
+        return null;
+      };
+
+      window.dispatchEvent(new CustomEvent('repository-refresh'));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(internal.cachedAuthor).to.equal('New Identity');
+    });
+
     it('handleStageGroup isolates the group by unstaging the other groups', async () => {
       const el = await renderCommitPanel();
       const internal = el as unknown as {

--- a/src/components/sidebar/__tests__/lv-commit-panel.test.ts
+++ b/src/components/sidebar/__tests__/lv-commit-panel.test.ts
@@ -719,4 +719,92 @@ describe('lv-commit-panel', () => {
       }
     });
   });
+
+  // ── AI vibe-check / split analysis feedback ─────────────────────────────
+  describe('AI analysis feedback', () => {
+    it('handleVibeCheck surfaces an error and resets loading on failure', async () => {
+      const el = await renderCommitPanel();
+      const internal = el as unknown as {
+        handleVibeCheck: () => Promise<void>;
+        isAnalyzing: boolean;
+        generationError: string | null;
+      };
+      mockInvoke = async (command: string) => {
+        if (command === 'analyze_staged_changes') throw new Error('vibe boom');
+        return null;
+      };
+
+      await internal.handleVibeCheck();
+
+      expect(internal.isAnalyzing).to.be.false; // not stuck
+      expect(internal.generationError).to.contain('vibe boom');
+    });
+
+    it('handleSuggestSplits surfaces an error and resets loading on failure', async () => {
+      const el = await renderCommitPanel();
+      const internal = el as unknown as {
+        handleSuggestSplits: () => Promise<void>;
+        isAnalyzingSplit: boolean;
+        generationError: string | null;
+      };
+      mockInvoke = async (command: string) => {
+        if (command === 'suggest_commit_splits') throw new Error('split boom');
+        return null;
+      };
+
+      await internal.handleSuggestSplits();
+
+      expect(internal.isAnalyzingSplit).to.be.false; // not stuck
+      expect(internal.generationError).to.contain('split boom');
+    });
+
+    it('handleSuggestSplits gives feedback when no split is needed', async () => {
+      const el = await renderCommitPanel();
+      const internal = el as unknown as {
+        handleSuggestSplits: () => Promise<void>;
+        isAnalyzingSplit: boolean;
+        generationError: string | null;
+      };
+      mockInvoke = async (command: string) => {
+        if (command === 'suggest_commit_splits') {
+          return { shouldSplit: false, groups: [], explanation: 'cohesive' };
+        }
+        return null;
+      };
+
+      await internal.handleSuggestSplits();
+
+      // Success path: no error, loading cleared. (Toast feedback is emitted for
+      // the "no split needed" case.)
+      expect(internal.isAnalyzingSplit).to.be.false;
+      expect(internal.generationError).to.be.null;
+    });
+
+    it('handleStageGroup isolates the group by unstaging the other groups', async () => {
+      const el = await renderCommitPanel();
+      const internal = el as unknown as {
+        handleStageGroup: (files: string[]) => Promise<void>;
+        splitSuggestion: unknown;
+      };
+      internal.splitSuggestion = {
+        shouldSplit: true,
+        explanation: 'x',
+        groups: [
+          { files: ['a.ts', 'b.ts'], message: 'group a' },
+          { files: ['c.ts'], message: 'group b' },
+        ],
+      };
+      mockInvoke = async () => null; // all commands succeed
+
+      invokeHistory.length = 0;
+      await internal.handleStageGroup(['a.ts', 'b.ts']);
+
+      const unstage = invokeHistory.find(h => h.command === 'unstage_files');
+      const stage = invokeHistory.find(h => h.command === 'stage_files');
+      expect(unstage, 'unstages other group files').to.exist;
+      expect((unstage!.args as { paths: string[] }).paths).to.deep.equal(['c.ts']);
+      expect(stage, 'stages this group').to.exist;
+      expect((stage!.args as { paths: string[] }).paths).to.deep.equal(['a.ts', 'b.ts']);
+    });
+  });
 });

--- a/src/components/sidebar/__tests__/lv-commit-panel.test.ts
+++ b/src/components/sidebar/__tests__/lv-commit-panel.test.ts
@@ -798,29 +798,34 @@ describe('lv-commit-panel', () => {
       expect(internal.cachedAuthor).to.equal('New Identity');
     });
 
-    it('handleStageGroup isolates the group by unstaging the other groups', async () => {
+    it('handleStageGroup isolates the group by unstaging every other staged file', async () => {
       const el = await renderCommitPanel();
       const internal = el as unknown as {
         handleStageGroup: (files: string[]) => Promise<void>;
-        splitSuggestion: unknown;
       };
-      internal.splitSuggestion = {
-        shouldSplit: true,
-        explanation: 'x',
-        groups: [
-          { files: ['a.ts', 'b.ts'], message: 'group a' },
-          { files: ['c.ts'], message: 'group b' },
-        ],
+      // The index has the group's files, another group's file (c.ts), AND a
+      // staged file in no suggested group (z.ts). All non-group files must be
+      // unstaged so the commit is truly isolated.
+      mockInvoke = async (command: string) => {
+        if (command === 'get_status') {
+          return [
+            { path: 'a.ts', status: 'modified', isStaged: true, isConflicted: false },
+            { path: 'b.ts', status: 'modified', isStaged: true, isConflicted: false },
+            { path: 'c.ts', status: 'modified', isStaged: true, isConflicted: false },
+            { path: 'z.ts', status: 'modified', isStaged: true, isConflicted: false },
+            { path: 'u.ts', status: 'modified', isStaged: false, isConflicted: false },
+          ];
+        }
+        return null;
       };
-      mockInvoke = async () => null; // all commands succeed
 
       invokeHistory.length = 0;
       await internal.handleStageGroup(['a.ts', 'b.ts']);
 
       const unstage = invokeHistory.find(h => h.command === 'unstage_files');
       const stage = invokeHistory.find(h => h.command === 'stage_files');
-      expect(unstage, 'unstages other group files').to.exist;
-      expect((unstage!.args as { paths: string[] }).paths).to.deep.equal(['c.ts']);
+      expect(unstage, 'unstages all other staged files').to.exist;
+      expect((unstage!.args as { paths: string[] }).paths).to.deep.equal(['c.ts', 'z.ts']);
       expect(stage, 'stages this group').to.exist;
       expect((stage!.args as { paths: string[] }).paths).to.deep.equal(['a.ts', 'b.ts']);
     });

--- a/src/components/sidebar/lv-commit-panel.ts
+++ b/src/components/sidebar/lv-commit-panel.ts
@@ -1187,15 +1187,22 @@ export class LvCommitPanel extends LitElement {
   private async handleStageGroup(files: string[]): Promise<void> {
     if (!this.repositoryPath) return;
 
-    // Isolate this group so the next commit contains only its files: unstage the
-    // files belonging to the OTHER suggested groups, then stage this group.
+    // Isolate this group so the next commit contains ONLY its files. Unstage
+    // every currently-staged file that isn't in this group — deriving the set
+    // from the real index (not just the other AI-suggested groups, which may
+    // not cover every staged file when the diff was truncated for the model).
     const groupSet = new Set(files);
-    const otherFiles = (this.splitSuggestion?.groups ?? [])
-      .flatMap(g => g.files)
-      .filter(f => !groupSet.has(f));
+    const status = await gitService.getStatus(this.repositoryPath);
+    if (!status.success) {
+      showToast(status.error?.message ?? 'Failed to isolate group', 'error');
+      return;
+    }
+    const otherStaged = (status.data ?? [])
+      .filter(e => e.isStaged && !groupSet.has(e.path))
+      .map(e => e.path);
 
-    if (otherFiles.length > 0) {
-      const unstage = await gitService.unstageFiles(this.repositoryPath, { paths: otherFiles });
+    if (otherStaged.length > 0) {
+      const unstage = await gitService.unstageFiles(this.repositoryPath, { paths: otherStaged });
       if (!unstage.success) {
         showToast(unstage.error?.message ?? 'Failed to isolate group', 'error');
         return;

--- a/src/components/sidebar/lv-commit-panel.ts
+++ b/src/components/sidebar/lv-commit-panel.ts
@@ -690,6 +690,10 @@ export class LvCommitPanel extends LitElement {
 
   private boundHandleTriggerAmend = this.handleTriggerAmend.bind(this);
   private boundHandleAiSettingsChanged = () => this.checkAiAvailability();
+  // Reload the author identity when the repo refreshes (e.g. after applying a
+  // profile that rewrote user.name/user.email in the repo's git config), so the
+  // {{author}} template placeholder reflects the new identity.
+  private boundHandleRepositoryRefresh = () => this.loadAuthorName();
   private unsubscribeStore?: () => void;
   private aiRetryTimer?: ReturnType<typeof setTimeout>;
   private modelCompleteUnlisten?: UnlistenFn;
@@ -718,6 +722,9 @@ export class LvCommitPanel extends LitElement {
     // Re-check AI availability when settings change (browser event from settings dialog)
     window.addEventListener('ai-settings-changed', this.boundHandleAiSettingsChanged);
 
+    // Reload author identity after a repository refresh (e.g. profile applied).
+    window.addEventListener('repository-refresh', this.boundHandleRepositoryRefresh);
+
     // Also listen for Tauri backend event when a model download completes and auto-loads
     listen<{ modelId: string; loaded?: boolean }>('model-download-complete', (event) => {
       if (event.payload.loaded) {
@@ -737,6 +744,7 @@ export class LvCommitPanel extends LitElement {
     document.removeEventListener('click', this._onDocumentClick);
     window.removeEventListener('trigger-amend', this.boundHandleTriggerAmend);
     window.removeEventListener('ai-settings-changed', this.boundHandleAiSettingsChanged);
+    window.removeEventListener('repository-refresh', this.boundHandleRepositoryRefresh);
     this.modelCompleteUnlisten?.();
     if (this.aiRetryTimer) clearTimeout(this.aiRetryTimer);
     this.unsubscribeStore?.();

--- a/src/components/sidebar/lv-commit-panel.ts
+++ b/src/components/sidebar/lv-commit-panel.ts
@@ -1131,15 +1131,22 @@ export class LvCommitPanel extends LitElement {
 
     this.isAnalyzing = true;
     this.vibeCheckResult = null;
+    this.generationError = null;
 
-    const result = await aiService.analyzeStagedChanges(this.repositoryPath);
+    try {
+      const result = await aiService.analyzeStagedChanges(this.repositoryPath);
 
-    if (result.success && result.data) {
-      this.vibeCheckResult = result.data;
-      this.showVibeDetails = result.data.findings.length > 0;
+      if (result.success && result.data) {
+        this.vibeCheckResult = result.data;
+        this.showVibeDetails = result.data.findings.length > 0;
+      } else {
+        this.generationError = result.error?.message ?? 'Vibe check failed';
+      }
+    } catch (err) {
+      this.generationError = err instanceof Error ? err.message : 'Vibe check failed';
+    } finally {
+      this.isAnalyzing = false;
     }
-
-    this.isAnalyzing = false;
   }
 
   private async handleSuggestSplits(): Promise<void> {
@@ -1147,21 +1154,46 @@ export class LvCommitPanel extends LitElement {
 
     this.isAnalyzingSplit = true;
     this.splitSuggestion = null;
+    this.generationError = null;
 
-    const result = await aiService.suggestCommitSplits(this.repositoryPath);
+    try {
+      const result = await aiService.suggestCommitSplits(this.repositoryPath);
 
-    if (result.success && result.data) {
-      this.splitSuggestion = result.data;
-      this.showSplitDetails = result.data.shouldSplit;
+      if (result.success && result.data) {
+        this.splitSuggestion = result.data;
+        this.showSplitDetails = result.data.shouldSplit;
+        if (!result.data.shouldSplit) {
+          // Success path with nothing to render otherwise — give explicit feedback.
+          showToast('Staged changes look cohesive — no split needed', 'info');
+        }
+      } else {
+        this.generationError = result.error?.message ?? 'Split check failed';
+      }
+    } catch (err) {
+      this.generationError = err instanceof Error ? err.message : 'Split check failed';
+    } finally {
+      this.isAnalyzingSplit = false;
     }
-
-    this.isAnalyzingSplit = false;
   }
 
   private async handleStageGroup(files: string[]): Promise<void> {
     if (!this.repositoryPath) return;
 
-    // Unstage everything first, then stage only this group
+    // Isolate this group so the next commit contains only its files: unstage the
+    // files belonging to the OTHER suggested groups, then stage this group.
+    const groupSet = new Set(files);
+    const otherFiles = (this.splitSuggestion?.groups ?? [])
+      .flatMap(g => g.files)
+      .filter(f => !groupSet.has(f));
+
+    if (otherFiles.length > 0) {
+      const unstage = await gitService.unstageFiles(this.repositoryPath, { paths: otherFiles });
+      if (!unstage.success) {
+        showToast(unstage.error?.message ?? 'Failed to isolate group', 'error');
+        return;
+      }
+    }
+
     const result = await gitService.stageFiles(this.repositoryPath, { paths: files });
     if (result.success) {
       showToast(`Staged ${files.length} files`, 'success');

--- a/src/components/toolbar/__tests__/lv-toolbar.test.ts
+++ b/src/components/toolbar/__tests__/lv-toolbar.test.ts
@@ -6,16 +6,21 @@
 
 // ── Tauri mock (must be set before any imports) ────────────────────────────
 let cbId = 0;
+let mockInvoke: (command: string, args?: unknown) => Promise<unknown> = () => Promise.resolve(null);
 (globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
-  invoke: () => Promise.resolve(null),
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
   transformCallback: () => cbId++,
+};
+(globalThis as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+  convertCallback: () => 0,
+  unregisterListener: () => {},
 };
 
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
 import { expect, fixture, html } from '@open-wc/testing';
 import type { LvToolbar } from '../lv-toolbar.ts';
 import '../lv-toolbar.ts';
-import { repositoryStore } from '../../../stores/index.ts';
+import { repositoryStore, uiStore } from '../../../stores/index.ts';
 import type { Repository, Branch, StatusEntry } from '../../../types/git.types.ts';
 
 function mockRepo(path: string, name: string): Repository {
@@ -58,6 +63,7 @@ function tabs(el: LvToolbar): HTMLButtonElement[] {
 describe('lv-toolbar repository tabs', () => {
   beforeEach(() => {
     repositoryStore.getState().reset();
+    mockInvoke = () => Promise.resolve(null);
   });
 
   describe('tab rendering', () => {
@@ -307,6 +313,30 @@ describe('lv-toolbar repository tabs', () => {
 
       expect(el.shadowRoot!.querySelector('.tab-context-menu')).to.not.exist;
       expect(repositoryStore.getState().openRepositories.length).to.equal(3);
+    });
+  });
+
+  describe('open repository failures', () => {
+    it('shows a toast (not just a silent store error) when opening fails', async () => {
+      // Dialog returns a folder; the open then fails (e.g. not a git repo).
+      mockInvoke = (command: string) => {
+        if (command === 'plugin:dialog|open') return Promise.resolve('/not/a/repo');
+        if (command === 'open_repository') {
+          return Promise.reject({ message: 'not a git repository' });
+        }
+        return Promise.resolve(null);
+      };
+      uiStore.setState({ toasts: [] });
+
+      const el = await createToolbar();
+      await (el as unknown as { handleOpenRepo: () => Promise<void> }).handleOpenRepo();
+
+      const toasts = uiStore.getState().toasts;
+      const errorToast = toasts.find(t => t.type === 'error');
+      expect(errorToast, 'an error toast is surfaced to the user').to.exist;
+      expect(errorToast!.message).to.contain('not a git repository');
+      // And the store error is still set for any listener.
+      expect(repositoryStore.getState().error).to.contain('not a git repository');
     });
   });
 });

--- a/src/components/toolbar/lv-toolbar.ts
+++ b/src/components/toolbar/lv-toolbar.ts
@@ -436,10 +436,15 @@ export class LvToolbar extends LitElement {
             console.error('Failed to build embedding index:', err);
           });
         } else {
-          store.setError(result.error?.message ?? 'Failed to open repository');
+          const message = result.error?.message ?? 'Failed to open repository';
+          store.setError(message);
+          // repositoryStore.error has no render sink, so surface it directly.
+          showToast(message, 'error');
         }
       } catch (err) {
-        store.setError(err instanceof Error ? err.message : 'Unknown error');
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        store.setError(message);
+        showToast(message, 'error');
       } finally {
         store.setLoading(false);
       }

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -8,7 +8,15 @@ export default {
     esbuildPlugin({ ts: true, target: 'auto', tsconfig: 'tsconfig.json', loaders: { '.png': 'dataurl' } }),
   ],
   browsers: [
-    playwrightLauncher({ product: 'chromium' }),
+    playwrightLauncher({
+      product: 'chromium',
+      // Allow pointing at a preinstalled Chromium (e.g. in CI/sandbox images
+      // where the bundled download is skipped). Falls back to Playwright's
+      // default resolution when the env var is unset.
+      ...(process.env.PW_CHROMIUM_PATH
+        ? { launchOptions: { executablePath: process.env.PW_CHROMIUM_PATH } }
+        : {}),
+    }),
   ],
   testFramework: {
     config: {


### PR DESCRIPTION
## Summary
This PR fixes critical issues with git signing configuration when applying profiles, improves error handling consistency across cloud providers, and adds safeguards for rebase operations. It also includes test coverage for new signing behavior and fixes several edge cases in branch deletion, tag editing, and Unicode handling.

## Key Changes

### Git Signing Configuration (unified_profiles.rs)
- **Extract signing logic into `apply_profile_git_config()`** to enable reuse and testing
- **Add `detect_gpg_format()` function** to automatically detect SSH vs OpenPGP key types:
  - SSH keys (literal `ssh-*`, `ecdsa-sha2-*`, `sk-ssh-*`, `sk-ecdsa-*`, `key::*` forms, or `.pub` paths) → `gpg.format=ssh`
  - OpenPGP key IDs → `gpg.format=openpgp`
- **Fix signing behavior** to set `gpg.format` locally in both SSH and OpenPGP cases, preventing global config mismatches
- **Disable signing when no key is present** by explicitly setting `commit.gpgsign=false`, preventing globally-enabled signing from forcing commits with a missing local key
- **Add comprehensive test coverage** for SSH keys, OpenPGP keys, `.pub` paths, and profile switching scenarios

### Rebase Safety (merge.rs)
- **Add pre-flight checks** before starting rebase (matching canonical `git rebase` behavior):
  - Reject if another operation is in progress (`repo.state() != Clean`)
  - Reject if working tree has staged changes or modifications to tracked files
  - Allow untracked and ignored files (matching git's behavior)
- **Add tests** for dirty working tree rejection and untracked file allowance

### Tag Editing Atomicity (tags.rs)
- **Fix `edit_tag_message()` to use force flag** (`git tag -f`) instead of delete-then-create, preventing data loss if signing fails
- **Update `create_signed_tag_cli()` signature** to accept `force` parameter
- **Add safety documentation** explaining why atomic replacement is necessary (tags have no reflog)

### Branch Deletion Edge Case (branch.rs)
- **Fix `delete_branch()` to handle equality case** where branch points at same commit as HEAD
- **Add equality check** (`head_oid == branch_oid`) before `graph_descendant_of()` call, matching `git branch -d` behavior

### Error Handling Consistency
- **GitLab (gitlab.rs)**: Fix `list_gitlab_merge_requests()` and `list_gitlab_issues()` to respect `None` state parameter (means "All", not "opened")
- **Azure DevOps (azure_devops.rs)**: Fix `list_ado_pull_requests()` to respect `None` status parameter (means "All", not "active")
- **Bitbucket (bitbucket.rs)**: Distinguish 404 (issues disabled) from other errors; surface non-404 failures instead of silently returning empty list
- **GitHub Dialog (lv-github-dialog.ts)**: Surface errors for workflow runs and issues instead of silent failures
- **GitLab Dialog (lv-gitlab-dialog.ts)**: Surface errors for issues and pipelines
- **Azure DevOps Dialog (lv-azure-devops-dialog.ts)**: Surface errors for work items
- **Bitbucket Dialog (lv-bitbucket-dialog.ts)**: Surface errors for issues (with note about 404 = disabled)
- **Commit Panel (lv-commit-panel.ts)**: Add error handling and loading state reset for vibe check and split suggestions

### UI Event Consistency
- **Commit Panel**: Add `repository-refresh` event listener to reload author identity after profile application
- **Profile Manager Dialog**: Dispatch `repository-refresh` event after successful profile apply
- **App Shell**: Capture active repo path before awaiting IPC to prevent stale data writes if user switches tabs during refresh

### SSH Key Detection (gpg.rs)
- **Extract `is_ssh_literal_key()` as public function** for reuse by `unified_profiles::detect_gpg_format()`
-

https://claude.ai/code/session_01X44okurBjscsRNnMvWmXPx