### PR TITLE
feat(azure-devops): one-click Microsoft (Entra ID) sign-in with automatic token refresh

### DIFF
--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -40,26 +40,29 @@ This guide covers how to register OAuth applications with each integration provi
 
 ## Azure DevOps (Microsoft Entra ID)
 
-1. Go to [Azure Portal](https://portal.azure.com/)
-2. Navigate to **Microsoft Entra ID** → **App registrations** → **New registration**
-3. Fill in:
-   - **Name**: Leviathan
-   - **Supported account types**: "Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant) and personal Microsoft accounts"
-   - **Redirect URI**:
-     - Platform: **Public client/native (mobile & desktop)**
-     - URI: `leviathan://oauth/azure/callback`
-4. Click **Register**
-5. After creation, go to **API permissions**:
-   - Click **Add a permission**
-   - Select **Azure DevOps**
-   - Check `user_impersonation`
-   - Click **Add permissions**
-6. Copy the **Application (client) ID** - this gets hardcoded in the app
+**No registration is required.** "Sign in with Microsoft" uses the OAuth 2.0
+**device-code flow** with an embedded, well-known public client ID (the Visual
+Studio client `872cd9fa-d31f-45e0-9eab-6e460a02d1f1`, which is multi-tenant and
+pre-authorized for Azure DevOps). The user clicks the button, a short code is
+shown, they approve it in the browser, and the app polls for the token — there is
+**no redirect URI and no PKCE**, so nothing needs to be configured per deployment.
+
+### Swapping in your own client ID (optional)
+If you'd rather ship your own Entra app instead of the embedded one:
+
+1. Go to [Azure Portal](https://portal.azure.com/) → **Microsoft Entra ID** →
+   **App registrations** → **New registration**.
+2. **Supported account types**: "Accounts in any organizational directory
+   (Multitenant) and personal Microsoft accounts".
+3. Under **Authentication** → **Advanced settings**, set **Allow public client
+   flows** to **Yes** (required for the device-code flow). No redirect URI is needed.
+4. Under **API permissions**, add **Azure DevOps → `user_impersonation`**.
+5. Copy the **Application (client) ID** and set it as `azure` in `OAUTH_CLIENT_IDS`.
 
 ### Notes
-- No admin consent is required for `user_impersonation`
-- The app uses PKCE for secure authorization
-- Microsoft's redirect URI validation requires exact matches, so ensure the URI is correct
+- No admin consent is required for `user_impersonation`.
+- The device-code flow needs no redirect URI, which is why the embedded public
+  client works without Leviathan owning its app registration.
 
 ---
 
@@ -98,7 +101,7 @@ Look for the `OAUTH_CLIENT_IDS` object near the top of the file:
 const OAUTH_CLIENT_IDS: Record<OAuthProvider, string> = {
   github: 'your-github-client-id',
   gitlab: 'your-gitlab-application-id',
-  azure: 'your-azure-application-client-id',
+  azure: 'your-azure-application-client-id', // optional: defaults to the embedded Visual Studio public client (device-code flow)
   bitbucket: 'your-bitbucket-key',
 };
 ```

--- a/src-tauri/src/commands/azure_devops.rs
+++ b/src-tauri/src/commands/azure_devops.rs
@@ -118,6 +118,15 @@ pub struct AdoPipelineRun {
     pub url: String,
 }
 
+/// Azure DevOps organization (account) the signed-in user belongs to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdoOrganization {
+    pub id: String,
+    pub name: String,
+    pub url: String,
+}
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -1117,6 +1126,111 @@ pub async fn list_ado_pipeline_runs(
         .collect())
 }
 
+// ============================================================================
+// Organization Commands
+// ============================================================================
+
+/// List the Azure DevOps organizations the authenticated user is a member of.
+/// Used to auto-resolve the organization after an Entra sign-in when it cannot be
+/// detected from the repo remote. Uses the org-less vssps host so it works before
+/// any organization is known.
+#[command]
+pub async fn list_ado_organizations(token: Option<String>) -> Result<Vec<AdoOrganization>> {
+    let token = resolve_ado_token(token)?;
+
+    let client = reqwest::Client::new();
+
+    // Step 1: Resolve the member id via the org-less profile endpoint.
+    let profile_url =
+        "https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=7.1";
+    debug!("Requesting: {}", profile_url);
+
+    let profile_response = client
+        .get(profile_url)
+        .header("Authorization", get_auth_header(&token))
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+        .map_err(|e| {
+            error!("HTTP request failed: {}", e);
+            LeviathanError::OperationFailed(format!("Failed to fetch profile: {}", e))
+        })?;
+
+    if !profile_response.status().is_success() {
+        let status = profile_response.status();
+        let body = profile_response.text().await.unwrap_or_default();
+        return Err(LeviathanError::OperationFailed(format!(
+            "Azure DevOps API error {}: {}",
+            status, body
+        )));
+    }
+
+    #[derive(Deserialize)]
+    struct ProfileData {
+        id: String,
+    }
+
+    let profile: ProfileData = profile_response.json().await.map_err(|e| {
+        error!("Failed to parse profile data: {}", e);
+        LeviathanError::OperationFailed(format!("Failed to parse profile data: {}", e))
+    })?;
+
+    // Step 2: List accounts for the resolved member id.
+    let accounts_url = format!(
+        "https://app.vssps.visualstudio.com/_apis/accounts?memberId={}&api-version=7.1",
+        profile.id
+    );
+    debug!("Requesting: {}", accounts_url);
+
+    let accounts_response = client
+        .get(&accounts_url)
+        .header("Authorization", get_auth_header(&token))
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+        .map_err(|e| {
+            error!("HTTP request failed: {}", e);
+            LeviathanError::OperationFailed(format!("Failed to fetch accounts: {}", e))
+        })?;
+
+    if !accounts_response.status().is_success() {
+        let status = accounts_response.status();
+        let body = accounts_response.text().await.unwrap_or_default();
+        return Err(LeviathanError::OperationFailed(format!(
+            "Azure DevOps API error {}: {}",
+            status, body
+        )));
+    }
+
+    #[derive(Deserialize)]
+    struct AccountsResponse {
+        value: Vec<ApiAccount>,
+    }
+
+    #[derive(Deserialize)]
+    struct ApiAccount {
+        #[serde(rename = "accountId")]
+        account_id: String,
+        #[serde(rename = "accountName")]
+        account_name: String,
+    }
+
+    let data: AccountsResponse = accounts_response.json().await.map_err(|e| {
+        error!("Failed to parse accounts data: {}", e);
+        LeviathanError::OperationFailed(format!("Failed to parse accounts data: {}", e))
+    })?;
+
+    Ok(data
+        .value
+        .into_iter()
+        .map(|a| AdoOrganization {
+            id: a.account_id,
+            url: format!("https://dev.azure.com/{}", a.account_name),
+            name: a.account_name,
+        })
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1471,5 +1585,65 @@ mod tests {
         let json = serde_json::to_string(&run).unwrap();
         assert!(json.contains("sourceBranch"));
         assert!(json.contains("finishedDate"));
+    }
+
+    #[test]
+    fn test_ado_organization_serialization() {
+        let org = AdoOrganization {
+            id: "acct-123".to_string(),
+            name: "mycompany".to_string(),
+            url: "https://dev.azure.com/mycompany".to_string(),
+        };
+
+        let json = serde_json::to_string(&org).unwrap();
+        assert!(json.contains("\"id\":\"acct-123\""));
+        assert!(json.contains("\"name\":\"mycompany\""));
+        assert!(json.contains("\"url\":\"https://dev.azure.com/mycompany\""));
+    }
+
+    #[test]
+    fn test_ado_accounts_response_deserialization() {
+        // Mirrors the accounts API `value` array shape used by list_ado_organizations.
+        #[derive(Deserialize)]
+        struct AccountsResponse {
+            value: Vec<ApiAccount>,
+        }
+
+        #[derive(Deserialize)]
+        struct ApiAccount {
+            #[serde(rename = "accountId")]
+            account_id: String,
+            #[serde(rename = "accountName")]
+            account_name: String,
+        }
+
+        let raw = r#"{
+            "count": 2,
+            "value": [
+                { "accountId": "id-1", "accountName": "orgOne" },
+                { "accountId": "id-2", "accountName": "orgTwo" }
+            ]
+        }"#;
+
+        let parsed: AccountsResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.value.len(), 2);
+        assert_eq!(parsed.value[0].account_id, "id-1");
+        assert_eq!(parsed.value[0].account_name, "orgOne");
+        assert_eq!(parsed.value[1].account_id, "id-2");
+        assert_eq!(parsed.value[1].account_name, "orgTwo");
+
+        // Verify the mapping list_ado_organizations performs.
+        let orgs: Vec<AdoOrganization> = parsed
+            .value
+            .into_iter()
+            .map(|a| AdoOrganization {
+                id: a.account_id,
+                url: format!("https://dev.azure.com/{}", a.account_name),
+                name: a.account_name,
+            })
+            .collect();
+        assert_eq!(orgs[0].name, "orgOne");
+        assert_eq!(orgs[0].url, "https://dev.azure.com/orgOne");
+        assert_eq!(orgs[1].id, "id-2");
     }
 }

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -211,9 +211,13 @@ pub async fn oauth_get_authorize_url(
             (config, Some(port))
         }
         OAuthProvider::Azure => {
-            // For Azure, instance_url is used as tenant_id
-            let config = OAuthConfig::azure(&client_id, instance_url.as_deref());
-            (config, None)
+            // Azure DevOps (Entra ID) does not use the redirect/authorization-code
+            // flow: the embedded public client doesn't own our redirect URIs, so
+            // Entra would reject them (AADSTS50011). Sign-in goes through the
+            // device-code flow instead (oauth_start_device_code / oauth_poll_device_code).
+            return Err(LeviathanError::OAuth(
+                "Azure DevOps uses device-code sign-in — call oauth_start_device_code".to_string(),
+            ));
         }
         OAuthProvider::Bitbucket => {
             // Bitbucket requires http/https redirect URIs and only allows ONE callback URL
@@ -596,6 +600,311 @@ pub async fn oauth_wait_for_github_callback(port: u16) -> Result<CallbackRespons
     oauth_wait_for_callback(port).await
 }
 
+// ========================================================================
+// Device Authorization Grant (OAuth 2.0 Device Code) — used by Azure DevOps
+// ========================================================================
+//
+// The device-code flow needs no redirect URI, so it works with the embedded
+// public client (whose registered redirects we don't control). The user is shown
+// a short code to enter at a verification URL; the backend polls the token
+// endpoint until they finish. This is how `az devops` / Git Credential Manager
+// authenticate against Azure DevOps.
+
+/// Server-side state for an in-flight device-code flow, keyed by a generated flow id.
+struct PendingDeviceFlow {
+    provider: OAuthProvider,
+    /// Client ID used to start the flow (reused for polling).
+    client_id: String,
+    /// Instance / tenant (Azure). Determines the token endpoint.
+    instance_url: Option<String>,
+    /// The device_code secret returned by the authorization server.
+    device_code: String,
+    /// Poll interval in seconds (may be increased on `slow_down`).
+    interval: u64,
+    /// Absolute expiry — polling stops after this.
+    expires_at: std::time::Instant,
+}
+
+static DEVICE_FLOWS: Lazy<Mutex<HashMap<String, PendingDeviceFlow>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Response returned to the frontend when a device-code flow starts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartDeviceCodeResponse {
+    /// Handle used to poll this flow (the device_code itself stays server-side).
+    pub flow_id: String,
+    /// Short code the user types at the verification URL.
+    pub user_code: String,
+    /// URL the user opens to enter the code.
+    pub verification_uri: String,
+    /// Seconds until the code expires.
+    pub expires_in: u64,
+    /// Suggested seconds between polls.
+    pub interval: u64,
+    /// Human-readable instruction message from the provider.
+    pub message: String,
+}
+
+/// Azure DevOps scopes requested for the device-code flow.
+const AZURE_DEVICE_SCOPES: &str =
+    "499b84ac-1321-427f-aa17-267ca6975798/user_impersonation offline_access";
+
+fn azure_tenant_base(instance_url: Option<&str>) -> String {
+    let tenant = instance_url.unwrap_or("common");
+    format!("https://login.microsoftonline.com/{}/oauth2/v2.0", tenant)
+}
+
+/// Start a device-code flow. Currently only Azure (Entra ID) is supported.
+#[tauri::command]
+pub async fn oauth_start_device_code(
+    provider: String,
+    client_id: String,
+    instance_url: Option<String>,
+) -> Result<StartDeviceCodeResponse> {
+    let provider_enum: OAuthProvider = provider
+        .parse()
+        .map_err(|e: String| LeviathanError::OAuth(e))?;
+
+    let (device_url, scopes) = match provider_enum {
+        OAuthProvider::Azure => (
+            format!("{}/devicecode", azure_tenant_base(instance_url.as_deref())),
+            AZURE_DEVICE_SCOPES,
+        ),
+        _ => {
+            return Err(LeviathanError::OAuth(
+                "Device-code flow is not supported for this provider".to_string(),
+            ))
+        }
+    };
+
+    #[derive(Deserialize)]
+    struct DeviceCodeApiResponse {
+        device_code: String,
+        user_code: String,
+        verification_uri: String,
+        expires_in: u64,
+        interval: u64,
+        message: Option<String>,
+    }
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&device_url)
+        .header("Accept", "application/json")
+        .form(&[("client_id", client_id.as_str()), ("scope", scopes)])
+        .send()
+        .await
+        .map_err(|e| LeviathanError::OAuth(format!("Device code request failed: {}", e)))?;
+
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        // Surface the provider's error field without echoing the whole body.
+        let msg = serde_json::from_str::<serde_json::Value>(&text)
+            .ok()
+            .and_then(|v| {
+                v.get("error_description")
+                    .or_else(|| v.get("error"))
+                    .and_then(|d| d.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| format!("HTTP {}", status));
+        return Err(LeviathanError::OAuth(format!(
+            "Failed to start device sign-in: {}",
+            msg
+        )));
+    }
+
+    let data: DeviceCodeApiResponse = serde_json::from_str(&text).map_err(|e| {
+        LeviathanError::OAuth(format!("Failed to parse device code response: {}", e))
+    })?;
+
+    let flow_id = generate_state();
+    let expires_at = std::time::Instant::now() + Duration::from_secs(data.expires_in);
+
+    {
+        let mut flows = DEVICE_FLOWS
+            .lock()
+            .map_err(|e| LeviathanError::OAuth(format!("Failed to store device flow: {}", e)))?;
+        // Evict expired flows opportunistically.
+        let now = std::time::Instant::now();
+        flows.retain(|_, f| f.expires_at > now);
+        flows.insert(
+            flow_id.clone(),
+            PendingDeviceFlow {
+                provider: provider_enum,
+                client_id,
+                instance_url,
+                device_code: data.device_code,
+                interval: data.interval,
+                expires_at,
+            },
+        );
+    }
+
+    Ok(StartDeviceCodeResponse {
+        flow_id,
+        user_code: data.user_code,
+        verification_uri: data.verification_uri,
+        expires_in: data.expires_in,
+        interval: data.interval,
+        message: data
+            .message
+            .unwrap_or_else(|| "Sign in with the code shown.".to_string()),
+    })
+}
+
+/// Poll a device-code flow until the user completes sign-in, it is cancelled, or
+/// it expires. Blocks server-side (polling the token endpoint at the provider's
+/// interval) so the frontend only awaits once.
+#[tauri::command]
+pub async fn oauth_poll_device_code(flow_id: String) -> Result<OAuthTokenResponse> {
+    // Snapshot the flow parameters (do not hold the lock across awaits).
+    let (token_url, client_id, device_code, mut interval) = {
+        let flows = DEVICE_FLOWS
+            .lock()
+            .map_err(|e| LeviathanError::OAuth(format!("Failed to access device flow: {}", e)))?;
+        let flow = flows.get(&flow_id).ok_or_else(|| {
+            LeviathanError::OAuth("Device sign-in flow not found or already finished".to_string())
+        })?;
+        let token_url = match flow.provider {
+            OAuthProvider::Azure => {
+                format!("{}/token", azure_tenant_base(flow.instance_url.as_deref()))
+            }
+            _ => {
+                return Err(LeviathanError::OAuth(
+                    "Device-code flow is not supported for this provider".to_string(),
+                ))
+            }
+        };
+        (
+            token_url,
+            flow.client_id.clone(),
+            flow.device_code.clone(),
+            flow.interval,
+        )
+    };
+
+    let client = reqwest::Client::new();
+
+    loop {
+        // Bail if the flow was cancelled (removed) or has expired.
+        {
+            let mut flows = DEVICE_FLOWS.lock().map_err(|e| {
+                LeviathanError::OAuth(format!("Failed to access device flow: {}", e))
+            })?;
+            match flows.get(&flow_id) {
+                None => {
+                    return Err(LeviathanError::OAuth(
+                        "Device sign-in was cancelled".to_string(),
+                    ))
+                }
+                Some(f) if f.expires_at <= std::time::Instant::now() => {
+                    // Remove the expired flow so its device_code secret doesn't
+                    // linger until the next start's opportunistic cleanup.
+                    flows.remove(&flow_id);
+                    return Err(LeviathanError::OAuth(
+                        "Device sign-in timed out — please try again".to_string(),
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(interval.max(1))).await;
+
+        // A transient transport error (wifi drop, sleep/resume, VPN reconnect)
+        // must NOT abort a flow the user is still completing — retry on the next
+        // tick (bounded by the expiry check at the top of the loop).
+        let response = match client
+            .post(&token_url)
+            .header("Accept", "application/json")
+            .form(&[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                ("client_id", client_id.as_str()),
+                ("device_code", device_code.as_str()),
+            ])
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!("Device token poll transient error (will retry): {}", e);
+                continue;
+            }
+        };
+
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+
+        if status.is_success() {
+            // This flow is terminal now — remove it BEFORE parsing so a 2xx body
+            // that fails to deserialize doesn't leave the entry (and its
+            // device_code secret) lingering in the map until expiry.
+            DEVICE_FLOWS.lock().ok().map(|mut f| f.remove(&flow_id));
+            let tokens: OAuthTokenResponse = serde_json::from_str(&text).map_err(|e| {
+                LeviathanError::OAuth(format!("Failed to parse token response: {}", e))
+            })?;
+            return Ok(tokens);
+        }
+
+        // Non-success: inspect the OAuth error code to decide whether to keep polling.
+        let error_code = serde_json::from_str::<serde_json::Value>(&text)
+            .ok()
+            .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(str::to_string))
+            .unwrap_or_default();
+
+        match classify_device_poll_error(&error_code, status.as_u16()) {
+            DevicePollAction::KeepWaiting => { /* authorization_pending */ }
+            DevicePollAction::SlowDown => interval += 5,
+            DevicePollAction::Fail(msg) => {
+                DEVICE_FLOWS.lock().ok().map(|mut f| f.remove(&flow_id));
+                return Err(LeviathanError::OAuth(msg));
+            }
+        }
+    }
+}
+
+/// What the device-code poll loop should do for a given token-endpoint error.
+#[derive(Debug, PartialEq)]
+enum DevicePollAction {
+    /// Authorization still pending — poll again on the next tick.
+    KeepWaiting,
+    /// Provider asked us to back off — increase the interval and poll again.
+    SlowDown,
+    /// Terminal failure — stop polling and surface this message.
+    Fail(String),
+}
+
+/// Classify a device-code token-poll error (RFC 8628 §3.5) into a poll action.
+/// Pure function so the state machine is unit-testable without an HTTP server.
+fn classify_device_poll_error(error_code: &str, status: u16) -> DevicePollAction {
+    match error_code {
+        "authorization_pending" => DevicePollAction::KeepWaiting,
+        "slow_down" => DevicePollAction::SlowDown,
+        "authorization_declined" => DevicePollAction::Fail("Sign-in was declined".to_string()),
+        "expired_token" => {
+            DevicePollAction::Fail("Device sign-in timed out — please try again".to_string())
+        }
+        // No recognized OAuth error field. A 5xx is a transient server blip —
+        // keep polling (same tolerance as a transport error) instead of aborting
+        // a flow the user is still completing; a 4xx is a genuine terminal error.
+        "" if status >= 500 => DevicePollAction::KeepWaiting,
+        "" => DevicePollAction::Fail(format!("Token poll failed (HTTP {})", status)),
+        other => DevicePollAction::Fail(other.to_string()),
+    }
+}
+
+/// Cancel an in-flight device-code flow so its poll stops.
+#[tauri::command]
+pub async fn oauth_cancel_device_code(flow_id: String) -> Result<()> {
+    if let Ok(mut flows) = DEVICE_FLOWS.lock() {
+        flows.remove(&flow_id);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -769,32 +1078,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_oauth_get_authorize_url_azure() {
+    async fn test_oauth_get_authorize_url_azure_rejected() {
+        // Azure DevOps uses the device-code flow, not the redirect/authorize path,
+        // so the authorize-url command must reject it (pointing at device-code).
         let result =
             oauth_get_authorize_url("azure".to_string(), None, "test-client-id".to_string()).await;
 
-        assert!(result.is_ok());
-        let response = result.unwrap();
-
-        assert!(response.authorize_url.contains("login.microsoftonline.com"));
-        assert!(response.authorize_url.contains("common"));
-        // Azure uses deep link, not loopback server
-        assert!(response.loopback_port.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_oauth_get_authorize_url_azure_custom_tenant() {
-        let result = oauth_get_authorize_url(
-            "azure".to_string(),
-            Some("my-tenant-id".to_string()),
-            "test-client-id".to_string(),
-        )
-        .await;
-
-        assert!(result.is_ok());
-        let response = result.unwrap();
-
-        assert!(response.authorize_url.contains("my-tenant-id"));
+        assert!(result.is_err());
+        let msg = format!("{:?}", result.unwrap_err());
+        assert!(msg.contains("device-code"));
     }
 
     #[tokio::test]
@@ -826,10 +1118,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_oauth_get_authorize_url_generates_unique_state() {
+        // Use a redirect-flow provider (Azure uses device-code and has no authorize URL).
         let result1 =
-            oauth_get_authorize_url("azure".to_string(), None, "test-client-id".to_string()).await;
+            oauth_get_authorize_url("gitlab".to_string(), None, "test-client-id".to_string()).await;
         let result2 =
-            oauth_get_authorize_url("azure".to_string(), None, "test-client-id".to_string()).await;
+            oauth_get_authorize_url("gitlab".to_string(), None, "test-client-id".to_string()).await;
 
         assert!(result1.is_ok());
         assert!(result2.is_ok());
@@ -1207,6 +1500,130 @@ mod tests {
             deserialized.instance_url,
             Some("https://auth.example.com".to_string())
         );
+    }
+
+    // ==========================================================================
+    // Device Code Flow Tests
+    // ==========================================================================
+
+    #[test]
+    fn test_azure_tenant_base_default() {
+        let base = azure_tenant_base(None);
+        assert_eq!(base, "https://login.microsoftonline.com/common/oauth2/v2.0");
+    }
+
+    #[test]
+    fn test_azure_tenant_base_specific() {
+        let base = azure_tenant_base(Some("my-tenant"));
+        assert_eq!(
+            base,
+            "https://login.microsoftonline.com/my-tenant/oauth2/v2.0"
+        );
+    }
+
+    #[test]
+    fn test_start_device_code_response_serializes_camel_case() {
+        let response = StartDeviceCodeResponse {
+            flow_id: "flow-1".to_string(),
+            user_code: "ABCD-EFGH".to_string(),
+            verification_uri: "https://microsoft.com/devicelogin".to_string(),
+            expires_in: 900,
+            interval: 5,
+            message: "Enter the code".to_string(),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("flowId"));
+        assert!(json.contains("userCode"));
+        assert!(json.contains("verificationUri"));
+        assert!(json.contains("expiresIn"));
+    }
+
+    #[tokio::test]
+    async fn test_start_device_code_rejects_unsupported_provider() {
+        // Only Azure supports device code; GitHub must be rejected before any network call.
+        let result =
+            oauth_start_device_code("github".to_string(), "client".to_string(), None).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_start_device_code_rejects_invalid_provider() {
+        let result =
+            oauth_start_device_code("nonsense".to_string(), "client".to_string(), None).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_poll_device_code_unknown_flow_errors() {
+        // A flow id that was never started (or already consumed) must error, not hang.
+        let result = oauth_poll_device_code("does-not-exist".to_string()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_cancel_device_code_is_ok_for_missing_flow() {
+        // Cancelling a non-existent flow is a no-op success (idempotent).
+        assert!(oauth_cancel_device_code("no-such-flow".to_string())
+            .await
+            .is_ok());
+    }
+
+    #[test]
+    fn test_classify_device_poll_pending_keeps_waiting() {
+        assert_eq!(
+            classify_device_poll_error("authorization_pending", 400),
+            DevicePollAction::KeepWaiting
+        );
+    }
+
+    #[test]
+    fn test_classify_device_poll_slow_down() {
+        assert_eq!(
+            classify_device_poll_error("slow_down", 400),
+            DevicePollAction::SlowDown
+        );
+    }
+
+    #[test]
+    fn test_classify_device_poll_declined_fails() {
+        match classify_device_poll_error("authorization_declined", 400) {
+            DevicePollAction::Fail(msg) => assert!(msg.contains("declined")),
+            other => panic!("expected Fail, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_device_poll_expired_fails() {
+        match classify_device_poll_error("expired_token", 400) {
+            DevicePollAction::Fail(msg) => assert!(msg.contains("timed out")),
+            other => panic!("expected Fail, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_device_poll_empty_error_4xx_terminates_with_status() {
+        // A non-JSON / empty error body on a 4xx terminates, surfacing the status.
+        match classify_device_poll_error("", 400) {
+            DevicePollAction::Fail(msg) => assert!(msg.contains("400")),
+            other => panic!("expected Fail, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_device_poll_empty_error_5xx_retries() {
+        // A transient 5xx blip must be retried, not treated as terminal.
+        assert_eq!(
+            classify_device_poll_error("", 503),
+            DevicePollAction::KeepWaiting
+        );
+    }
+
+    #[test]
+    fn test_classify_device_poll_unknown_error_passed_through() {
+        match classify_device_poll_error("invalid_grant", 400) {
+            DevicePollAction::Fail(msg) => assert_eq!(msg, "invalid_grant"),
+            other => panic!("expected Fail, got {:?}", other),
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -573,6 +573,7 @@ pub fn run() {
             commands::azure_devops::query_ado_work_items,
             commands::azure_devops::create_azure_devops_work_item,
             commands::azure_devops::list_ado_pipeline_runs,
+            commands::azure_devops::list_ado_organizations,
             // GitLab integration
             commands::gitlab::check_gitlab_connection,
             commands::gitlab::detect_gitlab_repo,
@@ -664,6 +665,9 @@ pub fn run() {
             commands::oauth::oauth_refresh_token,
             commands::oauth::oauth_wait_for_callback,
             commands::oauth::oauth_wait_for_github_callback,
+            commands::oauth::oauth_start_device_code,
+            commands::oauth::oauth_poll_device_code,
+            commands::oauth::oauth_cancel_device_code,
             commands::oauth::discover_oidc_provider,
             commands::oauth::decode_oidc_id_token,
             // Git Flow

--- a/src-tauri/src/services/oauth.rs
+++ b/src-tauri/src/services/oauth.rs
@@ -122,28 +122,6 @@ impl OAuthConfig {
         }
     }
 
-    /// Get Azure DevOps (Microsoft Entra ID) OAuth configuration
-    /// Note: Only supports work/school accounts. Personal accounts must use PAT authentication.
-    pub fn azure(client_id: &str, tenant_id: Option<&str>) -> Self {
-        let tenant = tenant_id.unwrap_or("common");
-        Self {
-            client_id: client_id.to_string(),
-            authorize_url: format!(
-                "https://login.microsoftonline.com/{}/oauth2/v2.0/authorize",
-                tenant
-            ),
-            token_url: format!(
-                "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
-                tenant
-            ),
-            scopes: vec![
-                "499b84ac-1321-427f-aa17-267ca6975798/user_impersonation".to_string(),
-                "offline_access".to_string(),
-            ],
-            redirect_uri: "leviathan://oauth/azure/callback".to_string(),
-        }
-    }
-
     /// Get Bitbucket OAuth configuration
     /// Bitbucket requires http/https redirect URIs, so we use the loopback server
     pub fn bitbucket(client_id: &str, redirect_port: u16) -> Self {
@@ -583,23 +561,6 @@ mod tests {
     }
 
     #[test]
-    fn test_azure_config_common_tenant() {
-        let config = OAuthConfig::azure("test-client-id", None);
-
-        assert!(config.authorize_url.contains("/common/"));
-        assert!(config.token_url.contains("/common/"));
-        assert_eq!(config.redirect_uri, "leviathan://oauth/azure/callback");
-    }
-
-    #[test]
-    fn test_azure_config_specific_tenant() {
-        let config = OAuthConfig::azure("test-client-id", Some("my-tenant"));
-
-        assert!(config.authorize_url.contains("/my-tenant/"));
-        assert!(config.token_url.contains("/my-tenant/"));
-    }
-
-    #[test]
     fn test_bitbucket_config() {
         // Bitbucket uses dedicated port 8085 to avoid conflicts
         let config = OAuthConfig::bitbucket("test-client-id", 8085);
@@ -660,18 +621,6 @@ mod tests {
 
         // Spaces should be encoded
         assert!(url.contains("state+with+spaces") || url.contains("state%20with%20spaces"));
-    }
-
-    #[test]
-    fn test_azure_devops_authorize_url() {
-        let config = OAuthConfig::azure("test-client-id", None);
-        let pkce = PKCEChallenge::new();
-        let url = config.build_authorize_url(&pkce, "test-state");
-
-        assert!(url.starts_with("https://login.microsoftonline.com/common/oauth2/v2.0/authorize?"));
-        assert!(url.contains("client_id=test-client-id"));
-        assert!(url.contains("response_type=code"));
-        assert!(url.contains("code_challenge_method=S256"));
     }
 
     // ==========================================================================

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -1421,4 +1421,32 @@ describe('lv-azure-devops-dialog', () => {
       expect(deleteBtn!.disabled).to.equal(true);
     });
   });
+
+  describe('git credential sync', () => {
+    it('writes credentials once per (org, token) and dedupes repeats; re-syncs on change', async () => {
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      const api = el as unknown as { syncGitCredentials: (org: string, token: string) => Promise<void> };
+
+      const stores = () => invokeHistory.filter((h) => h.command === 'store_git_credentials').length;
+
+      invokeHistory.length = 0;
+      await api.syncGitCredentials('testorg', 'tok-1');
+      expect(stores(), 'writes both dev.azure.com and {org}.visualstudio.com').to.equal(2);
+
+      // Same (org, token) → deduped, no new writes.
+      await api.syncGitCredentials('testorg', 'tok-1');
+      expect(stores(), 'deduped repeat').to.equal(2);
+
+      // A refreshed token re-syncs.
+      await api.syncGitCredentials('testorg', 'tok-2');
+      expect(stores(), 'new token re-syncs').to.equal(4);
+
+      // A different org re-syncs even with the same token.
+      await api.syncGitCredentials('otherorg', 'tok-2');
+      expect(stores(), 'new org re-syncs').to.equal(6);
+    });
+  });
 });

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -116,6 +116,11 @@ const mockPipelineRuns = [
   },
 ];
 
+const mockAdoOrganizations = [
+  { id: 'org-1', name: 'contoso', url: 'https://dev.azure.com/contoso' },
+  { id: 'org-2', name: 'fabrikam', url: 'https://dev.azure.com/fabrikam' },
+];
+
 function createTestAccount(
   overrides: Partial<IntegrationAccount> & { id: string }
 ): IntegrationAccount {
@@ -197,8 +202,23 @@ function setupMockInvoke(): void {
     if (command === 'list_ado_pull_requests') return mockPullRequests;
     if (command === 'query_ado_work_items') return mockWorkItems;
     if (command === 'list_ado_pipeline_runs') return mockPipelineRuns;
+    if (command === 'list_ado_organizations') return mockAdoOrganizations;
     if (command === 'create_ado_pull_request') return mockPullRequests[0];
     if (command === 'sync_git_credential_for_ado') return null;
+
+    // Entra device-code flow (Sign in with Microsoft)
+    if (command === 'oauth_start_device_code') {
+      return {
+        flowId: 'device-flow-1',
+        userCode: 'ABCD-EFGH',
+        verificationUri: 'https://microsoft.com/devicelogin',
+        expiresIn: 900,
+        interval: 1,
+        message: 'Enter the code to sign in.',
+      };
+    }
+    if (command === 'oauth_poll_device_code') return { accessToken: 'ado_oauth_token' };
+    if (command === 'oauth_cancel_device_code') return null;
 
     return null;
   };
@@ -772,15 +792,6 @@ describe('lv-azure-devops-dialog', () => {
           if (command === 'get_unified_profiles_config') {
             return { version: 3, profiles: [], accounts: [...persistedAccounts], repositoryAssignments: {} };
           }
-          // startOAuth must succeed so the deep-link 'oauth-complete' listener is
-          // registered (Azure is deep-link only; no loopback port).
-          if (command === 'oauth_get_authorize_url') {
-            return {
-              authorizeUrl: 'https://login.microsoftonline.com/authorize',
-              state: 'azure-state-persist',
-              loopbackPort: null,
-            };
-          }
           // Echo back the persisted account (with its generated id) like the backend does.
           if (command === 'save_global_account') {
             const account = (args as { account?: IntegrationAccount } | undefined)?.account;
@@ -797,20 +808,13 @@ describe('lv-azure-devops-dialog', () => {
       await waitForLoad(el);
 
       (el as unknown as { organizationInput: string }).organizationInput = 'testorg';
-      (el as unknown as { oauthClientId: string }).oauthClientId = 'client-abc';
       (el as unknown as { selectedAccountId: string | null }).selectedAccountId = null;
       await el.updateComplete;
 
       invokeHistory.length = 0;
-      // Registers the oauth-complete listener.
+      // The device-code poll resolves with tokens, then the org is finalized.
       await (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
-
-      window.dispatchEvent(
-        new CustomEvent('oauth-complete', {
-          detail: { provider: 'azure', tokens: { accessToken: 'ado_oauth_token' } },
-        })
-      );
-      await new Promise((r) => setTimeout(r, 150));
+      await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
 
       const saveCall = invokeHistory.find((h) => h.command === 'save_global_account');
@@ -830,24 +834,17 @@ describe('lv-azure-devops-dialog', () => {
       expect(selected).to.equal((account as { id: string }).id);
     });
 
-    it('Cancel during a pending sign-in tears down the flow so a late deep link does NOT connect', async () => {
+    it('Cancel during a pending device sign-in stops the flow so a late completion does NOT connect', async () => {
       connectionResponse = mockConnectedStatus;
-      // Start with no accounts: if the (cancelled) flow ever completed it would
-      // create a brand-new account via save_global_account.
+      // Poll never resolves, so the flow stays pending and we can cancel mid-flight.
       mockInvoke = (() => {
         const orig = mockInvoke;
         return async (command: string, args?: unknown) => {
           if (command === 'get_unified_profiles_config') {
             return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
           }
-          // Make startOAuth register a real pending flow so cancelOAuth('azure')
-          // has something to tear down (deep-link provider, no loopback port).
-          if (command === 'oauth_get_authorize_url') {
-            return {
-              authorizeUrl: 'https://login.microsoftonline.com/authorize',
-              state: 'azure-state-xyz',
-              loopbackPort: null,
-            };
+          if (command === 'oauth_poll_device_code') {
+            return new Promise(() => { /* never resolves */ });
           }
           return orig(command, args);
         };
@@ -859,67 +856,262 @@ describe('lv-azure-devops-dialog', () => {
       await waitForLoad(el);
 
       (el as unknown as { organizationInput: string }).organizationInput = 'testorg';
-      (el as unknown as { oauthClientId: string }).oauthClientId = 'client-abc';
       (el as unknown as { selectedAccountId: string | null }).selectedAccountId = null;
       await el.updateComplete;
 
-      // Start the flow — registers the oauth-complete listener and sets pending.
-      await (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
+      // Start the flow WITHOUT awaiting — the poll hangs, leaving the device code shown.
+      void (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
       expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.true;
-      expect(
-        (el as unknown as { _pendingOAuthHandler?: EventListener })._pendingOAuthHandler,
-        'a listener is registered after start'
-      ).to.not.be.undefined;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode, 'device code shown').to.not.be.null;
 
       // User clicks Cancel.
       invokeHistory.length = 0;
-      await (el as unknown as { handleCancelEntraOAuth: () => void }).handleCancelEntraOAuth();
+      (el as unknown as { handleCancelEntraOAuth: () => void }).handleCancelEntraOAuth();
       await el.updateComplete;
 
-      // The underlying flow is cancelled and the listener is removed.
+      // The flow is cancelled server-side and the UI resets.
       expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
-      expect(
-        (el as unknown as { _pendingOAuthHandler?: EventListener })._pendingOAuthHandler,
-        'listener removed after cancel'
-      ).to.be.undefined;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.be.null;
+      expect(invokeHistory.some((h) => h.command === 'oauth_cancel_device_code'), 'backend flow cancelled').to.be.true;
 
-      // A late deep-link completion fires AFTER cancel. With the listener gone,
-      // it must NOT verify/persist/connect anything.
-      window.dispatchEvent(
-        new CustomEvent('oauth-complete', {
-          detail: { provider: 'azure', tokens: { accessToken: 'ado_oauth_token' } },
-        })
-      );
-      await new Promise((r) => setTimeout(r, 150));
-      await el.updateComplete;
-
-      expect(
-        invokeHistory.some((h) => h.command === 'check_ado_connection_with_token'),
-        'no connection verification after cancel'
-      ).to.be.false;
-      expect(
-        invokeHistory.some((h) => h.command === 'save_global_account'),
-        'no account persisted after cancel'
-      ).to.be.false;
-      expect(
-        invokeHistory.some((h) => h.command === 'store_keyring_token'),
-        'no token stored after cancel'
-      ).to.be.false;
+      // Nothing was verified or persisted.
+      expect(invokeHistory.some((h) => h.command === 'save_global_account')).to.be.false;
+      expect(invokeHistory.some((h) => h.command === 'store_keyring_token')).to.be.false;
       expect((el as unknown as { selectedAccountId: string | null }).selectedAccountId).to.be.null;
     });
 
-    it('surfaces an error and stops the spinner when Entra OAuth fails (not a stuck dead-end)', async () => {
-      // A failing authorize-url makes startOAuth emit OAuth state 'error' (it does
-      // NOT fire the success-only oauth-complete event). Without the OAuth state
-      // subscription this left the dialog spinning forever.
+    it('closing the dialog mid-sign-in cancels the device flow (no silent late connect)', async () => {
+      connectionResponse = mockConnectedStatus;
       mockInvoke = (() => {
         const orig = mockInvoke;
         return async (command: string, args?: unknown) => {
           if (command === 'get_unified_profiles_config') {
             return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
           }
-          if (command === 'oauth_get_authorize_url') {
-            throw new Error('Entra discovery failed');
+          if (command === 'oauth_poll_device_code') {
+            return new Promise(() => { /* never resolves */ });
+          }
+          return orig(command, args);
+        };
+      })();
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      (el as unknown as { selectedAccountId: string | null }).selectedAccountId = null;
+      await el.updateComplete;
+
+      void (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode, 'device code shown').to.not.be.null;
+
+      // Close via the modal (X / Escape / backdrop all route through handleClose).
+      invokeHistory.length = 0;
+      (el as unknown as { handleClose: () => void }).handleClose();
+      await el.updateComplete;
+
+      expect(invokeHistory.some((h) => h.command === 'oauth_cancel_device_code'), 'flow cancelled on close').to.be.true;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.be.null;
+      expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
+      expect(invokeHistory.some((h) => h.command === 'save_global_account')).to.be.false;
+    });
+
+    it('switching accounts mid-sign-in abandons the device flow (no write to the new account)', async () => {
+      connectionResponse = mockConnectedStatus;
+      mockInvoke = (() => {
+        const orig = mockInvoke;
+        return async (command: string, args?: unknown) => {
+          if (command === 'get_unified_profiles_config') {
+            return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
+          }
+          if (command === 'oauth_poll_device_code') {
+            return new Promise(() => { /* never resolves */ });
+          }
+          return orig(command, args);
+        };
+      })();
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      await el.updateComplete;
+
+      // Start a device flow (poll hangs), showing the device code.
+      void (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.not.be.null;
+
+      // Switching to another account must abandon the flow first.
+      invokeHistory.length = 0;
+      await (el as unknown as { handleAddAccount: () => void }).handleAddAccount();
+      await el.updateComplete;
+
+      expect(invokeHistory.some((h) => h.command === 'oauth_cancel_device_code'), 'flow cancelled on account switch').to.be.true;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.be.null;
+      expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
+      expect(invokeHistory.some((h) => h.command === 'save_global_account')).to.be.false;
+    });
+
+    it('cancelling clears the loading state so the sign-in button is not stuck disabled', async () => {
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Simulate being mid-"Connecting..." (resolveOrgAndFinalize sets both).
+      (el as unknown as { isLoading: boolean }).isLoading = true;
+      (el as unknown as { oauthPending: boolean }).oauthPending = true;
+      await el.updateComplete;
+
+      (el as unknown as { handleCancelEntraOAuth: () => void }).handleCancelEntraOAuth();
+      await el.updateComplete;
+
+      expect((el as unknown as { isLoading: boolean }).isLoading, 'loading cleared on cancel').to.be.false;
+      expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
+    });
+
+    it('Add account clears a stale organization so a new sign-in uses the org picker', async () => {
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // A previously-selected account left an org populated.
+      (el as unknown as { organizationInput: string }).organizationInput = 'previous-org';
+      await el.updateComplete;
+
+      (el as unknown as { handleAddAccount: () => void }).handleAddAccount();
+      await el.updateComplete;
+
+      expect((el as unknown as { organizationInput: string }).organizationInput, 'stale org cleared').to.equal('');
+      expect((el as unknown as { selectedAccountId: string | null }).selectedAccountId).to.be.null;
+    });
+
+    it('switching to the PAT tab mid-sign-in abandons the device flow', async () => {
+      connectionResponse = mockConnectedStatus;
+      mockInvoke = (() => {
+        const orig = mockInvoke;
+        return async (command: string, args?: unknown) => {
+          if (command === 'get_unified_profiles_config') {
+            return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
+          }
+          if (command === 'oauth_poll_device_code') {
+            return new Promise(() => { /* never resolves */ });
+          }
+          return orig(command, args);
+        };
+      })();
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      (el as unknown as { authMethod: string }).authMethod = 'oauth';
+      await el.updateComplete;
+
+      void (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.not.be.null;
+
+      invokeHistory.length = 0;
+      (el as unknown as { setAuthMethod: (m: string) => void }).setAuthMethod('pat');
+      await el.updateComplete;
+
+      expect((el as unknown as { authMethod: string }).authMethod).to.equal('pat');
+      expect(invokeHistory.some((h) => h.command === 'oauth_cancel_device_code'), 'flow cancelled on tab switch').to.be.true;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.be.null;
+      expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
+    });
+
+    it('opening Manage Accounts mid-sign-in abandons the device flow', async () => {
+      connectionResponse = mockConnectedStatus;
+      mockInvoke = (() => {
+        const orig = mockInvoke;
+        return async (command: string, args?: unknown) => {
+          if (command === 'get_unified_profiles_config') {
+            return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
+          }
+          if (command === 'oauth_poll_device_code') {
+            return new Promise(() => { /* never resolves */ });
+          }
+          return orig(command, args);
+        };
+      })();
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      await el.updateComplete;
+
+      void (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.not.be.null;
+
+      invokeHistory.length = 0;
+      (el as unknown as { handleManageAccounts: (e: Event) => void }).handleManageAccounts(new Event('manage'));
+      await el.updateComplete;
+
+      expect(invokeHistory.some((h) => h.command === 'oauth_cancel_device_code'), 'flow cancelled on manage-accounts').to.be.true;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.be.null;
+      expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
+    });
+
+    it('preserves a PAT-typed organization across an OAuth tab round-trip', async () => {
+      // No accounts so nothing is auto-selected (org clearing only applies when
+      // there's no selected account and no detected repo).
+      mockInvoke = (() => {
+        const orig = mockInvoke;
+        return async (command: string, args?: unknown) => {
+          if (command === 'get_unified_profiles_config') {
+            return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
+          }
+          return orig(command, args);
+        };
+      })();
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      const api = el as unknown as {
+        setAuthMethod: (m: string) => void;
+        organizationInput: string;
+        selectedAccountId: string | null;
+      };
+      api.selectedAccountId = null;
+
+      // On the PAT tab the user typed an org (no account/repo context).
+      api.organizationInput = 'my-typed-org';
+
+      // Switch to OAuth: the org is stashed (not used for device-code resolution).
+      api.setAuthMethod('oauth');
+      await el.updateComplete;
+      expect(api.organizationInput, 'org hidden from OAuth resolution').to.equal('');
+
+      // Switch back to PAT: the typed org is restored, not lost.
+      api.setAuthMethod('pat');
+      await el.updateComplete;
+      expect(api.organizationInput, 'PAT org restored').to.equal('my-typed-org');
+    });
+
+    it('surfaces an error and stops the spinner when the device sign-in fails (not a stuck dead-end)', async () => {
+      mockInvoke = (() => {
+        const orig = mockInvoke;
+        return async (command: string, args?: unknown) => {
+          if (command === 'get_unified_profiles_config') {
+            return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
+          }
+          if (command === 'oauth_start_device_code') {
+            throw new Error('Failed to start device sign-in');
           }
           return orig(command, args);
         };
@@ -930,21 +1122,185 @@ describe('lv-azure-devops-dialog', () => {
       `);
       await waitForLoad(el);
       (el as unknown as { organizationInput: string }).organizationInput = 'testorg';
-      (el as unknown as { oauthClientId: string }).oauthClientId = 'client-abc';
       (el as unknown as { selectedAccountId: string | null }).selectedAccountId = null;
       await el.updateComplete;
 
       await (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
       await el.updateComplete;
 
-      // The failure must clear the spinner, surface an error, and tear down the
-      // pending listener — not hang on "Waiting for Microsoft sign-in...".
+      // The failure must clear the spinner and surface an error — not hang.
       expect((el as unknown as { oauthPending: boolean }).oauthPending, 'spinner cleared on failure').to.be.false;
+      expect((el as unknown as { deviceCode: unknown }).deviceCode, 'device code cleared').to.be.null;
       expect((el as unknown as { error: string | null }).error, 'error surfaced').to.be.a('string').and.not.empty;
-      expect(
-        (el as unknown as { _pendingOAuthHandler?: EventListener })._pendingOAuthHandler,
-        'pending listener torn down'
-      ).to.be.undefined;
+    });
+  });
+
+  describe('Entra OAuth tab UI', () => {
+    it('renders a single "Sign in with Microsoft" button with no Client ID or Organization inputs', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      (el as unknown as { authMethod: string }).authMethod = 'oauth';
+      await el.updateComplete;
+
+      const tokenForm = el.shadowRoot!.querySelector('.token-form')!;
+      expect(tokenForm).to.not.be.null;
+
+      // The simplified OAuth path has NO inputs (no Client ID, no Organization).
+      expect(tokenForm.querySelectorAll('input').length).to.equal(0);
+
+      // Exactly the primary "Sign in with Microsoft" button is present.
+      const primaryBtn = tokenForm.querySelector('.btn-primary');
+      expect(primaryBtn).to.not.be.null;
+      expect(primaryBtn!.textContent?.trim()).to.include('Sign in with Microsoft');
+    });
+
+    it('renders an org picker when needsOrgSelection is true with availableOrgs set', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      (el as unknown as { authMethod: string }).authMethod = 'oauth';
+      (el as unknown as { availableOrgs: unknown[] }).availableOrgs = mockAdoOrganizations;
+      (el as unknown as { needsOrgSelection: boolean }).needsOrgSelection = true;
+      await el.updateComplete;
+
+      const tokenForm = el.shadowRoot!.querySelector('.token-form')!;
+      expect(tokenForm.textContent).to.include('Select an organization');
+
+      // One clickable button per available organization.
+      const orgButtons = Array.from(tokenForm.querySelectorAll('.btn')).filter((b) =>
+        ['contoso', 'fabrikam'].includes(b.textContent?.trim() ?? '')
+      );
+      expect(orgButtons.length).to.equal(2);
+
+      // The "Sign in with Microsoft" button is hidden while picking.
+      expect(tokenForm.querySelector('.btn-primary')).to.be.null;
+    });
+
+    it('shows the org picker after sign-in when the org cannot be detected (multiple orgs), and finalizes on selection', async () => {
+      connectionResponse = mockConnectedStatus;
+      mockInvoke = (() => {
+        const orig = mockInvoke;
+        return async (command: string, args?: unknown) => {
+          if (command === 'get_unified_profiles_config') {
+            return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
+          }
+          if (command === 'list_ado_organizations') return mockAdoOrganizations;
+          if (command === 'save_global_account') {
+            const account = (args as { account?: IntegrationAccount } | undefined)?.account;
+            return account ?? null;
+          }
+          return orig(command, args);
+        };
+      })();
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // No detected repo and no org typed → resolution must fall back to listing orgs.
+      (el as unknown as { organizationInput: string }).organizationInput = '';
+      (el as unknown as { selectedAccountId: string | null }).selectedAccountId = null;
+      (el as unknown as { authMethod: string }).authMethod = 'oauth';
+      await el.updateComplete;
+
+      // Device-code poll resolves with a token; org resolution then lists orgs.
+      await (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      expect(invokeHistory.some((h) => h.command === 'list_ado_organizations')).to.be.true;
+      expect((el as unknown as { needsOrgSelection: boolean }).needsOrgSelection).to.be.true;
+
+      const orgButtons = Array.from(el.shadowRoot!.querySelectorAll('.btn')).filter((b) =>
+        ['contoso', 'fabrikam'].includes(b.textContent?.trim() ?? '')
+      );
+      expect(orgButtons.length).to.equal(2);
+
+      // Selecting an org verifies the connection and persists a new account.
+      invokeHistory.length = 0;
+      (orgButtons.find((b) => b.textContent?.trim() === 'fabrikam') as HTMLButtonElement).click();
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      expect(invokeHistory.some((h) => h.command === 'check_ado_connection')).to.be.true;
+      expect(invokeHistory.some((h) => h.command === 'save_global_account')).to.be.true;
+      expect(invokeHistory.some((h) => h.command === 'store_keyring_token')).to.be.true;
+      expect((el as unknown as { needsOrgSelection: boolean }).needsOrgSelection).to.be.false;
+      expect((el as unknown as { organizationInput: string }).organizationInput).to.equal('fabrikam');
+    });
+
+    it('Cancel in the org picker returns to the sign-in button without picking an org', async () => {
+      connectionResponse = mockDisconnectedStatus;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      (el as unknown as { authMethod: string }).authMethod = 'oauth';
+      (el as unknown as { availableOrgs: unknown[] }).availableOrgs = mockAdoOrganizations;
+      (el as unknown as { needsOrgSelection: boolean }).needsOrgSelection = true;
+      (el as unknown as { pendingTokens: unknown }).pendingTokens = { accessToken: 'tok' };
+      await el.updateComplete;
+
+      const cancelBtn = Array.from(el.shadowRoot!.querySelectorAll('.btn')).find(
+        (b) => b.textContent?.trim() === 'Cancel'
+      ) as HTMLButtonElement;
+      expect(cancelBtn, 'org picker has a Cancel button').to.not.be.undefined;
+
+      invokeHistory.length = 0;
+      cancelBtn.click();
+      await el.updateComplete;
+
+      // No account verified/persisted, picker torn down, and the primary button is back.
+      expect(invokeHistory.some((h) => h.command === 'check_ado_connection')).to.be.false;
+      expect((el as unknown as { needsOrgSelection: boolean }).needsOrgSelection).to.be.false;
+      expect((el as unknown as { pendingTokens: unknown }).pendingTokens).to.be.null;
+      expect((el as unknown as { availableOrgs: unknown[] }).availableOrgs).to.have.length(0);
+      const primaryBtn = el.shadowRoot!.querySelector('.token-form .btn-primary');
+      expect(primaryBtn?.textContent?.trim()).to.include('Sign in with Microsoft');
+    });
+
+    it('surfaces an error (not a silent dead-end) when the account has no organizations', async () => {
+      connectionResponse = mockConnectedStatus;
+      mockInvoke = (() => {
+        const orig = mockInvoke;
+        return async (command: string, args?: unknown) => {
+          if (command === 'get_unified_profiles_config') {
+            return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
+          }
+          if (command === 'list_ado_organizations') return []; // no orgs for this account
+          return orig(command, args);
+        };
+      })();
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      (el as unknown as { organizationInput: string }).organizationInput = '';
+      (el as unknown as { authMethod: string }).authMethod = 'oauth';
+      await el.updateComplete;
+
+      await (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      // Error surfaced, spinner cleared, and no half-finished picker left behind.
+      expect((el as unknown as { error: string | null }).error, 'error surfaced').to.be.a('string').and.not.empty;
+      expect((el as unknown as { oauthPending: boolean }).oauthPending, 'spinner cleared').to.be.false;
+      expect((el as unknown as { needsOrgSelection: boolean }).needsOrgSelection).to.be.false;
+      expect(invokeHistory.some((h) => h.command === 'save_global_account')).to.be.false;
     });
   });
 

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -616,6 +616,8 @@ export class LvAzureDevOpsDialog extends LitElement {
   private deviceFlowId: string | null = null;
   /** Org typed on the PAT form, stashed while on the OAuth tab so it survives a round-trip. */
   private savedPatOrg = '';
+  /** Last `${org}::${token}` written to the keyring git credential, to skip redundant re-syncs. */
+  private lastSyncedGitCredKey: string | null = null;
   /**
    * Bumped whenever an Entra sign-in should be abandoned (new start, cancel,
    * close, disconnect). Async continuations capture the value at start and bail
@@ -821,7 +823,7 @@ export class LvAzureDevOpsDialog extends LitElement {
     const org = this.detectedRepo?.organization || this.organizationInput;
     if (!org) return;
 
-    // Get token for selected account (or legacy token if no account)
+    // Get token for selected account (refresh-aware for OAuth accounts).
     const token = await this.getSelectedAccountToken();
     const result = await gitService.checkAdoConnectionWithToken(org, token);
     if (result.success && result.data) {
@@ -837,17 +839,10 @@ export class LvAzureDevOpsDialog extends LitElement {
         });
       }
 
-      // Ensure git credentials are stored in keyring for push/pull operations
-      if (result.data.connected && org && token) {
-        try {
-          // Store for both dev.azure.com and {org}.visualstudio.com formats
-          // Username must be non-empty for macOS Keychain - use 'pat' as a placeholder
-          await gitService.storeGitCredentials('https://dev.azure.com', 'pat', token);
-          await gitService.storeGitCredentials(`https://${org}.visualstudio.com`, 'pat', token);
-          log.debug(`Synced git credentials to keyring for dev.azure.com and ${org}.visualstudio.com`);
-        } catch (err) {
-          log.warn('Failed to sync git credentials to keyring:', err);
-        }
+      // Sync the keyring git credentials only with a VERIFIED-connected token, so
+      // external git push/pull get a valid credential (never a stale fallback).
+      if (result.data.connected && token) {
+        await this.syncGitCredentials(org, token);
       }
     } else if (!result.success) {
       log.error('checkConnection failed:', result.error?.message);
@@ -859,13 +854,20 @@ export class LvAzureDevOpsDialog extends LitElement {
   }
 
   /**
-   * Get the token for the currently selected account
+   * Get the token for the currently selected account, refreshing an expiring
+   * Entra OAuth token first (and re-syncing the keyring git credentials so
+   * push/pull stay valid). Non-OAuth (PAT) accounts return their stored token.
    */
   private async getSelectedAccountToken(): Promise<string | null> {
     if (!this.selectedAccountId) return null;
 
-    // Check account-specific token
-    let token = await credentialService.getAccountToken('azure-devops', this.selectedAccountId);
+    // Refresh-aware: for an OAuth account this returns a freshly-refreshed access
+    // token when the stored one is near expiry; for a PAT it returns it unchanged.
+    let token = await credentialService.getFreshAccountToken(
+      'azure-devops',
+      this.selectedAccountId,
+      'azure',
+    );
 
     // If not found, check legacy token and migrate it
     if (!token) {
@@ -879,6 +881,28 @@ export class LvAzureDevOpsDialog extends LitElement {
     }
 
     return token;
+  }
+
+  /**
+   * Write the git credentials for `org` to the OS keyring so git push/pull
+   * outside this dialog use a valid credential. Only call this with a token that
+   * has been VERIFIED to work (a connected check) — never a stale fallback, which
+   * would clobber a previously-valid credential. Deduped by (org, token) to avoid
+   * redundant keyring writes on hot paths.
+   */
+  private async syncGitCredentials(org: string, token: string): Promise<void> {
+    const syncKey = `${org}::${token}`;
+    if (syncKey === this.lastSyncedGitCredKey) return;
+    // storeGitCredentials resolves to a CommandResult (it never throws), so check
+    // .success and only mark synced on success — otherwise a failed write would be
+    // stickily suppressed and never retried.
+    const c1 = await gitService.storeGitCredentials('https://dev.azure.com', 'pat', token);
+    const c2 = await gitService.storeGitCredentials(`https://${org}.visualstudio.com`, 'pat', token);
+    if (c1.success && c2.success) {
+      this.lastSyncedGitCredKey = syncKey;
+    } else {
+      log.warn('Failed to sync Azure DevOps git credentials to keyring:', c1.error ?? c2.error);
+    }
   }
 
   /**
@@ -1276,17 +1300,17 @@ export class LvAzureDevOpsDialog extends LitElement {
 
       // Store git credentials in keyring for push/pull operations. Non-fatal:
       // a keyring failure must not undo an otherwise-successful sign-in.
-      // Username must be non-empty for macOS Keychain - use 'pat' as a placeholder.
-      // Store for both dev.azure.com and {org}.visualstudio.com formats.
-      // NOTE: this stores the short-lived Entra access token (~1h). It is not
-      // auto-refreshed today, so git push/pull may require re-running "Sign in
-      // with Microsoft" after it expires (the account token keeps its refresh
-      // token via storeAccountOAuthToken for a future refresh path).
+      // The stored access token (~1h) is refreshed on-demand by getFreshAccountToken
+      // (using the refresh token persisted above via storeAccountOAuthToken), so
+      // in-app git push/pull keep working past expiry.
       // storeGitCredentials resolves to a CommandResult (it never throws), so
       // check .success rather than relying on a catch.
       const cred1 = await gitService.storeGitCredentials('https://dev.azure.com', 'pat', accessToken);
       const cred2 = await gitService.storeGitCredentials(`https://${organization}.visualstudio.com`, 'pat', accessToken);
-      if (!cred1.success || !cred2.success) {
+      if (cred1.success && cred2.success) {
+        // Record the synced (org, token) so checkConnection doesn't re-write it.
+        this.lastSyncedGitCredKey = `${organization}::${accessToken}`;
+      } else {
         log.warn('Failed to store Azure DevOps git credentials for push/pull:', cred1.error ?? cred2.error);
         showToast('Signed in, but saving git credentials failed — push/pull may prompt for credentials', 'error');
       }
@@ -1541,6 +1565,10 @@ export class LvAzureDevOpsDialog extends LitElement {
       if (this.organizationInput) {
         await gitService.deleteGitCredentials(`https://${this.organizationInput}.visualstudio.com`);
       }
+      // Deleted creds — force a re-sync on the next connect even if the token
+      // matches, both here and in the git.service token path (external git).
+      this.lastSyncedGitCredKey = null;
+      gitService.resetAdoGitCredentialSyncCache();
       log.debug('Deleted git credentials from keyring');
 
       this.syncSharedConnectionStatus(false);
@@ -1600,6 +1628,8 @@ export class LvAzureDevOpsDialog extends LitElement {
         if (organization) {
           await gitService.deleteGitCredentials(`https://${organization}.visualstudio.com`);
         }
+        this.lastSyncedGitCredKey = null;
+        gitService.resetAdoGitCredentialSyncCache();
       } catch (tokenErr) {
         const msg =
           tokenErr instanceof Error

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -20,6 +20,7 @@ import type {
   AdoPullRequest,
   AdoWorkItem,
   AdoPipelineRun,
+  AdoOrganization,
   CreateAdoPullRequestInput,
   CreateAdoWorkItemInput,
 } from '../../services/git.service.ts';
@@ -31,6 +32,13 @@ import './lv-modal.ts';
 import './lv-account-selector.ts';
 
 type TabType = 'connection' | 'pull-requests' | 'work-items' | 'pipelines' | 'create-pr' | 'create-work-item';
+
+/** OAuth tokens carried from an Entra sign-in through org resolution to persistence. */
+interface EntraTokens {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+}
 
 @customElement('lv-azure-devops-dialog')
 export class LvAzureDevOpsDialog extends LitElement {
@@ -161,6 +169,20 @@ export class LvAzureDevOpsDialog extends LitElement {
       .help-text {
         font-size: var(--font-size-xs);
         color: var(--color-text-muted);
+      }
+
+      .device-code {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-xl);
+        font-weight: var(--font-weight-semibold);
+        letter-spacing: 0.15em;
+        text-align: center;
+        padding: var(--spacing-md);
+        background: var(--color-bg-tertiary);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        color: var(--color-text-primary);
+        user-select: all;
       }
 
       .help-link {
@@ -586,8 +608,23 @@ export class LvAzureDevOpsDialog extends LitElement {
   @state() private organizationInput = '';
   @state() private hasStoredToken = false;
   @state() private authMethod: 'oauth' | 'pat' = 'pat';
-  @state() private oauthClientId = '';
+  /** True from the moment "Sign in with Microsoft" is clicked until the flow settles. */
   @state() private oauthPending = false;
+  /** The device code + verification URL to show the user while they sign in. */
+  @state() private deviceCode: { userCode: string; verificationUri: string } | null = null;
+  /** Handle for the in-flight device-code flow (used to poll/cancel it). */
+  private deviceFlowId: string | null = null;
+  /** Org typed on the PAT form, stashed while on the OAuth tab so it survives a round-trip. */
+  private savedPatOrg = '';
+  /**
+   * Bumped whenever an Entra sign-in should be abandoned (new start, cancel,
+   * close, disconnect). Async continuations capture the value at start and bail
+   * if it changed — so closing the dialog mid-finalize can't silently connect.
+   */
+  private entraGeneration = 0;
+  @state() private availableOrgs: AdoOrganization[] = [];
+  @state() private needsOrgSelection = false;
+  private pendingTokens: EntraTokens | null = null;
   @state() private prFilter: 'active' | 'completed' | 'abandoned' | 'all' = 'active';
   @state() private workItemFilter: string = '';
 
@@ -596,8 +633,6 @@ export class LvAzureDevOpsDialog extends LitElement {
   @state() private selectedAccountId: string | null = null;
 
   private unsubscribeStore?: () => void;
-  private _pendingOAuthHandler?: EventListener;
-  private oauthStateUnsubscribe?: () => void;
   private loadGeneration = 0;
   // Set while the user is mid-"Add account" (selection intentionally cleared so
   // the next save creates a NEW account). Guards the store subscription from
@@ -653,31 +688,6 @@ export class LvAzureDevOpsDialog extends LitElement {
       }
     });
 
-    // Subscribe to OAuth state so a FAILED/denied Entra sign-in is surfaced
-    // (Azure is deep-link only and the success-path `oauth-complete` event never
-    // fires on failure — without this the dialog would spin forever). Mirrors
-    // the other provider dialogs.
-    this.oauthStateUnsubscribe = oauthService.onOAuthStateChange((state) => {
-      if (state.provider !== 'azure') return;
-      if (state.status === 'error') {
-        this.oauthPending = false;
-        this.error = state.error ?? 'Microsoft sign-in failed';
-        showToast(this.error, 'error');
-        // Tear down the pending success-listener INLINE. Do NOT call
-        // handleCancelEntraOAuth() here: this callback can fire synchronously
-        // from inside oauthService (during startOAuth's own error dispatch),
-        // and handleCancelEntraOAuth() re-enters oauthService.cancelOAuth(),
-        // which re-emits state from within the in-flight dispatch — a re-entrant
-        // cascade. Cleaning up locally keeps this idempotent and loop-free.
-        if (this._pendingOAuthHandler) {
-          window.removeEventListener('oauth-complete', this._pendingOAuthHandler);
-          this._pendingOAuthHandler = undefined;
-        }
-      } else if (state.status === 'idle') {
-        this.oauthPending = false;
-      }
-    });
-
     // Initialize from current state
     this.accounts = getAccountsByType('azure-devops');
     if (this.accounts.length > 0 && !this.selectedAccountId) {
@@ -696,18 +706,19 @@ export class LvAzureDevOpsDialog extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.unsubscribeStore?.();
-    this.oauthStateUnsubscribe?.();
-    // Clean up pending OAuth listener to prevent leak
-    if (this._pendingOAuthHandler) {
-      window.removeEventListener('oauth-complete', this._pendingOAuthHandler);
-      this._pendingOAuthHandler = undefined;
-    }
+    // Cancel any in-flight device-code sign-in so it doesn't poll after unmount,
+    // and invalidate continuations so a late finalize can't mutate a dead element.
+    this.abandonPendingEntraFlow();
   }
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     if (changedProperties.has('open') && this.open) {
-      // Fresh open: clear selectedAccountId so loadInitialData() re-derives
-      // it from the current active profile's preferred account.
+      // Fresh open: abandon any sign-in left in-flight from a prior session
+      // (the host may hide the dialog without routing through handleClose, e.g.
+      // by setting its `open` prop false), so a reopen can't surface a stale
+      // device code or a stuck "Connecting..." spinner. Then clear
+      // selectedAccountId so loadInitialData() re-derives it.
+      this.abandonPendingEntraFlow();
       this.selectedAccountId = null;
       await this.loadInitialData();
     }
@@ -875,6 +886,10 @@ export class LvAzureDevOpsDialog extends LitElement {
    */
   private async handleAccountChange(e: CustomEvent<{ account: IntegrationAccount }>): Promise<void> {
     const { account } = e.detail;
+    // Abandon any in-flight Entra sign-in BEFORE switching accounts, or a
+    // completing flow would persist its token/identity onto the newly selected
+    // account.
+    this.abandonPendingEntraFlow();
     // The user explicitly selected an existing account — re-enable the
     // subscription's auto-apply branch.
     this.isAddingAccount = false;
@@ -899,19 +914,30 @@ export class LvAzureDevOpsDialog extends LitElement {
    * Handle add account request
    */
   private handleAddAccount(): void {
+    // Abandon any in-flight Entra sign-in before clearing the selection, or a
+    // completing flow would create/overwrite an unexpected account.
+    this.abandonPendingEntraFlow();
     // Clear selection so the next token save creates a new account instead of
-    // overwriting the previously-selected account's token.
+    // overwriting the previously-selected account's token. Also clear the org:
+    // otherwise a new Entra sign-in would reuse the previous account's org and
+    // bypass the org picker (binding the new account to the wrong org). Rotating
+    // an existing selected account still uses that account's org.
     this.isAddingAccount = true;
     this.activeTab = 'connection';
     this.connectionStatus = null;
     this.selectedAccountId = null;
     this.tokenInput = '';
+    this.organizationInput = '';
   }
 
   /**
    * Handle manage accounts request
    */
   private handleManageAccounts(e: Event): void {
+    // Navigating to the Accounts view hides (but doesn't unmount) this dialog and
+    // can re-derive selectedAccountId on the way back, so abandon any in-flight
+    // Entra sign-in first — otherwise a late poll could write to the wrong account.
+    this.abandonPendingEntraFlow();
     // Consume the account-selector's bubbling/composed event so it can't ALSO
     // reach the host — otherwise the host would receive both it and our re-dispatch
     // below, firing its handler twice (the second pass corrupts reversible-Back state).
@@ -1019,139 +1045,325 @@ export class LvAzureDevOpsDialog extends LitElement {
     }
   }
 
+  /**
+   * Start the one-click Microsoft (Entra ID) sign-in via the OAuth device-code
+   * flow. Shows the user a short code to enter at a verification URL, opens that
+   * URL in the browser, then blocks on the backend poll until the user finishes.
+   * Uses the embedded public client — no per-user app registration and no
+   * redirect URI (device code needs neither).
+   */
   private async handleStartEntraOAuth(): Promise<void> {
-    if (!this.organizationInput.trim() || !this.oauthClientId.trim()) return;
+    // Guard against a double-click starting a second (orphaned) device flow.
+    if (this.oauthPending) return;
 
-    // Remove any existing listener from a prior sign-in attempt before
-    // registering a new one, to avoid orphaned 'oauth-complete' listeners.
-    if (this._pendingOAuthHandler) {
-      window.removeEventListener('oauth-complete', this._pendingOAuthHandler);
-      this._pendingOAuthHandler = undefined;
-    }
-
+    const generation = ++this.entraGeneration;
     this.oauthPending = true;
     this.error = null;
+    this.deviceCode = null;
 
     try {
-      // Start OAuth flow with Entra ID
-      await oauthService.startOAuth('azure', this.oauthClientId);
-
-      // If the flow already failed synchronously, the OAuth-state subscription
-      // above has cleared the spinner and surfaced the error. Don't register the
-      // success-path listener for a flow that never opened — that would leave an
-      // orphaned 'oauth-complete' listener after a failed start.
-      if (!this.oauthPending) {
+      const start = await oauthService.startDeviceCode('azure', oauthService.getClientId('azure'));
+      if (generation !== this.entraGeneration) {
+        // Cancelled/closed while starting: abandonPendingEntraFlow ran before we
+        // knew the flow id, so cancel the now-orphaned backend flow here.
+        void oauthService.cancelDeviceCode(start.flowId);
         return;
       }
+      this.deviceFlowId = start.flowId;
+      this.deviceCode = { userCode: start.userCode, verificationUri: start.verificationUri };
 
-      // For Azure, deep link is used — wait for the oauth-complete event
-      const handleComplete = async (e: Event) => {
-        const detail = (e as CustomEvent).detail;
-        if (detail?.provider !== 'azure') return;
+      // Open the verification page so the user only has to enter the code.
+      openExternalUrl(start.verificationUri);
 
-        window.removeEventListener('oauth-complete', handleComplete);
-        this._pendingOAuthHandler = undefined;
-        this.oauthPending = false;
+      // Blocks until the user completes sign-in (or it is cancelled / times out).
+      const tokens = await oauthService.pollDeviceCode(start.flowId);
 
-        if (detail.error) {
-          this.error = detail.error;
-          showToast(`OAuth failed: ${detail.error}`, 'error');
-          return;
-        }
+      // The user may have cancelled (or started a new flow) while we waited.
+      if (generation !== this.entraGeneration) return;
 
-        if (detail.tokens?.accessToken) {
-          const accessToken = detail.tokens.accessToken;
-          const organization = this.organizationInput.trim();
-
-          // Verify connection BEFORE persisting anything
-          const result = await gitService.checkAdoConnectionWithToken(organization, accessToken);
-
-          if (result.success && result.data?.connected) {
-            const user = result.data.user;
-            const cachedUser = user
-              ? {
-                  username: user.displayName,
-                  displayName: user.displayName,
-                  email: null, // ADO API doesn't return email in this context
-                  avatarUrl: user.imageUrl ?? null,
-                }
-              : null;
-
-            if (this.selectedAccountId) {
-              // Rotating credentials on an existing account
-              await credentialService.storeAccountToken(
-                'azure-devops',
-                this.selectedAccountId,
-                accessToken,
-              );
-              if (cachedUser) {
-                await unifiedProfileService.updateGlobalAccountCachedUser(
-                  this.selectedAccountId,
-                  cachedUser,
-                );
-              }
-            } else {
-              // No account selected - create and persist a new global account
-              // (mirror the PAT path) BEFORE storing the token so the keyring
-              // entry is never orphaned.
-              const { createEmptyIntegrationAccount, generateId } = await import(
-                '../../types/unified-profile.types.ts'
-              );
-              const newAccount: IntegrationAccount = {
-                ...createEmptyIntegrationAccount('azure-devops', organization),
-                id: generateId(),
-                name: user?.displayName
-                  ? `Azure DevOps (${user.displayName})`
-                  : `Azure DevOps (${organization})`,
-                isDefault: this.accounts.length === 0,
-                cachedUser,
-              };
-
-              const savedAccount = await unifiedProfileService.saveGlobalAccount(newAccount);
-              await credentialService.storeAccountToken('azure-devops', savedAccount.id, accessToken);
-              this.selectedAccountId = savedAccount.id;
-              // The new account now exists and is selected — add flow complete.
-              this.isAddingAccount = false;
-
-              // Refresh accounts list
-              await unifiedProfileService.loadUnifiedProfiles();
-              this.accounts = getAccountsByType('azure-devops');
-            }
-
-            this.connectionStatus = result.data;
-            this.syncSharedConnectionStatus(true);
-            showToast('Connected to Azure DevOps via Microsoft Entra ID', 'success');
-          } else {
-            this.error = 'Connection verification failed';
-            showToast('OAuth token received but connection verification failed', 'error');
-          }
-        }
-      };
-
-      window.addEventListener('oauth-complete', handleComplete);
-      this._pendingOAuthHandler = handleComplete;
+      this.deviceCode = null;
+      this.deviceFlowId = null;
+      // resolveOrgAndFinalize owns the loading/error/oauthPending state from here.
+      await this.resolveOrgAndFinalize(
+        {
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          expiresIn: tokens.expiresIn,
+        },
+        generation,
+      );
     } catch (err) {
-      this.error = err instanceof Error ? err.message : 'OAuth flow failed';
+      // A cancel/close races the poll rejection; only surface if still current.
+      if (generation !== this.entraGeneration) return;
+      this.error = err instanceof Error ? err.message : 'Microsoft sign-in failed';
       showToast(this.error, 'error');
+      this.deviceCode = null;
+      this.deviceFlowId = null;
       this.oauthPending = false;
     }
   }
 
   /**
-   * Cancel a pending Entra ID OAuth sign-in.
+   * Resolve which Azure DevOps organization to use after an Entra sign-in, then
+   * finalize. Prefer the org detected from the repo remote; otherwise list the
+   * user's orgs — 1 is used automatically, >1 shows an in-dialog picker, 0 errors.
+   */
+  private async resolveOrgAndFinalize(tokens: EntraTokens, generation: number): Promise<void> {
+    this.isLoading = true;
+    this.error = null;
+    try {
+      let org = this.detectedRepo?.organization || this.organizationInput.trim();
+      if (!org) {
+        const orgsResult = await gitService.listAdoOrganizations(tokens.accessToken);
+        if (generation !== this.entraGeneration) return; // dialog closed/cancelled
+        if (!orgsResult.success || !orgsResult.data) {
+          this.error = orgsResult.error?.message ?? 'Failed to list Azure DevOps organizations';
+          showToast(this.error, 'error');
+          return;
+        }
+        if (orgsResult.data.length === 1) {
+          org = orgsResult.data[0].name;
+        } else if (orgsResult.data.length > 1) {
+          // Defer: let the user pick. Stash tokens + orgs and show the picker.
+          this.availableOrgs = orgsResult.data;
+          this.pendingTokens = tokens;
+          this.needsOrgSelection = true;
+          return;
+        } else {
+          this.error = 'No Azure DevOps organizations found for this Microsoft account';
+          showToast(this.error, 'error');
+          return;
+        }
+      }
+      this.organizationInput = org;
+      await this.finalizeEntraLogin(tokens, org, generation);
+    } catch (err) {
+      if (generation !== this.entraGeneration) return;
+      this.error = err instanceof Error ? err.message : 'Failed to complete Microsoft sign-in';
+      showToast(this.error, 'error');
+    } finally {
+      // Only reset shared state if this flow is still current — a superseding
+      // flow (close→reopen→restart) may already own oauthPending/isLoading.
+      if (generation === this.entraGeneration) {
+        this.oauthPending = false;
+        this.isLoading = false;
+      }
+    }
+  }
+
+  /**
+   * Complete an in-dialog org selection: finalize the sign-in with the chosen
+   * organization. The picker is only dismissed on success — on failure the token
+   * and org list are retained so the user can pick another org without re-signing.
+   */
+  private async handleSelectOrg(org: AdoOrganization): Promise<void> {
+    const tokens = this.pendingTokens;
+    if (!tokens) return;
+    const generation = this.entraGeneration;
+    this.isLoading = true;
+    this.error = null;
+    try {
+      this.organizationInput = org.name;
+      await this.finalizeEntraLogin(tokens, org.name, generation);
+      if (generation !== this.entraGeneration) return; // dialog closed while finalizing
+      // finalizeEntraLogin sets this.error on verification failure without throwing.
+      if (!this.error) {
+        this.needsOrgSelection = false;
+        this.pendingTokens = null;
+        this.availableOrgs = [];
+      }
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to complete Microsoft sign-in';
+      showToast(this.error, 'error');
+      // Keep the picker + tokens so the user can retry or choose another org.
+    } finally {
+      if (generation === this.entraGeneration) {
+        this.isLoading = false;
+      }
+    }
+  }
+
+  /**
+   * Abandon a pending org selection and return to the "Sign in with Microsoft"
+   * button, discarding the unused token and org list.
+   */
+  private handleCancelOrgSelection(): void {
+    this.needsOrgSelection = false;
+    this.pendingTokens = null;
+    this.availableOrgs = [];
+    this.error = null;
+  }
+
+  /**
+   * Verify the Entra token against `organization`, then persist the account,
+   * OAuth token (with refresh token + expiry), and git credentials. Handles both
+   * rotating an existing account and creating a new one (mirrors the PAT path).
+   */
+  private async finalizeEntraLogin(
+    tokens: EntraTokens,
+    organization: string,
+    generation: number,
+  ): Promise<void> {
+    const accessToken = tokens.accessToken;
+    // Verify connection BEFORE persisting anything
+    const result = await gitService.checkAdoConnectionWithToken(organization, accessToken);
+
+    // If the dialog was closed/cancelled during verification, do NOT persist an
+    // account, store credentials, or show a success toast for a dismissed flow.
+    if (generation !== this.entraGeneration) return;
+
+    if (result.success && result.data?.connected) {
+      const user = result.data.user;
+      const cachedUser = user
+        ? {
+            username: user.displayName,
+            displayName: user.displayName,
+            email: null, // ADO API doesn't return email in this context
+            avatarUrl: user.imageUrl ?? null,
+          }
+        : null;
+
+      if (this.selectedAccountId) {
+        // Rotating credentials on an existing account. Store the full OAuth
+        // bundle (access + refresh + expiry) so the token can be refreshed —
+        // Entra access tokens are short-lived (~1h).
+        await credentialService.storeAccountOAuthToken(
+          'azure-devops',
+          this.selectedAccountId,
+          accessToken,
+          tokens.refreshToken,
+          tokens.expiresIn,
+        );
+        if (cachedUser) {
+          await unifiedProfileService.updateGlobalAccountCachedUser(
+            this.selectedAccountId,
+            cachedUser,
+          );
+        }
+      } else {
+        // No account selected - create and persist a new global account
+        // (mirror the PAT path) BEFORE storing the token so the keyring
+        // entry is never orphaned.
+        const { createEmptyIntegrationAccount, generateId } = await import(
+          '../../types/unified-profile.types.ts'
+        );
+        const newAccount: IntegrationAccount = {
+          ...createEmptyIntegrationAccount('azure-devops', organization),
+          id: generateId(),
+          name: user?.displayName
+            ? `Azure DevOps (${user.displayName})`
+            : `Azure DevOps (${organization})`,
+          isDefault: this.accounts.length === 0,
+          cachedUser,
+        };
+
+        const savedAccount = await unifiedProfileService.saveGlobalAccount(newAccount);
+        await credentialService.storeAccountOAuthToken(
+          'azure-devops',
+          savedAccount.id,
+          accessToken,
+          tokens.refreshToken,
+          tokens.expiresIn,
+        );
+        this.selectedAccountId = savedAccount.id;
+        // The new account now exists and is selected — add flow complete.
+        this.isAddingAccount = false;
+
+        // Refresh accounts list
+        await unifiedProfileService.loadUnifiedProfiles();
+        this.accounts = getAccountsByType('azure-devops');
+      }
+
+      // Store git credentials in keyring for push/pull operations. Non-fatal:
+      // a keyring failure must not undo an otherwise-successful sign-in.
+      // Username must be non-empty for macOS Keychain - use 'pat' as a placeholder.
+      // Store for both dev.azure.com and {org}.visualstudio.com formats.
+      // NOTE: this stores the short-lived Entra access token (~1h). It is not
+      // auto-refreshed today, so git push/pull may require re-running "Sign in
+      // with Microsoft" after it expires (the account token keeps its refresh
+      // token via storeAccountOAuthToken for a future refresh path).
+      // storeGitCredentials resolves to a CommandResult (it never throws), so
+      // check .success rather than relying on a catch.
+      const cred1 = await gitService.storeGitCredentials('https://dev.azure.com', 'pat', accessToken);
+      const cred2 = await gitService.storeGitCredentials(`https://${organization}.visualstudio.com`, 'pat', accessToken);
+      if (!cred1.success || !cred2.success) {
+        log.warn('Failed to store Azure DevOps git credentials for push/pull:', cred1.error ?? cred2.error);
+        showToast('Signed in, but saving git credentials failed — push/pull may prompt for credentials', 'error');
+      }
+
+      this.connectionStatus = result.data;
+      this.syncSharedConnectionStatus(true);
+      showToast('Connected to Azure DevOps via Microsoft Entra ID', 'success');
+
+      // Populate the PR / work-item / pipeline tabs immediately (mirror the PAT
+      // path) so they aren't empty until the user clicks each tab.
+      if (this.connectionStatus?.connected && this.detectedRepo) {
+        await this.loadAllData(accessToken);
+      }
+    } else {
+      this.error = 'Connection verification failed';
+      showToast('OAuth token received but connection verification failed', 'error');
+    }
+  }
+
+  /**
+   * Cancel a pending Entra ID device-code sign-in.
    *
-   * Azure uses a deep-link callback, so simply clearing `oauthPending` would
-   * leave the 'oauth-complete' listener registered — if the browser sign-in
-   * later completed, the deep link would silently verify/persist/connect an
-   * account. Cancel the underlying flow AND remove the listener.
+   * Clearing `deviceFlowId` first makes the in-flight poll's result be ignored
+   * (see handleStartEntraOAuth), and cancelDeviceCode stops the server-side poll.
    */
   private handleCancelEntraOAuth(): void {
-    oauthService.cancelOAuth('azure');
-    if (this._pendingOAuthHandler) {
-      window.removeEventListener('oauth-complete', this._pendingOAuthHandler);
-      this._pendingOAuthHandler = undefined;
-    }
+    this.abandonPendingEntraFlow();
+  }
+
+  /**
+   * Abandon any in-flight Entra sign-in: bump the generation so async
+   * continuations (poll/finalize) bail, cancel the backend device flow, and
+   * clear all transient sign-in UI state. Safe to call when no flow is active.
+   * MUST be called before anything that changes the target account
+   * (selectedAccountId) mid-flow, or a completing flow would write to the wrong
+   * account.
+   */
+  private abandonPendingEntraFlow(): void {
+    this.entraGeneration++;
+    const flowId = this.deviceFlowId;
+    this.deviceFlowId = null;
+    this.deviceCode = null;
     this.oauthPending = false;
+    // Bumping the generation makes resolveOrgAndFinalize's finally skip its own
+    // reset, so clear isLoading here too — otherwise cancelling during
+    // "Connecting..." would leave the sign-in button disabled forever.
+    this.isLoading = false;
+    this.needsOrgSelection = false;
+    this.pendingTokens = null;
+    this.availableOrgs = [];
+    if (flowId) {
+      void oauthService.cancelDeviceCode(flowId);
+    }
+  }
+
+  /**
+   * Switch between the "Sign in with Microsoft" and PAT tabs. Abandons any
+   * in-flight Entra sign-in so it can't complete underneath the other view, and
+   * when entering the OAuth tab without a selected account or detected repo,
+   * drops any org left over from the PAT form so device-code sign-in goes through
+   * org detection/listing instead of silently reusing a stray value.
+   */
+  private setAuthMethod(method: 'oauth' | 'pat'): void {
+    if (this.oauthPending || this.deviceCode || this.needsOrgSelection) {
+      this.abandonPendingEntraFlow();
+    }
+    if (method === 'oauth' && !this.selectedAccountId && !this.detectedRepo) {
+      // The OAuth path resolves the org from the repo/picker, not a typed value.
+      // Stash (don't destroy) any org typed on the PAT form so it survives a
+      // round-trip back to the PAT tab.
+      this.savedPatOrg = this.organizationInput;
+      this.organizationInput = '';
+    } else if (method === 'pat' && !this.organizationInput && this.savedPatOrg) {
+      this.organizationInput = this.savedPatOrg;
+      this.savedPatOrg = '';
+    }
+    this.authMethod = method;
   }
 
   private async handleConnectWithStoredToken(): Promise<void> {
@@ -1515,6 +1727,12 @@ export class LvAzureDevOpsDialog extends LitElement {
   }
 
   private handleClose(): void {
+    // The element stays mounted (only `open` toggles), so disconnectedCallback
+    // does NOT fire on close. Abandon any in-flight sign-in here so a background
+    // poll OR a still-running finalize can't silently connect an account after
+    // the user dismissed the dialog, and discard org-picker state so nothing
+    // reappears stale on reopen.
+    this.abandonPendingEntraFlow();
     this.dispatchEvent(new CustomEvent('close'));
   }
 
@@ -1581,56 +1799,66 @@ export class LvAzureDevOpsDialog extends LitElement {
         <div class="auth-method-toggle" style="display:flex;gap:0;margin-bottom:12px;border:1px solid var(--color-border);border-radius:6px;overflow:hidden">
           <button
             style="flex:1;padding:8px;border:none;cursor:pointer;font-size:13px;background:${this.authMethod === 'oauth' ? 'var(--color-accent)' : 'transparent'};color:${this.authMethod === 'oauth' ? 'white' : 'var(--color-text-secondary)'}"
-            @click=${() => { this.authMethod = 'oauth'; }}
+            @click=${() => this.setAuthMethod('oauth')}
           >Sign in with Microsoft</button>
           <button
             style="flex:1;padding:8px;border:none;border-left:1px solid var(--color-border);cursor:pointer;font-size:13px;background:${this.authMethod === 'pat' ? 'var(--color-accent)' : 'transparent'};color:${this.authMethod === 'pat' ? 'white' : 'var(--color-text-secondary)'}"
-            @click=${() => { this.authMethod = 'pat'; }}
+            @click=${() => this.setAuthMethod('pat')}
           >Personal Access Token</button>
         </div>
 
         ${this.authMethod === 'oauth' ? html`
-          <!-- Entra ID OAuth -->
-          <div class="form-group">
-            <label>Organization</label>
-            <input
-              type="text"
-              placeholder="my-organization"
-              .value=${this.organizationInput}
-              @input=${(e: Event) => this.organizationInput = (e.target as HTMLInputElement).value}
-            />
-          </div>
-          <div class="form-group">
-            <label>Entra ID Client ID</label>
-            <input
-              type="text"
-              placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-              .value=${this.oauthClientId}
-              @input=${(e: Event) => this.oauthClientId = (e.target as HTMLInputElement).value}
-            />
-            <span class="help-text">
-              Register an app at
-              <a class="help-link" href="https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade" @click=${handleExternalLink}>Azure Portal</a>
-              → Entra ID → App registrations. Add redirect URI: <code>leviathan://oauth/azure/callback</code> (Public client/native).
-              Add API permission: Azure DevOps → user_impersonation.
-            </span>
-          </div>
-          ${this.oauthPending ? html`
+          <!-- Entra ID OAuth (device-code flow) -->
+          ${this.deviceCode ? html`
+            <div class="form-group">
+              <label>Sign in with Microsoft</label>
+              <p class="help-text">
+                Open
+                <a class="help-link" href=${this.deviceCode.verificationUri} @click=${handleExternalLink}>${this.deviceCode.verificationUri}</a>
+                (it should open automatically) and enter this code:
+              </p>
+              <div class="device-code" aria-label="Device code">${this.deviceCode.userCode}</div>
+              <div style="display:flex;align-items:center;gap:8px;padding-top:8px;color:var(--color-text-secondary)">
+                <div style="width:16px;height:16px;border:2px solid var(--color-border);border-top-color:var(--color-accent);border-radius:50%;animation:spin 0.8s linear infinite"></div>
+                Waiting for you to sign in...
+                <button class="btn" @click=${this.handleCancelEntraOAuth}>Cancel</button>
+              </div>
+            </div>
+          ` : this.oauthPending ? html`
             <div style="display:flex;align-items:center;gap:8px;padding:12px;color:var(--color-text-secondary)">
               <div style="width:16px;height:16px;border:2px solid var(--color-border);border-top-color:var(--color-accent);border-radius:50%;animation:spin 0.8s linear infinite"></div>
-              Waiting for Microsoft sign-in...
+              Connecting to Azure DevOps...
               <button class="btn" @click=${this.handleCancelEntraOAuth}>Cancel</button>
+            </div>
+          ` : this.needsOrgSelection ? html`
+            <div class="form-group">
+              <label>Select an organization</label>
+              ${this.availableOrgs.map(org => html`
+                <button class="btn" @click=${() => this.handleSelectOrg(org)} ?disabled=${this.isLoading}>${org.name}</button>
+              `)}
+              ${this.isLoading ? html`
+                <div style="display:flex;align-items:center;gap:8px;padding-top:4px;color:var(--color-text-secondary)">
+                  <div style="width:16px;height:16px;border:2px solid var(--color-border);border-top-color:var(--color-accent);border-radius:50%;animation:spin 0.8s linear infinite"></div>
+                  Connecting...
+                </div>
+              ` : nothing}
+              <div class="btn-row">
+                <button class="btn" @click=${this.handleCancelOrgSelection} ?disabled=${this.isLoading}>Cancel</button>
+              </div>
             </div>
           ` : html`
             <div class="btn-row">
               <button
                 class="btn btn-primary"
                 @click=${this.handleStartEntraOAuth}
-                ?disabled=${this.isLoading || !this.organizationInput.trim() || !this.oauthClientId.trim()}
+                ?disabled=${this.isLoading || this.oauthPending}
               >
                 Sign in with Microsoft
               </button>
             </div>
+            <span class="help-text">
+              Signs in with your Microsoft work or school account via the browser. No setup required.
+            </span>
           `}
         ` : html`
           <!-- PAT Form -->

--- a/src/services/__tests__/credential.service.refresh.test.ts
+++ b/src/services/__tests__/credential.service.refresh.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for getFreshAccountToken — on-demand OAuth token refresh.
+ *
+ * Mocks the Tauri keyring commands with an in-memory map and the OAuth refresh
+ * command, so the refresh/persist/fallback logic can be exercised without a
+ * Tauri runtime.
+ */
+
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const keyring = new Map<string, string>();
+let refreshCalls = 0;
+/** Raw object returned for `oauth_refresh_token`; null → the refresh call fails. */
+let refreshResponse: unknown = null;
+
+(globalThis as unknown as { __TAURI_INTERNALS__: { invoke: MockInvoke } }).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+};
+
+import { expect } from '@open-wc/testing';
+import {
+  getFreshAccountToken,
+  storeAccountOAuthToken,
+  storeAccountToken,
+} from '../credential.service.ts';
+
+const OAUTH_KEY = 'azure-devops_token_a1_oauth';
+
+function installMock(): void {
+  mockInvoke = async (command: string, args?: unknown) => {
+    const a = args as Record<string, unknown> | undefined;
+    switch (command) {
+      case 'store_keyring_token':
+        keyring.set(a!.key as string, a!.value as string);
+        return null;
+      case 'get_keyring_token':
+        return keyring.get(a!.key as string) ?? null;
+      case 'delete_keyring_token':
+        keyring.delete(a!.key as string);
+        return null;
+      case 'oauth_refresh_token':
+        refreshCalls++;
+        return refreshResponse;
+      default:
+        return null;
+    }
+  };
+}
+
+describe('credential.service - getFreshAccountToken', () => {
+  beforeEach(() => {
+    keyring.clear();
+    refreshCalls = 0;
+    refreshResponse = null;
+    installMock();
+  });
+
+  it('returns the stored access token when it is not near expiry (no refresh)', async () => {
+    await storeAccountOAuthToken('azure-devops', 'a1', 'access-1', 'refresh-1', 3600); // ~1h out
+    const token = await getFreshAccountToken('azure-devops', 'a1', 'azure');
+    expect(token).to.equal('access-1');
+    expect(refreshCalls, 'no refresh while the token is fresh').to.equal(0);
+  });
+
+  it('refreshes and persists a rotated bundle when the token is expiring', async () => {
+    await storeAccountOAuthToken('azure-devops', 'a1', 'old-access', 'old-refresh', 60); // within 5-min window
+    refreshResponse = { accessToken: 'new-access', refreshToken: 'new-refresh', expiresIn: 3600 };
+
+    const token = await getFreshAccountToken('azure-devops', 'a1', 'azure');
+    expect(token).to.equal('new-access');
+    expect(refreshCalls).to.equal(1);
+
+    // The rotated bundle (with a fresh expiry) is persisted — a second call reuses it.
+    refreshCalls = 0;
+    const again = await getFreshAccountToken('azure-devops', 'a1', 'azure');
+    expect(again).to.equal('new-access');
+    expect(refreshCalls, 'rotated token persisted with new expiry').to.equal(0);
+
+    const stored = JSON.parse(keyring.get(OAUTH_KEY)!);
+    expect(stored.accessToken).to.equal('new-access');
+    expect(stored.refreshToken).to.equal('new-refresh');
+  });
+
+  it('keeps the previous refresh token when the provider returns none', async () => {
+    await storeAccountOAuthToken('azure-devops', 'a1', 'old-access', 'old-refresh', 60);
+    refreshResponse = { accessToken: 'new-access', expiresIn: 3600 }; // no refreshToken echoed back
+
+    const token = await getFreshAccountToken('azure-devops', 'a1', 'azure');
+    expect(token).to.equal('new-access');
+
+    const stored = JSON.parse(keyring.get(OAUTH_KEY)!);
+    expect(stored.refreshToken, 'previous refresh token retained').to.equal('old-refresh');
+  });
+
+  it('falls back to the existing token when the refresh call fails', async () => {
+    await storeAccountOAuthToken('azure-devops', 'a1', 'old-access', 'old-refresh', 60);
+    // refreshResponse stays null → invokeCommand treats it as failure → refresh throws.
+    const token = await getFreshAccountToken('azure-devops', 'a1', 'azure');
+    expect(token).to.equal('old-access');
+    expect(refreshCalls).to.equal(1);
+  });
+
+  it('returns the plain token for a PAT account (no OAuth bundle)', async () => {
+    await storeAccountToken('azure-devops', 'pat1', 'my-pat');
+    const token = await getFreshAccountToken('azure-devops', 'pat1', 'azure');
+    expect(token).to.equal('my-pat');
+    expect(refreshCalls).to.equal(0);
+  });
+
+  it('coalesces concurrent refreshes into a single call (single-flight)', async () => {
+    await storeAccountOAuthToken('azure-devops', 'a1', 'old-access', 'old-refresh', 60);
+    refreshResponse = { accessToken: 'new-access', refreshToken: 'new-refresh', expiresIn: 3600 };
+
+    // Two concurrent callers on the same expiring account share one refresh.
+    const [t1, t2] = await Promise.all([
+      getFreshAccountToken('azure-devops', 'a1', 'azure'),
+      getFreshAccountToken('azure-devops', 'a1', 'azure'),
+    ]);
+
+    expect(t1).to.equal('new-access');
+    expect(t2).to.equal('new-access');
+    expect(refreshCalls, 'only one refresh for two concurrent callers').to.equal(1);
+  });
+});

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -1,5 +1,14 @@
 import { expect } from '@open-wc/testing';
-import { parseIssueReferences, isClosingKeyword } from '../git.service.ts';
+import {
+  parseIssueReferences,
+  isClosingKeyword,
+  getAdoToken,
+  fetch as gitFetch,
+  resetAdoGitCredentialSyncCache,
+} from '../git.service.ts';
+import { unifiedProfileStore } from '../../stores/unified-profile.store.ts';
+import { createEmptyIntegrationAccount } from '../../types/unified-profile.types.ts';
+import type { IntegrationAccount } from '../../types/unified-profile.types.ts';
 
 // Mock Tauri API for tests that need invokeCommand
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
@@ -312,5 +321,134 @@ describe('git.service - Tauri command invocations', () => {
     expect(lastInvokedArgs).to.deep.equal({
       path: '/test/repo',
     });
+  });
+});
+
+describe('git.service - getAdoToken refresh wiring', () => {
+  const keyring = new Map<string, string>();
+
+  afterEach(() => {
+    unifiedProfileStore.getState().reset();
+    mockInvoke = () => Promise.resolve(null);
+  });
+
+  it('refreshes an expiring Entra OAuth token for the default azure-devops account', async () => {
+    const account: IntegrationAccount = {
+      ...createEmptyIntegrationAccount('azure-devops', 'myorg'),
+      id: 'ado-1',
+      isDefault: true,
+    };
+    unifiedProfileStore.getState().setAccounts([account]);
+
+    const key = 'azure-devops_token_ado-1';
+    keyring.clear();
+    keyring.set(key, 'old-access');
+    // Bundle within the 5-minute refresh window (expires ~1s out).
+    keyring.set(`${key}_oauth`, JSON.stringify({
+      accessToken: 'old-access',
+      refreshToken: 'r1',
+      expiresAt: Date.now() + 1000,
+    }));
+
+    let refreshCalled = false;
+    mockInvoke = async (command: string, args?: unknown) => {
+      const a = args as Record<string, unknown> | undefined;
+      if (command === 'get_keyring_token') return keyring.get(a!.key as string) ?? null;
+      if (command === 'store_keyring_token') { keyring.set(a!.key as string, a!.value as string); return null; }
+      if (command === 'oauth_refresh_token') {
+        refreshCalled = true;
+        return { accessToken: 'new-access', refreshToken: 'r2', expiresIn: 3600 };
+      }
+      return null;
+    };
+
+    const result = await getAdoToken();
+    expect(result.success).to.be.true;
+    expect(result.data, 'returns the refreshed token').to.equal('new-access');
+    expect(refreshCalled, 'refresh grant was used').to.be.true;
+  });
+});
+
+describe('git.service - getRepoToken keyring sync (via fetch)', () => {
+  const keyring = new Map<string, string>();
+
+  function setupAdoAccount(accountOrg: string) {
+    const account: IntegrationAccount = {
+      ...createEmptyIntegrationAccount('azure-devops', accountOrg),
+      id: 'ado-1',
+      isDefault: true,
+    };
+    unifiedProfileStore.getState().setAccounts([account]);
+    const key = 'azure-devops_token_ado-1';
+    keyring.clear();
+    keyring.set(key, 'tok');
+    // Far-future expiry → getFreshAccountToken returns the stored token, no refresh.
+    keyring.set(`${key}_oauth`, JSON.stringify({
+      accessToken: 'tok',
+      refreshToken: 'r',
+      expiresAt: Date.now() + 3_600_000,
+    }));
+  }
+
+  /** Mock invoke: GH repo absent, ADO repo in `repoOrg`, keyring-backed, fetch ok. */
+  function installMock(repoOrg: string, credWrites: string[]) {
+    mockInvoke = async (command: string, args?: unknown) => {
+      const a = args as Record<string, unknown> | undefined;
+      if (command === 'detect_github_repo') return null;
+      if (command === 'detect_gitlab_repo') return null;
+      if (command === 'detect_ado_repo') {
+        return { organization: repoOrg, project: 'p', repository: 'repo', remoteName: 'origin' };
+      }
+      if (command === 'get_keyring_token') return keyring.get(a!.key as string) ?? null;
+      if (command === 'store_keyring_token') { keyring.set(a!.key as string, a!.value as string); return null; }
+      if (command === 'store_git_credentials') { credWrites.push(a!.url as string); return null; }
+      if (command === 'fetch') return null;
+      return null;
+    };
+  }
+
+  afterEach(() => {
+    unifiedProfileStore.getState().reset();
+    resetAdoGitCredentialSyncCache();
+    mockInvoke = () => Promise.resolve(null);
+  });
+
+  it('syncs keyring git credentials when the default account org matches the repo org', async () => {
+    setupAdoAccount('myorg');
+    const credWrites: string[] = [];
+    installMock('myorg', credWrites);
+
+    await gitFetch({ path: '/repo', silent: true });
+
+    expect(credWrites).to.include('https://dev.azure.com');
+    expect(credWrites).to.include('https://myorg.visualstudio.com');
+  });
+
+  it('does NOT sync when the default account org differs from the repo org', async () => {
+    setupAdoAccount('myorg');
+    const credWrites: string[] = [];
+    installMock('otherorg', credWrites); // repo is in a different org than the account
+
+    await gitFetch({ path: '/repo', silent: true });
+
+    expect(credWrites, 'no keyring write for a mismatched org').to.have.length(0);
+  });
+
+  it('dedupes repeat syncs and re-syncs after resetAdoGitCredentialSyncCache', async () => {
+    setupAdoAccount('myorg');
+    const credWrites: string[] = [];
+    installMock('myorg', credWrites);
+
+    await gitFetch({ path: '/repo', silent: true });
+    expect(credWrites).to.have.length(2);
+
+    // Same (org, token) → deduped, no new writes.
+    await gitFetch({ path: '/repo', silent: true });
+    expect(credWrites, 'deduped repeat').to.have.length(2);
+
+    // After a reset (mirrors disconnect/delete), the next call re-writes.
+    resetAdoGitCredentialSyncCache();
+    await gitFetch({ path: '/repo', silent: true });
+    expect(credWrites, 're-synced after reset').to.have.length(4);
   });
 });

--- a/src/services/__tests__/oauth.service.test.ts
+++ b/src/services/__tests__/oauth.service.test.ts
@@ -204,7 +204,6 @@ describe('oauth.service - exchangeCode server-side PKCE contract (M5/M11)', () =
 
     mockInvoke = (command) => {
       if (command === 'oauth_exchange_code') {
-        // eslint-disable-next-line camelcase
         return Promise.resolve({ access_token: 'a', id_token: 'h2.p2.s2' });
       }
       return Promise.resolve(null);
@@ -333,5 +332,39 @@ describe('oauth.service - device-code flow (Azure DevOps)', () => {
     };
     await cancelDeviceCode('flow-9');
     expect(captured!.flowId).to.equal('flow-9');
+  });
+});
+
+describe('oauth.service - refreshToken', () => {
+  const defaultMock = mockInvoke;
+  afterEach(() => {
+    mockInvoke = defaultMock;
+  });
+
+  it('normalizes snake_case token fields returned by the backend', async () => {
+    mockInvoke = (command) => {
+      if (command === 'oauth_refresh_token') {
+        return Promise.resolve({ access_token: 'a2', refresh_token: 'r2', expires_in: 1800 });
+      }
+      return Promise.resolve(null);
+    };
+    const { refreshToken } = await import('../oauth.service.ts');
+    const tokens = await refreshToken('azure', 'old-refresh');
+    expect(tokens.accessToken).to.equal('a2');
+    expect(tokens.refreshToken).to.equal('r2');
+    expect(tokens.expiresIn).to.equal(1800);
+  });
+
+  it('accepts camelCase token fields', async () => {
+    mockInvoke = (command) => {
+      if (command === 'oauth_refresh_token') {
+        return Promise.resolve({ accessToken: 'a3', refreshToken: 'r3', expiresIn: 3600 });
+      }
+      return Promise.resolve(null);
+    };
+    const { refreshToken } = await import('../oauth.service.ts');
+    const tokens = await refreshToken('azure', 'old-refresh');
+    expect(tokens.accessToken).to.equal('a3');
+    expect(tokens.refreshToken).to.equal('r3');
   });
 });

--- a/src/services/__tests__/oauth.service.test.ts
+++ b/src/services/__tests__/oauth.service.test.ts
@@ -56,6 +56,9 @@ import {
   isPendingOAuth,
   getPendingProvider,
   exchangeCode,
+  startDeviceCode,
+  pollDeviceCode,
+  cancelDeviceCode,
 } from '../oauth.service.ts';
 import type { OAuthFlowState } from '../../types/oauth.types.ts';
 
@@ -231,5 +234,104 @@ describe('oauth.service - Provider Types', () => {
   it('should handle bitbucket provider type', () => {
     const provider = 'bitbucket' as const;
     expect(provider).to.equal('bitbucket');
+  });
+});
+
+describe('oauth.service - device-code flow (Azure DevOps)', () => {
+  const defaultMock = mockInvoke;
+  afterEach(() => {
+    mockInvoke = defaultMock;
+  });
+
+  it('startDeviceCode returns the flow details and sends provider/clientId', async () => {
+    let captured: Record<string, unknown> | undefined;
+    mockInvoke = (command, args) => {
+      if (command === 'oauth_start_device_code') {
+        captured = args as Record<string, unknown>;
+        return Promise.resolve({
+          flowId: 'flow-1',
+          userCode: 'ABCD-EFGH',
+          verificationUri: 'https://microsoft.com/devicelogin',
+          expiresIn: 900,
+          interval: 5,
+          message: 'Enter the code',
+        });
+      }
+      return Promise.resolve(null);
+    };
+
+    const res = await startDeviceCode('azure', 'client-abc');
+    expect(res.flowId).to.equal('flow-1');
+    expect(res.userCode).to.equal('ABCD-EFGH');
+    expect(res.verificationUri).to.equal('https://microsoft.com/devicelogin');
+    expect(captured!.provider).to.equal('azure');
+    expect(captured!.clientId).to.equal('client-abc');
+  });
+
+  it('startDeviceCode throws when the backend returns failure', async () => {
+    mockInvoke = (command) => {
+      if (command === 'oauth_start_device_code') return Promise.resolve(null); // null → failure
+      return Promise.resolve(null);
+    };
+    let threw = false;
+    try {
+      await startDeviceCode('azure', 'client-abc');
+    } catch {
+      threw = true;
+    }
+    expect(threw).to.be.true;
+  });
+
+  it('pollDeviceCode normalizes snake_case token fields to camelCase', async () => {
+    mockInvoke = (command, args) => {
+      if (command === 'oauth_poll_device_code') {
+        expect((args as Record<string, unknown>).flowId).to.equal('flow-1');
+        return Promise.resolve({ access_token: 'tok', refresh_token: 'ref', expires_in: 3600 });
+      }
+      return Promise.resolve(null);
+    };
+    const tokens = await pollDeviceCode('flow-1');
+    expect(tokens.accessToken).to.equal('tok');
+    expect(tokens.refreshToken).to.equal('ref');
+    expect(tokens.expiresIn).to.equal(3600);
+  });
+
+  it('pollDeviceCode accepts camelCase token fields', async () => {
+    mockInvoke = (command) => {
+      if (command === 'oauth_poll_device_code') {
+        return Promise.resolve({ accessToken: 'tok2', tokenType: 'bearer' });
+      }
+      return Promise.resolve(null);
+    };
+    const tokens = await pollDeviceCode('flow-1');
+    expect(tokens.accessToken).to.equal('tok2');
+    expect(tokens.tokenType).to.equal('bearer');
+  });
+
+  it('pollDeviceCode throws when the backend returns failure (cancelled/expired)', async () => {
+    mockInvoke = (command) => {
+      if (command === 'oauth_poll_device_code') return Promise.resolve(null);
+      return Promise.resolve(null);
+    };
+    let threw = false;
+    try {
+      await pollDeviceCode('flow-1');
+    } catch {
+      threw = true;
+    }
+    expect(threw).to.be.true;
+  });
+
+  it('cancelDeviceCode invokes the cancel command with the flow id', async () => {
+    let captured: Record<string, unknown> | undefined;
+    mockInvoke = (command, args) => {
+      if (command === 'oauth_cancel_device_code') {
+        captured = args as Record<string, unknown>;
+        return Promise.resolve(null);
+      }
+      return Promise.resolve(null);
+    };
+    await cancelDeviceCode('flow-9');
+    expect(captured!.flowId).to.equal('flow-9');
   });
 });

--- a/src/services/credential.service.ts
+++ b/src/services/credential.service.ts
@@ -190,6 +190,7 @@ export const AzureDevOpsCredentials = {
 // =============================================================================
 
 import type { IntegrationType } from '../types/integration-accounts.types.ts';
+import type { OAuthProvider } from '../types/oauth.types.ts';
 import type { GitHubConnectionStatus } from './git.service.ts';
 
 /**
@@ -418,6 +419,77 @@ export async function isOAuthTokenExpiring(
   const fiveMinutes = 5 * 60 * 1000;
   return Date.now() > tokenData.expiresAt - fiveMinutes;
 }
+
+/**
+ * Get a valid access token for an account, transparently refreshing it first if
+ * it is an OAuth token within 5 minutes of expiry. The rotated bundle (access +
+ * refresh + expiry) is persisted so subsequent calls reuse it.
+ *
+ * Falls back to the stored access token when there is no refresh token or the
+ * refresh fails, so callers still get something to try. Non-OAuth (PAT) accounts
+ * return their stored token unchanged.
+ *
+ * @param provider OAuth provider used for the refresh grant (e.g. 'azure').
+ * @param instanceUrl Optional instance/tenant forwarded to the refresh endpoint.
+ */
+export async function getFreshAccountToken(
+  integrationType: IntegrationType,
+  accountId: string,
+  provider: OAuthProvider,
+  instanceUrl?: string
+): Promise<string | null> {
+  const bundle = await getAccountOAuthToken(integrationType, accountId);
+  // No OAuth bundle (PAT / legacy) — return the plain stored token.
+  if (!bundle) {
+    return getAccountToken(integrationType, accountId);
+  }
+  // Compute expiry inline from the bundle we already have (avoid a second read).
+  const fiveMinutes = 5 * 60 * 1000;
+  const expiring = bundle.expiresAt ? Date.now() > bundle.expiresAt - fiveMinutes : false;
+  // Fresh enough, or nothing to refresh with — use the stored access token.
+  if (!bundle.refreshToken || !expiring) {
+    return bundle.accessToken;
+  }
+
+  // Single-flight per account: concurrent callers (e.g. a git push and the
+  // background token validator) share one refresh so rotated refresh tokens
+  // aren't lost to an overwrite.
+  const inFlightKey = `${integrationType}:${accountId}`;
+  const existing = inFlightTokenRefreshes.get(inFlightKey);
+  if (existing) return existing;
+
+  const refreshTokenValue = bundle.refreshToken;
+  const fallbackToken = bundle.accessToken;
+  const refreshPromise = (async (): Promise<string | null> => {
+    try {
+      const { refreshToken: refreshOAuthToken } = await import('./oauth.service.ts');
+      const refreshed = await refreshOAuthToken(provider, refreshTokenValue, instanceUrl);
+      await storeAccountOAuthToken(
+        integrationType,
+        accountId,
+        refreshed.accessToken,
+        // Entra rotates refresh tokens; keep the previous one if none was returned.
+        refreshed.refreshToken ?? refreshTokenValue,
+        refreshed.expiresIn
+      );
+      log.debug(` Refreshed OAuth token for ${integrationType} account ${accountId}`);
+      return refreshed.accessToken;
+    } catch (err) {
+      log.warn(
+        ` OAuth token refresh failed for ${integrationType} account ${accountId}; using existing token`,
+        err
+      );
+      return fallbackToken;
+    } finally {
+      inFlightTokenRefreshes.delete(inFlightKey);
+    }
+  })();
+  inFlightTokenRefreshes.set(inFlightKey, refreshPromise);
+  return refreshPromise;
+}
+
+/** In-flight OAuth refreshes keyed by `${integrationType}:${accountId}` (single-flight). */
+const inFlightTokenRefreshes = new Map<string, Promise<string | null>>();
 
 // ========================================================================
 // GitHub App Installation

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -897,6 +897,34 @@ export async function getFetchStatus(
   return invokeCommand<RemoteFetchStatus[]>("get_fetch_status", { path });
 }
 
+/** Last `${org}::${token}` written to the keyring ADO git credential (dedup). */
+let lastSyncedAdoGitCredKey: string | null = null;
+
+/**
+ * Reset the ADO git-credential sync dedup cache. Call this after deleting the
+ * keyring credential (disconnect/delete) so a subsequent connect with the same
+ * token value re-writes the (now-deleted) keyring entry instead of being skipped.
+ */
+export function resetAdoGitCredentialSyncCache(): void {
+  lastSyncedAdoGitCredKey = null;
+}
+
+/**
+ * Write the Azure DevOps git credentials to the OS keyring for both dev.azure.com
+ * and {org}.visualstudio.com so external git CLI operations use a valid token.
+ * Best-effort and deduped by (org, token); storeGitCredentials never throws.
+ * Only call with a token verified to work for `org`.
+ */
+export async function syncAdoGitCredentials(org: string, token: string): Promise<void> {
+  const key = `${org}::${token}`;
+  if (key === lastSyncedAdoGitCredKey) return;
+  const c1 = await storeGitCredentials("https://dev.azure.com", "pat", token);
+  const c2 = await storeGitCredentials(`https://${org}.visualstudio.com`, "pat", token);
+  if (c1.success && c2.success) {
+    lastSyncedAdoGitCredKey = key;
+  }
+}
+
 /**
  * Helper to get authentication token for a repository
  * Tries the multi-account system first, then falls back to legacy single-token methods
@@ -938,8 +966,23 @@ async function getRepoToken(
     ) {
       const account = selectDefaultGlobalAccount("azure-devops");
       if (account) {
-        const token = await AccountCredentials.getToken("azure-devops", account.id);
-        if (token) return token;
+        // Refresh the Entra OAuth access token if it is expiring, so push/pull/
+        // fetch (which pass this token directly) keep working past the ~1h expiry.
+        const { getFreshAccountToken } = await import("./credential.service.ts");
+        const token = await getFreshAccountToken("azure-devops", account.id, "azure");
+        if (token) {
+          // Keep the OS keyring git credential fresh too, so EXTERNAL git CLI
+          // operations (which read the keyring, not this returned token) also work
+          // after a refresh. Only sync when the default account actually belongs
+          // to THIS repo's org — otherwise, in a multi-account setup, a different
+          // org's token would clobber the keyring credential for the repo's org.
+          const accountOrg =
+            account.config.type === "azure-devops" ? account.config.organization : undefined;
+          if (accountOrg && accountOrg === adoRepoResult.data.organization) {
+            await syncAdoGitCredentials(adoRepoResult.data.organization, token);
+          }
+          return token;
+        }
       }
       // Legacy fallback for Azure DevOps
       const tokenResult = await getAdoToken();
@@ -3397,10 +3440,11 @@ export async function getAdoToken(): Promise<CommandResult<string | null>> {
   try {
     // Try account-based keyring credentials first (new system)
     const { selectDefaultGlobalAccount } = await import("../stores/unified-profile.store.ts");
-    const { AccountCredentials } = await import("./credential.service.ts");
+    const { getFreshAccountToken } = await import("./credential.service.ts");
     const account = selectDefaultGlobalAccount("azure-devops");
     if (account) {
-      const token = await AccountCredentials.getToken("azure-devops", account.id);
+      // Refresh an expiring Entra OAuth token so callers get a valid one.
+      const token = await getFreshAccountToken("azure-devops", account.id, "azure");
       if (token) return { success: true, data: token };
     }
     // Fall back to legacy single-account credentials

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -3327,6 +3327,12 @@ export interface DetectedAdoRepo {
   remoteName: string;
 }
 
+export interface AdoOrganization {
+  id: string;
+  name: string;
+  url: string;
+}
+
 export interface AdoPullRequest {
   pullRequestId: number;
   title: string;
@@ -3448,6 +3454,17 @@ export async function checkAdoConnectionWithToken(
     organization,
     token,
   });
+}
+
+/**
+ * List the Azure DevOps organizations the authenticated user belongs to.
+ * Used to auto-resolve the organization after an Entra sign-in when it can't be
+ * detected from the repo remote.
+ */
+export async function listAdoOrganizations(
+  token?: string | null,
+): Promise<CommandResult<AdoOrganization[]>> {
+  return invokeCommand<AdoOrganization[]>("list_ado_organizations", { token });
 }
 
 export async function detectAdoRepo(

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -2,8 +2,8 @@
  * OAuth service for provider authentication
  *
  * Handles OAuth authentication flows for GitHub, GitLab, Azure DevOps, and Bitbucket.
- * - GitHub, GitLab, Bitbucket use loopback server (127.0.0.1:port)
- * - Azure uses deep links (leviathan://oauth/...)
+ * - GitHub, GitLab, Bitbucket use a loopback server (127.0.0.1:port) for the callback.
+ * - Azure DevOps uses the device-code flow (no redirect); see startDeviceCode/pollDeviceCode.
  */
 
 import { onOpenUrl, getCurrent } from '@tauri-apps/plugin-deep-link';
@@ -27,8 +27,9 @@ import type {
 const OAUTH_CLIENT_IDS: Partial<Record<OAuthProvider, string>> = {
   github: 'Ov23liQxX14fxt3fRq4u',
   gitlab: '90d3d02fefb79e0303aaa54e8c6794bf806e9e8a1de7526bebc4f14288e12fec',
-  // Azure DevOps: OAuth not supported for personal Microsoft accounts - use PAT instead
-  // See ROADMAP.md for details on Microsoft's OAuth deprecation
+  // Well-known Visual Studio public client ID: multi-tenant and pre-authorized for
+  // Azure DevOps, so Entra sign-in works out-of-the-box with no per-user app registration.
+  azure: '872cd9fa-d31f-45e0-9eab-6e460a02d1f1',
   bitbucket: 'Tv5UjEqLKK7GSYjAJn',
 };
 
@@ -385,6 +386,73 @@ export async function exchangeCode(
   };
 
   return normalizedResult;
+}
+
+/**
+ * Response from starting a device-code flow.
+ */
+export interface StartDeviceCodeResponse {
+  flowId: string;
+  userCode: string;
+  verificationUri: string;
+  expiresIn: number;
+  interval: number;
+  message: string;
+}
+
+/**
+ * Start an OAuth 2.0 device-code flow (used by Azure DevOps / Entra ID).
+ *
+ * Returns the user code + verification URL to display. The device_code secret
+ * stays server-side, keyed by the returned `flowId`, which is passed to
+ * {@link pollDeviceCode}. Needs no redirect URI, so it works with the embedded
+ * public client whose registered redirects we don't control.
+ */
+export async function startDeviceCode(
+  provider: OAuthProvider,
+  clientId: string,
+  instanceUrl?: string
+): Promise<StartDeviceCodeResponse> {
+  const result = await invokeCommand<StartDeviceCodeResponse>('oauth_start_device_code', {
+    provider,
+    clientId,
+    instanceUrl,
+  });
+  if (!result.success || !result.data) {
+    throw new Error(result.error?.message ?? 'Failed to start device sign-in');
+  }
+  return result.data;
+}
+
+/**
+ * Poll a device-code flow until the user finishes signing in (or it is cancelled
+ * or times out). The backend blocks on the provider's poll interval, so this
+ * resolves once with the tokens.
+ */
+export async function pollDeviceCode(flowId: string): Promise<OAuthTokenResponse> {
+  const result = await invokeCommand<OAuthTokenResponse>('oauth_poll_device_code', { flowId });
+  if (!result.success || !result.data) {
+    throw new Error(result.error?.message ?? 'Device sign-in failed');
+  }
+
+  // Normalize snake_case/camelCase like exchangeCode (serde serialization edge case).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = result.data as any;
+  return {
+    accessToken: raw.accessToken || raw.access_token,
+    refreshToken: raw.refreshToken || raw.refresh_token,
+    expiresIn: raw.expiresIn || raw.expires_in,
+    tokenType: raw.tokenType || raw.token_type,
+    scope: raw.scope,
+    idToken: raw.idToken || raw.id_token,
+  };
+}
+
+/**
+ * Cancel an in-flight device-code flow so its server-side poll stops.
+ */
+export async function cancelDeviceCode(flowId: string): Promise<void> {
+  await invokeCommand<void>('oauth_cancel_device_code', { flowId });
 }
 
 /**

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -474,7 +474,19 @@ export async function refreshToken(
   if (!result.success || !result.data) {
     throw new Error(result.error?.message ?? 'Failed to refresh OAuth token');
   }
-  return result.data;
+
+  // Normalize snake_case/camelCase like exchangeCode/pollDeviceCode (serde edge case),
+  // so callers reliably read accessToken/refreshToken/expiresIn.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = result.data as any;
+  return {
+    accessToken: raw.accessToken || raw.access_token,
+    refreshToken: raw.refreshToken || raw.refresh_token,
+    expiresIn: raw.expiresIn || raw.expires_in,
+    tokenType: raw.tokenType || raw.token_type,
+    scope: raw.scope,
+    idToken: raw.idToken || raw.id_token,
+  };
 }
 
 /**

--- a/src/services/unified-profile.service.ts
+++ b/src/services/unified-profile.service.ts
@@ -663,8 +663,17 @@ export async function refreshAccountCachedUser(
   const store = unifiedProfileStore.getState();
 
   try {
-    // Get the token for this account
-    const token = await AccountCredentials.getToken(account.integrationType, account.id);
+    // Get the token for this account. For Azure DevOps OAuth accounts, refresh an
+    // expiring Entra access token first — otherwise the ~1h expiry would make this
+    // path (periodic validation, "Refresh account", profile manager) mark the
+    // account disconnected even though a valid refresh token exists.
+    let token: string | null;
+    if (account.integrationType === 'azure-devops') {
+      const { getFreshAccountToken } = await import('./credential.service.ts');
+      token = await getFreshAccountToken('azure-devops', account.id, 'azure');
+    } else {
+      token = await AccountCredentials.getToken(account.integrationType, account.id);
+    }
     if (!token) {
       log.debug(` No token for account ${account.id}, skipping refresh`);
       store.setAccountConnectionStatus(account.id, 'disconnected');
@@ -725,6 +734,11 @@ export async function refreshAccountCachedUser(
               avatarUrl: null,
               email: result.data.user.uniqueName || null,
             };
+            // Token verified for this org — keep the keyring git credential fresh
+            // too, so external git push/pull work after a background refresh even
+            // without an in-app git operation. (token is non-null here.)
+            const { syncAdoGitCredentials } = await import('./git.service.ts');
+            await syncAdoGitCredentials(organization, token);
           }
         }
         break;


### PR DESCRIPTION
## Summary

Azure DevOps Entra ID login previously required each user to register their own Entra app and paste a Client ID + Organization before they could sign in — and even once signed in, the short-lived (~1h) token was never refreshed, so git push/pull and API calls broke after an hour.

This PR makes it a true **one-click "Sign in with Microsoft"** button and keeps the token valid indefinitely via on-demand refresh.

## 1. One-click "Sign in with Microsoft" (device-code flow)

- Uses the OAuth 2.0 **device-code flow** with an embedded, well-known multi-tenant public client (Visual Studio, pre-authorized for Azure DevOps). **No redirect URI, no PKCE, no per-user app registration** — the button works out of the box. (The device-code flow was chosen because the embedded public client doesn't own our redirect URIs, so any redirect-based flow would be rejected by Entra.)
- New backend commands: `oauth_start_device_code` / `oauth_poll_device_code` / `oauth_cancel_device_code` (server-side flow map; the poll handles `authorization_pending` / `slow_down` / decline / expiry, retries transient transport + 5xx errors, and removes the flow secret on every terminal path).
- The OAuth tab is a single button. After sign-in, the organization is resolved from the repo remote, else from the account's org list (1 auto-used, >1 shown in an in-dialog picker with Cancel, 0 surfaces an error).
- `finalizeEntraLogin` verifies the token, persists the account with the full OAuth bundle (access + refresh + expiry), stores git credentials for push/pull, and loads the PR/work-item/pipeline tabs. All error paths surface a toast or inline message.
- Any in-flight sign-in is abandoned (generation guard + backend cancel) on cancel, close, disconnect, account switch/add, manage-accounts, and auth-method toggle, so a late completion can never connect or write to the wrong account. A PAT-typed org is preserved across a tab round-trip.
- Removes the now-unreachable Azure redirect/loopback authorize path.

## 2. Automatic token refresh (so push/pull survive expiry)

- New `credentialService.getFreshAccountToken(...)`: returns the stored token, but when an OAuth token is within 5 minutes of expiry it refreshes via the refresh grant, persists the rotated bundle (keeping the old refresh token if the provider returns none), and falls back to the existing token if refresh fails. **Single-flight per account** so concurrent callers don't lose a rotated token.
- `oauth.service.refreshToken` now normalizes snake_case/camelCase like the other token responses.
- Wired into every consumption path: in-app git push/pull/fetch (`getRepoToken`), the ADO API calls (`getSelectedAccountToken`), and periodic background validation / "Refresh account".
- The OS-keyring git credential (used by external git CLI) is re-synced only with a **verified** token, only when the account's org matches the repo's org (avoids a multi-account clobber), deduped, and reset on disconnect/delete.

## Testing

- **Rust:** device-code commands + poll-error classifier; `list_ado_organizations`; existing azure/oauth suites (`cargo fmt`, `clippy -D warnings`, tests all green).
- **TypeScript:** device-code + refresh service functions, dialog flows (one-click button, org picker, cancel/close/switch abandonment, credential-sync dedup), `getFreshAccountToken` (refresh/persist/fallback/single-flight/PAT), and `getRepoToken`/`getAdoToken` wiring.
- `docs/oauth-setup.md` updated for the device-code flow.
- Reviewed to convergence by a recursive multi-model review (Opus/Sonnet/Haiku) per the repo's review process; merged latest `main` and resolved conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ