### PR TITLE
feat(azure-devops): interactive Microsoft (Entra ID) sign-in via authorization-code + loopback

### DIFF
--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -211,13 +211,25 @@ pub async fn oauth_get_authorize_url(
             (config, Some(port))
         }
         OAuthProvider::Azure => {
-            // Azure DevOps (Entra ID) does not use the redirect/authorization-code
-            // flow: the embedded public client doesn't own our redirect URIs, so
-            // Entra would reject them (AADSTS50011). Sign-in goes through the
-            // device-code flow instead (oauth_start_device_code / oauth_poll_device_code).
-            return Err(LeviathanError::OAuth(
-                "Azure DevOps uses device-code sign-in — call oauth_start_device_code".to_string(),
-            ));
+            // Azure DevOps (Entra ID): interactive auth-code + loopback (like GitHub/GitLab),
+            // using the embedded registered public client. instance_url carries the optional tenant.
+            let server = LoopbackServer::new()?;
+            let port = server.port();
+            let config = OAuthConfig::azure(&client_id, instance_url.as_deref(), port);
+
+            let mut servers = PENDING_SERVERS
+                .lock()
+                .map_err(|e| LeviathanError::OAuth(format!("Failed to store server: {}", e)))?;
+            cleanup_expired_pending_servers(&mut servers);
+            servers.insert(
+                port,
+                PendingServer {
+                    server,
+                    created_at: std::time::Instant::now(),
+                },
+            );
+
+            (config, Some(port))
         }
         OAuthProvider::Bitbucket => {
             // Bitbucket requires http/https redirect URIs and only allows ONE callback URL
@@ -600,311 +612,6 @@ pub async fn oauth_wait_for_github_callback(port: u16) -> Result<CallbackRespons
     oauth_wait_for_callback(port).await
 }
 
-// ========================================================================
-// Device Authorization Grant (OAuth 2.0 Device Code) — used by Azure DevOps
-// ========================================================================
-//
-// The device-code flow needs no redirect URI, so it works with the embedded
-// public client (whose registered redirects we don't control). The user is shown
-// a short code to enter at a verification URL; the backend polls the token
-// endpoint until they finish. This is how `az devops` / Git Credential Manager
-// authenticate against Azure DevOps.
-
-/// Server-side state for an in-flight device-code flow, keyed by a generated flow id.
-struct PendingDeviceFlow {
-    provider: OAuthProvider,
-    /// Client ID used to start the flow (reused for polling).
-    client_id: String,
-    /// Instance / tenant (Azure). Determines the token endpoint.
-    instance_url: Option<String>,
-    /// The device_code secret returned by the authorization server.
-    device_code: String,
-    /// Poll interval in seconds (may be increased on `slow_down`).
-    interval: u64,
-    /// Absolute expiry — polling stops after this.
-    expires_at: std::time::Instant,
-}
-
-static DEVICE_FLOWS: Lazy<Mutex<HashMap<String, PendingDeviceFlow>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
-
-/// Response returned to the frontend when a device-code flow starts.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StartDeviceCodeResponse {
-    /// Handle used to poll this flow (the device_code itself stays server-side).
-    pub flow_id: String,
-    /// Short code the user types at the verification URL.
-    pub user_code: String,
-    /// URL the user opens to enter the code.
-    pub verification_uri: String,
-    /// Seconds until the code expires.
-    pub expires_in: u64,
-    /// Suggested seconds between polls.
-    pub interval: u64,
-    /// Human-readable instruction message from the provider.
-    pub message: String,
-}
-
-/// Azure DevOps scopes requested for the device-code flow.
-const AZURE_DEVICE_SCOPES: &str =
-    "499b84ac-1321-427f-aa17-267ca6975798/user_impersonation offline_access";
-
-fn azure_tenant_base(instance_url: Option<&str>) -> String {
-    let tenant = instance_url.unwrap_or("common");
-    format!("https://login.microsoftonline.com/{}/oauth2/v2.0", tenant)
-}
-
-/// Start a device-code flow. Currently only Azure (Entra ID) is supported.
-#[tauri::command]
-pub async fn oauth_start_device_code(
-    provider: String,
-    client_id: String,
-    instance_url: Option<String>,
-) -> Result<StartDeviceCodeResponse> {
-    let provider_enum: OAuthProvider = provider
-        .parse()
-        .map_err(|e: String| LeviathanError::OAuth(e))?;
-
-    let (device_url, scopes) = match provider_enum {
-        OAuthProvider::Azure => (
-            format!("{}/devicecode", azure_tenant_base(instance_url.as_deref())),
-            AZURE_DEVICE_SCOPES,
-        ),
-        _ => {
-            return Err(LeviathanError::OAuth(
-                "Device-code flow is not supported for this provider".to_string(),
-            ))
-        }
-    };
-
-    #[derive(Deserialize)]
-    struct DeviceCodeApiResponse {
-        device_code: String,
-        user_code: String,
-        verification_uri: String,
-        expires_in: u64,
-        interval: u64,
-        message: Option<String>,
-    }
-
-    let client = reqwest::Client::new();
-    let response = client
-        .post(&device_url)
-        .header("Accept", "application/json")
-        .form(&[("client_id", client_id.as_str()), ("scope", scopes)])
-        .send()
-        .await
-        .map_err(|e| LeviathanError::OAuth(format!("Device code request failed: {}", e)))?;
-
-    let status = response.status();
-    let text = response.text().await.unwrap_or_default();
-    if !status.is_success() {
-        // Surface the provider's error field without echoing the whole body.
-        let msg = serde_json::from_str::<serde_json::Value>(&text)
-            .ok()
-            .and_then(|v| {
-                v.get("error_description")
-                    .or_else(|| v.get("error"))
-                    .and_then(|d| d.as_str())
-                    .map(str::to_string)
-            })
-            .unwrap_or_else(|| format!("HTTP {}", status));
-        return Err(LeviathanError::OAuth(format!(
-            "Failed to start device sign-in: {}",
-            msg
-        )));
-    }
-
-    let data: DeviceCodeApiResponse = serde_json::from_str(&text).map_err(|e| {
-        LeviathanError::OAuth(format!("Failed to parse device code response: {}", e))
-    })?;
-
-    let flow_id = generate_state();
-    let expires_at = std::time::Instant::now() + Duration::from_secs(data.expires_in);
-
-    {
-        let mut flows = DEVICE_FLOWS
-            .lock()
-            .map_err(|e| LeviathanError::OAuth(format!("Failed to store device flow: {}", e)))?;
-        // Evict expired flows opportunistically.
-        let now = std::time::Instant::now();
-        flows.retain(|_, f| f.expires_at > now);
-        flows.insert(
-            flow_id.clone(),
-            PendingDeviceFlow {
-                provider: provider_enum,
-                client_id,
-                instance_url,
-                device_code: data.device_code,
-                interval: data.interval,
-                expires_at,
-            },
-        );
-    }
-
-    Ok(StartDeviceCodeResponse {
-        flow_id,
-        user_code: data.user_code,
-        verification_uri: data.verification_uri,
-        expires_in: data.expires_in,
-        interval: data.interval,
-        message: data
-            .message
-            .unwrap_or_else(|| "Sign in with the code shown.".to_string()),
-    })
-}
-
-/// Poll a device-code flow until the user completes sign-in, it is cancelled, or
-/// it expires. Blocks server-side (polling the token endpoint at the provider's
-/// interval) so the frontend only awaits once.
-#[tauri::command]
-pub async fn oauth_poll_device_code(flow_id: String) -> Result<OAuthTokenResponse> {
-    // Snapshot the flow parameters (do not hold the lock across awaits).
-    let (token_url, client_id, device_code, mut interval) = {
-        let flows = DEVICE_FLOWS
-            .lock()
-            .map_err(|e| LeviathanError::OAuth(format!("Failed to access device flow: {}", e)))?;
-        let flow = flows.get(&flow_id).ok_or_else(|| {
-            LeviathanError::OAuth("Device sign-in flow not found or already finished".to_string())
-        })?;
-        let token_url = match flow.provider {
-            OAuthProvider::Azure => {
-                format!("{}/token", azure_tenant_base(flow.instance_url.as_deref()))
-            }
-            _ => {
-                return Err(LeviathanError::OAuth(
-                    "Device-code flow is not supported for this provider".to_string(),
-                ))
-            }
-        };
-        (
-            token_url,
-            flow.client_id.clone(),
-            flow.device_code.clone(),
-            flow.interval,
-        )
-    };
-
-    let client = reqwest::Client::new();
-
-    loop {
-        // Bail if the flow was cancelled (removed) or has expired.
-        {
-            let mut flows = DEVICE_FLOWS.lock().map_err(|e| {
-                LeviathanError::OAuth(format!("Failed to access device flow: {}", e))
-            })?;
-            match flows.get(&flow_id) {
-                None => {
-                    return Err(LeviathanError::OAuth(
-                        "Device sign-in was cancelled".to_string(),
-                    ))
-                }
-                Some(f) if f.expires_at <= std::time::Instant::now() => {
-                    // Remove the expired flow so its device_code secret doesn't
-                    // linger until the next start's opportunistic cleanup.
-                    flows.remove(&flow_id);
-                    return Err(LeviathanError::OAuth(
-                        "Device sign-in timed out — please try again".to_string(),
-                    ));
-                }
-                _ => {}
-            }
-        }
-
-        tokio::time::sleep(Duration::from_secs(interval.max(1))).await;
-
-        // A transient transport error (wifi drop, sleep/resume, VPN reconnect)
-        // must NOT abort a flow the user is still completing — retry on the next
-        // tick (bounded by the expiry check at the top of the loop).
-        let response = match client
-            .post(&token_url)
-            .header("Accept", "application/json")
-            .form(&[
-                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
-                ("client_id", client_id.as_str()),
-                ("device_code", device_code.as_str()),
-            ])
-            .send()
-            .await
-        {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::debug!("Device token poll transient error (will retry): {}", e);
-                continue;
-            }
-        };
-
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-
-        if status.is_success() {
-            // This flow is terminal now — remove it BEFORE parsing so a 2xx body
-            // that fails to deserialize doesn't leave the entry (and its
-            // device_code secret) lingering in the map until expiry.
-            DEVICE_FLOWS.lock().ok().map(|mut f| f.remove(&flow_id));
-            let tokens: OAuthTokenResponse = serde_json::from_str(&text).map_err(|e| {
-                LeviathanError::OAuth(format!("Failed to parse token response: {}", e))
-            })?;
-            return Ok(tokens);
-        }
-
-        // Non-success: inspect the OAuth error code to decide whether to keep polling.
-        let error_code = serde_json::from_str::<serde_json::Value>(&text)
-            .ok()
-            .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(str::to_string))
-            .unwrap_or_default();
-
-        match classify_device_poll_error(&error_code, status.as_u16()) {
-            DevicePollAction::KeepWaiting => { /* authorization_pending */ }
-            DevicePollAction::SlowDown => interval += 5,
-            DevicePollAction::Fail(msg) => {
-                DEVICE_FLOWS.lock().ok().map(|mut f| f.remove(&flow_id));
-                return Err(LeviathanError::OAuth(msg));
-            }
-        }
-    }
-}
-
-/// What the device-code poll loop should do for a given token-endpoint error.
-#[derive(Debug, PartialEq)]
-enum DevicePollAction {
-    /// Authorization still pending — poll again on the next tick.
-    KeepWaiting,
-    /// Provider asked us to back off — increase the interval and poll again.
-    SlowDown,
-    /// Terminal failure — stop polling and surface this message.
-    Fail(String),
-}
-
-/// Classify a device-code token-poll error (RFC 8628 §3.5) into a poll action.
-/// Pure function so the state machine is unit-testable without an HTTP server.
-fn classify_device_poll_error(error_code: &str, status: u16) -> DevicePollAction {
-    match error_code {
-        "authorization_pending" => DevicePollAction::KeepWaiting,
-        "slow_down" => DevicePollAction::SlowDown,
-        "authorization_declined" => DevicePollAction::Fail("Sign-in was declined".to_string()),
-        "expired_token" => {
-            DevicePollAction::Fail("Device sign-in timed out — please try again".to_string())
-        }
-        // No recognized OAuth error field. A 5xx is a transient server blip —
-        // keep polling (same tolerance as a transport error) instead of aborting
-        // a flow the user is still completing; a 4xx is a genuine terminal error.
-        "" if status >= 500 => DevicePollAction::KeepWaiting,
-        "" => DevicePollAction::Fail(format!("Token poll failed (HTTP {})", status)),
-        other => DevicePollAction::Fail(other.to_string()),
-    }
-}
-
-/// Cancel an in-flight device-code flow so its poll stops.
-#[tauri::command]
-pub async fn oauth_cancel_device_code(flow_id: String) -> Result<()> {
-    if let Ok(mut flows) = DEVICE_FLOWS.lock() {
-        flows.remove(&flow_id);
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1078,15 +785,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_oauth_get_authorize_url_azure_rejected() {
-        // Azure DevOps uses the device-code flow, not the redirect/authorize path,
-        // so the authorize-url command must reject it (pointing at device-code).
+    async fn test_oauth_get_authorize_url_azure() {
         let result =
             oauth_get_authorize_url("azure".to_string(), None, "test-client-id".to_string()).await;
 
-        assert!(result.is_err());
-        let msg = format!("{:?}", result.unwrap_err());
-        assert!(msg.contains("device-code"));
+        assert!(result.is_ok());
+        let response = result.unwrap();
+
+        assert!(response.authorize_url.contains("login.microsoftonline.com"));
+        assert!(response.authorize_url.contains("organizations"));
+        assert!(response.loopback_port.is_some());
+        // The redirect URI (localhost loopback) is urlencoded into the URL.
+        assert!(
+            response.authorize_url.contains("127.0.0.1")
+                || response.authorize_url.contains("localhost")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_oauth_get_authorize_url_azure_custom_tenant() {
+        let result = oauth_get_authorize_url(
+            "azure".to_string(),
+            Some("my-tenant-id".to_string()),
+            "test-client-id".to_string(),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let response = result.unwrap();
+
+        assert!(response.authorize_url.contains("my-tenant-id"));
     }
 
     #[tokio::test]
@@ -1118,7 +846,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_oauth_get_authorize_url_generates_unique_state() {
-        // Use a redirect-flow provider (Azure uses device-code and has no authorize URL).
         let result1 =
             oauth_get_authorize_url("gitlab".to_string(), None, "test-client-id".to_string()).await;
         let result2 =
@@ -1500,130 +1227,6 @@ mod tests {
             deserialized.instance_url,
             Some("https://auth.example.com".to_string())
         );
-    }
-
-    // ==========================================================================
-    // Device Code Flow Tests
-    // ==========================================================================
-
-    #[test]
-    fn test_azure_tenant_base_default() {
-        let base = azure_tenant_base(None);
-        assert_eq!(base, "https://login.microsoftonline.com/common/oauth2/v2.0");
-    }
-
-    #[test]
-    fn test_azure_tenant_base_specific() {
-        let base = azure_tenant_base(Some("my-tenant"));
-        assert_eq!(
-            base,
-            "https://login.microsoftonline.com/my-tenant/oauth2/v2.0"
-        );
-    }
-
-    #[test]
-    fn test_start_device_code_response_serializes_camel_case() {
-        let response = StartDeviceCodeResponse {
-            flow_id: "flow-1".to_string(),
-            user_code: "ABCD-EFGH".to_string(),
-            verification_uri: "https://microsoft.com/devicelogin".to_string(),
-            expires_in: 900,
-            interval: 5,
-            message: "Enter the code".to_string(),
-        };
-        let json = serde_json::to_string(&response).unwrap();
-        assert!(json.contains("flowId"));
-        assert!(json.contains("userCode"));
-        assert!(json.contains("verificationUri"));
-        assert!(json.contains("expiresIn"));
-    }
-
-    #[tokio::test]
-    async fn test_start_device_code_rejects_unsupported_provider() {
-        // Only Azure supports device code; GitHub must be rejected before any network call.
-        let result =
-            oauth_start_device_code("github".to_string(), "client".to_string(), None).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_start_device_code_rejects_invalid_provider() {
-        let result =
-            oauth_start_device_code("nonsense".to_string(), "client".to_string(), None).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_poll_device_code_unknown_flow_errors() {
-        // A flow id that was never started (or already consumed) must error, not hang.
-        let result = oauth_poll_device_code("does-not-exist".to_string()).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_cancel_device_code_is_ok_for_missing_flow() {
-        // Cancelling a non-existent flow is a no-op success (idempotent).
-        assert!(oauth_cancel_device_code("no-such-flow".to_string())
-            .await
-            .is_ok());
-    }
-
-    #[test]
-    fn test_classify_device_poll_pending_keeps_waiting() {
-        assert_eq!(
-            classify_device_poll_error("authorization_pending", 400),
-            DevicePollAction::KeepWaiting
-        );
-    }
-
-    #[test]
-    fn test_classify_device_poll_slow_down() {
-        assert_eq!(
-            classify_device_poll_error("slow_down", 400),
-            DevicePollAction::SlowDown
-        );
-    }
-
-    #[test]
-    fn test_classify_device_poll_declined_fails() {
-        match classify_device_poll_error("authorization_declined", 400) {
-            DevicePollAction::Fail(msg) => assert!(msg.contains("declined")),
-            other => panic!("expected Fail, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_classify_device_poll_expired_fails() {
-        match classify_device_poll_error("expired_token", 400) {
-            DevicePollAction::Fail(msg) => assert!(msg.contains("timed out")),
-            other => panic!("expected Fail, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_classify_device_poll_empty_error_4xx_terminates_with_status() {
-        // A non-JSON / empty error body on a 4xx terminates, surfacing the status.
-        match classify_device_poll_error("", 400) {
-            DevicePollAction::Fail(msg) => assert!(msg.contains("400")),
-            other => panic!("expected Fail, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_classify_device_poll_empty_error_5xx_retries() {
-        // A transient 5xx blip must be retried, not treated as terminal.
-        assert_eq!(
-            classify_device_poll_error("", 503),
-            DevicePollAction::KeepWaiting
-        );
-    }
-
-    #[test]
-    fn test_classify_device_poll_unknown_error_passed_through() {
-        match classify_device_poll_error("invalid_grant", 400) {
-            DevicePollAction::Fail(msg) => assert_eq!(msg, "invalid_grant"),
-            other => panic!("expected Fail, got {:?}", other),
-        }
     }
 }
 

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -339,6 +339,18 @@ pub async fn oauth_start_github_flow(client_id: String) -> Result<StartOAuthResp
 /// NOT accepted from the frontend. This both validates the `state` (it must
 /// match an in-flight flow this process issued) and prevents the PKCE secret
 /// from round-tripping through the client.
+/// Build the Azure (Entra ID) token endpoint for a given tenant. Defaults to
+/// `organizations` so the code is redeemed at the SAME authority segment the
+/// authorize URL was built with (see `OAuthConfig::azure`) — redeeming under a
+/// different segment (e.g. `common`) can be rejected by Entra.
+fn azure_token_url(instance_url: Option<&str>) -> String {
+    let tenant = instance_url.unwrap_or("organizations");
+    format!(
+        "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+        tenant
+    )
+}
+
 #[tauri::command]
 pub async fn oauth_exchange_code(
     state: String,
@@ -374,13 +386,7 @@ pub async fn oauth_exchange_code(
             let base = instance_url.as_deref().unwrap_or("https://gitlab.com");
             format!("{}/oauth/token", base)
         }
-        OAuthProvider::Azure => {
-            let tenant = instance_url.as_deref().unwrap_or("common");
-            format!(
-                "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
-                tenant
-            )
-        }
+        OAuthProvider::Azure => azure_token_url(instance_url.as_deref()),
         OAuthProvider::Bitbucket => "https://bitbucket.org/site/oauth2/access_token".to_string(),
         OAuthProvider::Oidc => {
             // For OIDC, discover the token endpoint from the issuer URL
@@ -479,13 +485,7 @@ pub async fn oauth_refresh_token(
             let base = instance_url.as_deref().unwrap_or("https://gitlab.com");
             format!("{}/oauth/token", base)
         }
-        OAuthProvider::Azure => {
-            let tenant = instance_url.as_deref().unwrap_or("common");
-            format!(
-                "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
-                tenant
-            )
-        }
+        OAuthProvider::Azure => azure_token_url(instance_url.as_deref()),
         OAuthProvider::Bitbucket => "https://bitbucket.org/site/oauth2/access_token".to_string(),
         OAuthProvider::Oidc => {
             let issuer = instance_url
@@ -815,6 +815,27 @@ mod tests {
         let response = result.unwrap();
 
         assert!(response.authorize_url.contains("my-tenant-id"));
+    }
+
+    #[test]
+    fn test_azure_token_url_default_tenant_matches_authorize() {
+        // The exchange/refresh token endpoint must default to the SAME tenant
+        // segment (`organizations`) the authorize URL is built with, or Entra can
+        // reject redeeming the code under a mismatched authority.
+        let authorize = OAuthConfig::azure("cid", None, 8080).authorize_url;
+        assert!(authorize.contains("/organizations/"));
+        assert_eq!(
+            azure_token_url(None),
+            "https://login.microsoftonline.com/organizations/oauth2/v2.0/token"
+        );
+    }
+
+    #[test]
+    fn test_azure_token_url_specific_tenant() {
+        assert_eq!(
+            azure_token_url(Some("my-tenant-id")),
+            "https://login.microsoftonline.com/my-tenant-id/oauth2/v2.0/token"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -665,9 +665,6 @@ pub fn run() {
             commands::oauth::oauth_refresh_token,
             commands::oauth::oauth_wait_for_callback,
             commands::oauth::oauth_wait_for_github_callback,
-            commands::oauth::oauth_start_device_code,
-            commands::oauth::oauth_poll_device_code,
-            commands::oauth::oauth_cancel_device_code,
             commands::oauth::discover_oidc_provider,
             commands::oauth::decode_oidc_id_token,
             // Git Flow

--- a/src-tauri/src/services/oauth.rs
+++ b/src-tauri/src/services/oauth.rs
@@ -122,6 +122,32 @@ impl OAuthConfig {
         }
     }
 
+    /// Get Azure DevOps (Microsoft Entra ID) OAuth configuration for the interactive
+    /// authorization-code + loopback flow. Uses `localhost` (Entra ignores the port for
+    /// loopback) with the `/callback` path the loopback server serves. `tenant_id`
+    /// (passed as instance_url) defaults to `organizations` (multi-tenant work/school).
+    pub fn azure(client_id: &str, tenant_id: Option<&str>, redirect_port: u16) -> Self {
+        let tenant = tenant_id.unwrap_or("organizations");
+        Self {
+            client_id: client_id.to_string(),
+            authorize_url: format!(
+                "https://login.microsoftonline.com/{}/oauth2/v2.0/authorize",
+                tenant
+            ),
+            token_url: format!(
+                "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+                tenant
+            ),
+            scopes: vec![
+                "499b84ac-1321-427f-aa17-267ca6975798/user_impersonation".to_string(),
+                "offline_access".to_string(),
+                "openid".to_string(),
+                "profile".to_string(),
+            ],
+            redirect_uri: format!("http://localhost:{}/callback", redirect_port),
+        }
+    }
+
     /// Get Bitbucket OAuth configuration
     /// Bitbucket requires http/https redirect URIs, so we use the loopback server
     pub fn bitbucket(client_id: &str, redirect_port: u16) -> Self {
@@ -577,6 +603,24 @@ mod tests {
         assert_eq!(config.redirect_uri, "http://127.0.0.1:8085/callback");
         assert!(config.scopes.contains(&"repository".to_string()));
         assert!(config.scopes.contains(&"pullrequest".to_string()));
+    }
+
+    #[test]
+    fn test_azure_config_default_tenant() {
+        let config = OAuthConfig::azure("cid", None, 8080);
+
+        assert!(config.authorize_url.contains("/organizations/"));
+        assert_eq!(config.redirect_uri, "http://localhost:8080/callback");
+        assert!(config
+            .scopes
+            .contains(&"499b84ac-1321-427f-aa17-267ca6975798/user_impersonation".to_string()));
+        assert!(config.scopes.contains(&"offline_access".to_string()));
+    }
+
+    #[test]
+    fn test_azure_config_specific_tenant() {
+        let config = OAuthConfig::azure("cid", Some("my-tenant"), 8080);
+        assert!(config.authorize_url.contains("/my-tenant/"));
     }
 
     // ==========================================================================

--- a/src-tauri/src/services/oauth.rs
+++ b/src-tauri/src/services/oauth.rs
@@ -123,9 +123,10 @@ impl OAuthConfig {
     }
 
     /// Get Azure DevOps (Microsoft Entra ID) OAuth configuration for the interactive
-    /// authorization-code + loopback flow. Uses `localhost` (Entra ignores the port for
-    /// loopback) with the `/callback` path the loopback server serves. `tenant_id`
-    /// (passed as instance_url) defaults to `organizations` (multi-tenant work/school).
+    /// authorization-code + loopback flow. Uses `127.0.0.1` (the address the loopback
+    /// server binds; Entra ignores the port for loopback) with the `/callback` path the
+    /// loopback server serves — matching the other providers. `tenant_id` (passed as
+    /// instance_url) defaults to `organizations` (multi-tenant work/school).
     pub fn azure(client_id: &str, tenant_id: Option<&str>, redirect_port: u16) -> Self {
         let tenant = tenant_id.unwrap_or("organizations");
         Self {
@@ -144,7 +145,7 @@ impl OAuthConfig {
                 "openid".to_string(),
                 "profile".to_string(),
             ],
-            redirect_uri: format!("http://localhost:{}/callback", redirect_port),
+            redirect_uri: format!("http://127.0.0.1:{}/callback", redirect_port),
         }
     }
 
@@ -610,7 +611,7 @@ mod tests {
         let config = OAuthConfig::azure("cid", None, 8080);
 
         assert!(config.authorize_url.contains("/organizations/"));
-        assert_eq!(config.redirect_uri, "http://localhost:8080/callback");
+        assert_eq!(config.redirect_uri, "http://127.0.0.1:8080/callback");
         assert!(config
             .scopes
             .contains(&"499b84ac-1321-427f-aa17-267ca6975798/user_impersonation".to_string()));

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -206,23 +206,51 @@ function setupMockInvoke(): void {
     if (command === 'create_ado_pull_request') return mockPullRequests[0];
     if (command === 'sync_git_credential_for_ado') return null;
 
-    // Entra device-code flow (Sign in with Microsoft)
-    if (command === 'oauth_start_device_code') {
+    // Entra interactive auth-code + loopback flow (Sign in with Microsoft).
+    // startOAuth: get authorize URL → open browser → wait for loopback callback →
+    // exchange code → dispatch a global `oauth-complete` event with the tokens.
+    if (command === 'oauth_get_authorize_url') {
       return {
-        flowId: 'device-flow-1',
-        userCode: 'ABCD-EFGH',
-        verificationUri: 'https://microsoft.com/devicelogin',
-        expiresIn: 900,
-        interval: 1,
-        message: 'Enter the code to sign in.',
+        authorizeUrl:
+          'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?client_id=x&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback',
+        state: 'state-xyz',
+        loopbackPort: 8080,
       };
     }
-    if (command === 'oauth_poll_device_code') return { accessToken: 'ado_oauth_token' };
-    if (command === 'oauth_cancel_device_code') return null;
+    if (command === 'oauth_wait_for_callback') return { code: 'code-123', state: 'state-xyz' };
+    if (command === 'oauth_exchange_code') return { accessToken: 'ado_oauth_token' };
 
     return null;
   };
 }
+
+// --- Interactive Entra sign-in helpers (auth-code + loopback) ---
+
+// Put the dialog into the "interactive sign-in started" state without driving the
+// real loopback/browser plumbing (that lives in the OAuth service tests).
+// Capturing entraFlowGeneration is what lets a later `oauth-complete` pass the
+// generation guard — exactly what handleStartEntraOAuth does.
+function beginPendingFlow(el: LvAzureDevOpsDialog): void {
+  const api = el as unknown as {
+    oauthPending: boolean;
+    entraFlowGeneration: number;
+    entraGeneration: number;
+  };
+  api.oauthPending = true;
+  api.entraFlowGeneration = api.entraGeneration;
+}
+
+// Simulate the OAuth service finishing the loopback exchange: it dispatches a
+// global `oauth-complete` window event with the exchanged tokens.
+function dispatchOAuthComplete(accessToken = 'ado_oauth_token'): void {
+  window.dispatchEvent(
+    new CustomEvent('oauth-complete', {
+      detail: { provider: 'azure', tokens: { accessToken } },
+    })
+  );
+}
+
+const flush = (ms = 60): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 describe('lv-azure-devops-dialog', () => {
   beforeEach(() => {
@@ -779,7 +807,48 @@ describe('lv-azure-devops-dialog', () => {
   });
 
   describe('Entra ID OAuth', () => {
-    it('persists a new IntegrationAccount via save_global_account (not just the token)', async () => {
+    it('handleStartEntraOAuth kicks off the interactive loopback flow (oauth_get_authorize_url) and shows the connecting state', async () => {
+      connectionResponse = mockConnectedStatus;
+      // Hang the callback so the started flow stays pending and we can observe it.
+      mockInvoke = (() => {
+        const orig = mockInvoke;
+        return async (command: string, args?: unknown) => {
+          if (command === 'get_unified_profiles_config') {
+            return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
+          }
+          if (command === 'oauth_wait_for_callback') {
+            return new Promise(() => { /* never resolves */ });
+          }
+          return orig(command, args);
+        };
+      })();
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      (el as unknown as { authMethod: string }).authMethod = 'oauth';
+      await el.updateComplete;
+
+      invokeHistory.length = 0;
+      await (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
+      await flush(20);
+      await el.updateComplete;
+
+      // The interactive auth-code flow was started (no device-code command).
+      expect(invokeHistory.some((h) => h.command === 'oauth_get_authorize_url'), 'authorize URL requested').to.be.true;
+      expect(invokeHistory.some((h) => h.command === 'oauth_start_device_code'), 'no device-code flow').to.be.false;
+      expect((el as unknown as { oauthPending: boolean }).oauthPending, 'connecting spinner shown').to.be.true;
+
+      // The connecting state renders a spinner + Cancel, no device code.
+      const tokenForm = el.shadowRoot!.querySelector('.token-form')!;
+      expect(tokenForm.textContent).to.include('Complete sign-in in your browser');
+
+      // Clean up the pending service flow so it doesn't leak into later tests.
+      (el as unknown as { handleCancelEntraOAuth: () => void }).handleCancelEntraOAuth();
+    });
+
+    it('persists a new IntegrationAccount via save_global_account (not just the token) on completion', async () => {
       connectionResponse = mockConnectedStatus;
       // Start with no accounts so the OAuth path creates a brand-new one. The
       // backend persists the saved account, so a stateful store mirrors that:
@@ -812,9 +881,10 @@ describe('lv-azure-devops-dialog', () => {
       await el.updateComplete;
 
       invokeHistory.length = 0;
-      // The device-code poll resolves with tokens, then the org is finalized.
-      await (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
-      await new Promise((r) => setTimeout(r, 50));
+      // A started flow completes: the service dispatches oauth-complete with tokens.
+      beginPendingFlow(el);
+      dispatchOAuthComplete();
+      await flush();
       await el.updateComplete;
 
       const saveCall = invokeHistory.find((h) => h.command === 'save_global_account');
@@ -834,17 +904,13 @@ describe('lv-azure-devops-dialog', () => {
       expect(selected).to.equal((account as { id: string }).id);
     });
 
-    it('Cancel during a pending device sign-in stops the flow so a late completion does NOT connect', async () => {
+    it('Cancel during a pending sign-in stops the flow so a late completion does NOT connect', async () => {
       connectionResponse = mockConnectedStatus;
-      // Poll never resolves, so the flow stays pending and we can cancel mid-flight.
       mockInvoke = (() => {
         const orig = mockInvoke;
         return async (command: string, args?: unknown) => {
           if (command === 'get_unified_profiles_config') {
             return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
-          }
-          if (command === 'oauth_poll_device_code') {
-            return new Promise(() => { /* never resolves */ });
           }
           return orig(command, args);
         };
@@ -859,39 +925,33 @@ describe('lv-azure-devops-dialog', () => {
       (el as unknown as { selectedAccountId: string | null }).selectedAccountId = null;
       await el.updateComplete;
 
-      // Start the flow WITHOUT awaiting — the poll hangs, leaving the device code shown.
-      void (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
-      await new Promise((r) => setTimeout(r, 30));
+      beginPendingFlow(el);
       await el.updateComplete;
       expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.true;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode, 'device code shown').to.not.be.null;
 
       // User clicks Cancel.
-      invokeHistory.length = 0;
       (el as unknown as { handleCancelEntraOAuth: () => void }).handleCancelEntraOAuth();
       await el.updateComplete;
-
-      // The flow is cancelled server-side and the UI resets.
       expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.be.null;
-      expect(invokeHistory.some((h) => h.command === 'oauth_cancel_device_code'), 'backend flow cancelled').to.be.true;
 
-      // Nothing was verified or persisted.
-      expect(invokeHistory.some((h) => h.command === 'save_global_account')).to.be.false;
+      // A late callback arrives after cancel — the generation guard must ignore it.
+      invokeHistory.length = 0;
+      dispatchOAuthComplete();
+      await flush();
+      await el.updateComplete;
+
+      expect(invokeHistory.some((h) => h.command === 'save_global_account'), 'no account persisted after cancel').to.be.false;
       expect(invokeHistory.some((h) => h.command === 'store_keyring_token')).to.be.false;
       expect((el as unknown as { selectedAccountId: string | null }).selectedAccountId).to.be.null;
     });
 
-    it('closing the dialog mid-sign-in cancels the device flow (no silent late connect)', async () => {
+    it('closing the dialog mid-sign-in blocks a silent late connect', async () => {
       connectionResponse = mockConnectedStatus;
       mockInvoke = (() => {
         const orig = mockInvoke;
         return async (command: string, args?: unknown) => {
           if (command === 'get_unified_profiles_config') {
             return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
-          }
-          if (command === 'oauth_poll_device_code') {
-            return new Promise(() => { /* never resolves */ });
           }
           return orig(command, args);
         };
@@ -904,32 +964,29 @@ describe('lv-azure-devops-dialog', () => {
       (el as unknown as { selectedAccountId: string | null }).selectedAccountId = null;
       await el.updateComplete;
 
-      void (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
-      await new Promise((r) => setTimeout(r, 30));
+      beginPendingFlow(el);
       await el.updateComplete;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode, 'device code shown').to.not.be.null;
 
       // Close via the modal (X / Escape / backdrop all route through handleClose).
-      invokeHistory.length = 0;
       (el as unknown as { handleClose: () => void }).handleClose();
       await el.updateComplete;
-
-      expect(invokeHistory.some((h) => h.command === 'oauth_cancel_device_code'), 'flow cancelled on close').to.be.true;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.be.null;
       expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
-      expect(invokeHistory.some((h) => h.command === 'save_global_account')).to.be.false;
+
+      invokeHistory.length = 0;
+      dispatchOAuthComplete();
+      await flush();
+      await el.updateComplete;
+
+      expect(invokeHistory.some((h) => h.command === 'save_global_account'), 'no connect after close').to.be.false;
     });
 
-    it('switching accounts mid-sign-in abandons the device flow (no write to the new account)', async () => {
+    it('switching accounts mid-sign-in blocks a write to the new account', async () => {
       connectionResponse = mockConnectedStatus;
       mockInvoke = (() => {
         const orig = mockInvoke;
         return async (command: string, args?: unknown) => {
           if (command === 'get_unified_profiles_config') {
             return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
-          }
-          if (command === 'oauth_poll_device_code') {
-            return new Promise(() => { /* never resolves */ });
           }
           return orig(command, args);
         };
@@ -941,21 +998,20 @@ describe('lv-azure-devops-dialog', () => {
       await waitForLoad(el);
       await el.updateComplete;
 
-      // Start a device flow (poll hangs), showing the device code.
-      void (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
-      await new Promise((r) => setTimeout(r, 30));
-      await el.updateComplete;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.not.be.null;
-
-      // Switching to another account must abandon the flow first.
-      invokeHistory.length = 0;
-      await (el as unknown as { handleAddAccount: () => void }).handleAddAccount();
+      beginPendingFlow(el);
       await el.updateComplete;
 
-      expect(invokeHistory.some((h) => h.command === 'oauth_cancel_device_code'), 'flow cancelled on account switch').to.be.true;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.be.null;
+      // Starting an "Add account" must abandon the flow first.
+      (el as unknown as { handleAddAccount: () => void }).handleAddAccount();
+      await el.updateComplete;
       expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
-      expect(invokeHistory.some((h) => h.command === 'save_global_account')).to.be.false;
+
+      invokeHistory.length = 0;
+      dispatchOAuthComplete();
+      await flush();
+      await el.updateComplete;
+
+      expect(invokeHistory.some((h) => h.command === 'save_global_account'), 'no connect after account switch').to.be.false;
     });
 
     it('cancelling clears the loading state so the sign-in button is not stuck disabled', async () => {
@@ -993,16 +1049,13 @@ describe('lv-azure-devops-dialog', () => {
       expect((el as unknown as { selectedAccountId: string | null }).selectedAccountId).to.be.null;
     });
 
-    it('switching to the PAT tab mid-sign-in abandons the device flow', async () => {
+    it('switching to the PAT tab mid-sign-in abandons the flow', async () => {
       connectionResponse = mockConnectedStatus;
       mockInvoke = (() => {
         const orig = mockInvoke;
         return async (command: string, args?: unknown) => {
           if (command === 'get_unified_profiles_config') {
             return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
-          }
-          if (command === 'oauth_poll_device_code') {
-            return new Promise(() => { /* never resolves */ });
           }
           return orig(command, args);
         };
@@ -1015,31 +1068,29 @@ describe('lv-azure-devops-dialog', () => {
       (el as unknown as { authMethod: string }).authMethod = 'oauth';
       await el.updateComplete;
 
-      void (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
-      await new Promise((r) => setTimeout(r, 30));
+      beginPendingFlow(el);
       await el.updateComplete;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.not.be.null;
 
-      invokeHistory.length = 0;
       (el as unknown as { setAuthMethod: (m: string) => void }).setAuthMethod('pat');
       await el.updateComplete;
 
       expect((el as unknown as { authMethod: string }).authMethod).to.equal('pat');
-      expect(invokeHistory.some((h) => h.command === 'oauth_cancel_device_code'), 'flow cancelled on tab switch').to.be.true;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.be.null;
       expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
+
+      invokeHistory.length = 0;
+      dispatchOAuthComplete();
+      await flush();
+      await el.updateComplete;
+      expect(invokeHistory.some((h) => h.command === 'save_global_account'), 'no connect after tab switch').to.be.false;
     });
 
-    it('opening Manage Accounts mid-sign-in abandons the device flow', async () => {
+    it('opening Manage Accounts mid-sign-in abandons the flow', async () => {
       connectionResponse = mockConnectedStatus;
       mockInvoke = (() => {
         const orig = mockInvoke;
         return async (command: string, args?: unknown) => {
           if (command === 'get_unified_profiles_config') {
             return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
-          }
-          if (command === 'oauth_poll_device_code') {
-            return new Promise(() => { /* never resolves */ });
           }
           return orig(command, args);
         };
@@ -1051,18 +1102,18 @@ describe('lv-azure-devops-dialog', () => {
       await waitForLoad(el);
       await el.updateComplete;
 
-      void (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
-      await new Promise((r) => setTimeout(r, 30));
+      beginPendingFlow(el);
       await el.updateComplete;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.not.be.null;
 
-      invokeHistory.length = 0;
       (el as unknown as { handleManageAccounts: (e: Event) => void }).handleManageAccounts(new Event('manage'));
       await el.updateComplete;
-
-      expect(invokeHistory.some((h) => h.command === 'oauth_cancel_device_code'), 'flow cancelled on manage-accounts').to.be.true;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode).to.be.null;
       expect((el as unknown as { oauthPending: boolean }).oauthPending).to.be.false;
+
+      invokeHistory.length = 0;
+      dispatchOAuthComplete();
+      await flush();
+      await el.updateComplete;
+      expect(invokeHistory.some((h) => h.command === 'save_global_account'), 'no connect after manage-accounts').to.be.false;
     });
 
     it('preserves a PAT-typed organization across an OAuth tab round-trip', async () => {
@@ -1092,7 +1143,7 @@ describe('lv-azure-devops-dialog', () => {
       // On the PAT tab the user typed an org (no account/repo context).
       api.organizationInput = 'my-typed-org';
 
-      // Switch to OAuth: the org is stashed (not used for device-code resolution).
+      // Switch to OAuth: the org is stashed (not used for OAuth resolution).
       api.setAuthMethod('oauth');
       await el.updateComplete;
       expect(api.organizationInput, 'org hidden from OAuth resolution').to.equal('');
@@ -1103,16 +1154,16 @@ describe('lv-azure-devops-dialog', () => {
       expect(api.organizationInput, 'PAT org restored').to.equal('my-typed-org');
     });
 
-    it('surfaces an error and stops the spinner when the device sign-in fails (not a stuck dead-end)', async () => {
+    it('surfaces an error and stops the spinner when the sign-in fails to start (not a stuck dead-end)', async () => {
       mockInvoke = (() => {
         const orig = mockInvoke;
         return async (command: string, args?: unknown) => {
           if (command === 'get_unified_profiles_config') {
             return { version: 3, profiles: [], accounts: [], repositoryAssignments: {} };
           }
-          if (command === 'oauth_start_device_code') {
-            throw new Error('Failed to start device sign-in');
-          }
+          // Fail to obtain the authorize URL: startOAuth emits an error state,
+          // which the dialog's onOAuthStateChange subscription surfaces.
+          if (command === 'oauth_get_authorize_url') return null;
           return orig(command, args);
         };
       })();
@@ -1123,14 +1174,15 @@ describe('lv-azure-devops-dialog', () => {
       await waitForLoad(el);
       (el as unknown as { organizationInput: string }).organizationInput = 'testorg';
       (el as unknown as { selectedAccountId: string | null }).selectedAccountId = null;
+      (el as unknown as { authMethod: string }).authMethod = 'oauth';
       await el.updateComplete;
 
       await (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
+      await flush();
       await el.updateComplete;
 
       // The failure must clear the spinner and surface an error — not hang.
       expect((el as unknown as { oauthPending: boolean }).oauthPending, 'spinner cleared on failure').to.be.false;
-      expect((el as unknown as { deviceCode: unknown }).deviceCode, 'device code cleared').to.be.null;
       expect((el as unknown as { error: string | null }).error, 'error surfaced').to.be.a('string').and.not.empty;
     });
   });
@@ -1153,10 +1205,10 @@ describe('lv-azure-devops-dialog', () => {
       // The simplified OAuth path has NO inputs (no Client ID, no Organization).
       expect(tokenForm.querySelectorAll('input').length).to.equal(0);
 
-      // Exactly the primary "Sign in with Microsoft" button is present.
-      const primaryBtn = tokenForm.querySelector('.btn-primary');
-      expect(primaryBtn).to.not.be.null;
-      expect(primaryBtn!.textContent?.trim()).to.include('Sign in with Microsoft');
+      // Exactly the branded "Sign in with Microsoft" button is present.
+      const signInBtn = tokenForm.querySelector('.ms-signin-btn');
+      expect(signInBtn).to.not.be.null;
+      expect(signInBtn!.textContent?.trim()).to.include('Sign in with Microsoft');
     });
 
     it('renders an org picker when needsOrgSelection is true with availableOrgs set', async () => {
@@ -1182,7 +1234,7 @@ describe('lv-azure-devops-dialog', () => {
       expect(orgButtons.length).to.equal(2);
 
       // The "Sign in with Microsoft" button is hidden while picking.
-      expect(tokenForm.querySelector('.btn-primary')).to.be.null;
+      expect(tokenForm.querySelector('.ms-signin-btn')).to.be.null;
     });
 
     it('shows the org picker after sign-in when the org cannot be detected (multiple orgs), and finalizes on selection', async () => {
@@ -1213,9 +1265,10 @@ describe('lv-azure-devops-dialog', () => {
       (el as unknown as { authMethod: string }).authMethod = 'oauth';
       await el.updateComplete;
 
-      // Device-code poll resolves with a token; org resolution then lists orgs.
-      await (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
-      await new Promise((r) => setTimeout(r, 50));
+      // The sign-in completes with a token; org resolution then lists orgs.
+      beginPendingFlow(el);
+      dispatchOAuthComplete();
+      await flush();
       await el.updateComplete;
 
       expect(invokeHistory.some((h) => h.command === 'list_ado_organizations')).to.be.true;
@@ -1267,8 +1320,8 @@ describe('lv-azure-devops-dialog', () => {
       expect((el as unknown as { needsOrgSelection: boolean }).needsOrgSelection).to.be.false;
       expect((el as unknown as { pendingTokens: unknown }).pendingTokens).to.be.null;
       expect((el as unknown as { availableOrgs: unknown[] }).availableOrgs).to.have.length(0);
-      const primaryBtn = el.shadowRoot!.querySelector('.token-form .btn-primary');
-      expect(primaryBtn?.textContent?.trim()).to.include('Sign in with Microsoft');
+      const signInBtn = el.shadowRoot!.querySelector('.token-form .ms-signin-btn');
+      expect(signInBtn?.textContent?.trim()).to.include('Sign in with Microsoft');
     });
 
     it('surfaces an error (not a silent dead-end) when the account has no organizations', async () => {
@@ -1292,8 +1345,9 @@ describe('lv-azure-devops-dialog', () => {
       (el as unknown as { authMethod: string }).authMethod = 'oauth';
       await el.updateComplete;
 
-      await (el as unknown as { handleStartEntraOAuth: () => Promise<void> }).handleStartEntraOAuth();
-      await new Promise((r) => setTimeout(r, 50));
+      beginPendingFlow(el);
+      dispatchOAuthComplete();
+      await flush();
       await el.updateComplete;
 
       // Error surfaced, spinner cleared, and no half-finished picker left behind.

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -1881,7 +1881,7 @@ export class LvAzureDevOpsDialog extends LitElement {
           ${this.oauthPending ? html`
             <div style="display:flex;align-items:center;gap:8px;padding:12px;color:var(--color-text-secondary)">
               <div style="width:16px;height:16px;border:2px solid var(--color-border);border-top-color:var(--color-accent);border-radius:50%;animation:spin 0.8s linear infinite"></div>
-              Complete sign-in in your browser...
+              ${this.isLoading ? 'Connecting to Azure DevOps...' : 'Complete sign-in in your browser...'}
               <button class="btn" @click=${this.handleCancelEntraOAuth}>Cancel</button>
             </div>
           ` : this.needsOrgSelection ? html`

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -12,6 +12,7 @@ import { showToast } from '../../services/notification.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
 import { loggers, openExternalUrl, handleExternalLink } from '../../utils/index.ts';
 import * as oauthService from '../../services/oauth.service.ts';
+import type { OAuthTokenResponse } from '../../types/oauth.types.ts';
 
 const log = loggers.azureDevOps;
 import type {
@@ -171,18 +172,38 @@ export class LvAzureDevOpsDialog extends LitElement {
         color: var(--color-text-muted);
       }
 
-      .device-code {
-        font-family: var(--font-family-mono);
-        font-size: var(--font-size-xl);
-        font-weight: var(--font-weight-semibold);
-        letter-spacing: 0.15em;
-        text-align: center;
-        padding: var(--spacing-md);
-        background: var(--color-bg-tertiary);
-        border: 1px solid var(--color-border);
-        border-radius: var(--radius-md);
-        color: var(--color-text-primary);
-        user-select: all;
+      /* Official Microsoft-branded sign-in button (light variant). Kept close to
+         Microsoft's brand guidelines: white background, square corners, the
+         four-square logo, "Sign in with Microsoft" in Segoe UI. */
+      .ms-signin-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        height: 41px;
+        padding: 0 12px;
+        background: #ffffff;
+        border: 1px solid #8c8c8c;
+        border-radius: 0;
+        color: #5e5e5e;
+        font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-size: 15px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background var(--transition-fast);
+      }
+
+      .ms-signin-btn:hover:not(:disabled) {
+        background: #f5f5f5;
+      }
+
+      .ms-signin-btn:focus-visible {
+        outline: 2px solid #0067b8;
+        outline-offset: 1px;
+      }
+
+      .ms-signin-btn:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
       }
 
       .help-link {
@@ -610,10 +631,16 @@ export class LvAzureDevOpsDialog extends LitElement {
   @state() private authMethod: 'oauth' | 'pat' = 'pat';
   /** True from the moment "Sign in with Microsoft" is clicked until the flow settles. */
   @state() private oauthPending = false;
-  /** The device code + verification URL to show the user while they sign in. */
-  @state() private deviceCode: { userCode: string; verificationUri: string } | null = null;
-  /** Handle for the in-flight device-code flow (used to poll/cancel it). */
-  private deviceFlowId: string | null = null;
+  /** `oauth-complete` window listener for the interactive loopback flow. */
+  private oauthCompleteHandler?: EventListener;
+  /** Unsubscribe handle for the OAuth state-change subscription (error surfacing). */
+  private oauthStateUnsubscribe?: () => void;
+  /**
+   * The `entraGeneration` captured when the current sign-in was started. The
+   * global `oauth-complete` event carries no generation, so the handler compares
+   * this against `entraGeneration` to ignore a callback for an abandoned flow.
+   */
+  private entraFlowGeneration = 0;
   /** Org typed on the PAT form, stashed while on the OAuth tab so it survives a round-trip. */
   private savedPatOrg = '';
   /** Last `${org}::${token}` written to the keyring git credential, to skip redundant re-syncs. */
@@ -656,6 +683,28 @@ export class LvAzureDevOpsDialog extends LitElement {
 
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
+
+    // Interactive Entra sign-in (auth-code + loopback) completes asynchronously
+    // via a global `oauth-complete` window event dispatched by the OAuth service.
+    // Route the azure one into org resolution + finalize.
+    this.oauthCompleteHandler = ((e: CustomEvent<{ provider: string; tokens: OAuthTokenResponse; instanceUrl?: string }>) => {
+      if (e.detail.provider === 'azure') {
+        void this.handleOAuthComplete(e.detail.tokens);
+      }
+    }) as unknown as EventListener;
+    window.addEventListener('oauth-complete', this.oauthCompleteHandler);
+
+    // Surface a failed/denied sign-in so the pending spinner clears with feedback.
+    this.oauthStateUnsubscribe = oauthService.onOAuthStateChange((state) => {
+      if (state.provider !== 'azure') return;
+      // Ignore state for a flow the dialog already abandoned (cancel/close/switch).
+      if (this.entraFlowGeneration !== this.entraGeneration) return;
+      if (state.status === 'error') {
+        this.oauthPending = false;
+        this.error = state.error ?? 'Microsoft sign-in failed';
+        showToast(this.error, 'error');
+      }
+    });
 
     // Subscribe to unified profile store. When the active profile changes,
     // re-derive the preferred account so a profile switch is reflected here.
@@ -708,18 +757,22 @@ export class LvAzureDevOpsDialog extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.unsubscribeStore?.();
-    // Cancel any in-flight device-code sign-in so it doesn't poll after unmount,
-    // and invalidate continuations so a late finalize can't mutate a dead element.
+    // Cancel any in-flight sign-in so its callback can't fire after unmount, and
+    // invalidate continuations so a late finalize can't mutate a dead element.
     this.abandonPendingEntraFlow();
+    if (this.oauthCompleteHandler) {
+      window.removeEventListener('oauth-complete', this.oauthCompleteHandler);
+    }
+    this.oauthStateUnsubscribe?.();
   }
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     if (changedProperties.has('open') && this.open) {
       // Fresh open: abandon any sign-in left in-flight from a prior session
       // (the host may hide the dialog without routing through handleClose, e.g.
-      // by setting its `open` prop false), so a reopen can't surface a stale
-      // device code or a stuck "Connecting..." spinner. Then clear
-      // selectedAccountId so loadInitialData() re-derives it.
+      // by setting its `open` prop false), so a reopen can't surface a stuck
+      // "Connecting..." spinner. Then clear selectedAccountId so
+      // loadInitialData() re-derives it.
       this.abandonPendingEntraFlow();
       this.selectedAccountId = null;
       await this.loadInitialData();
@@ -1074,61 +1127,44 @@ export class LvAzureDevOpsDialog extends LitElement {
   }
 
   /**
-   * Start the one-click Microsoft (Entra ID) sign-in via the OAuth device-code
-   * flow. Shows the user a short code to enter at a verification URL, opens that
-   * URL in the browser, then blocks on the backend poll until the user finishes.
-   * Uses the embedded public client — no per-user app registration and no
-   * redirect URI (device code needs neither).
+   * Start the one-click Microsoft (Entra ID) sign-in via the interactive
+   * authorization-code + loopback flow (the same path GitHub/GitLab use). Opens
+   * the Microsoft sign-in page in the browser; the OAuth service waits on the
+   * loopback callback, exchanges the code, and dispatches a global
+   * `oauth-complete` event that `handleOAuthComplete` picks up. Uses the embedded
+   * registered public client — no per-user app registration.
    */
   private async handleStartEntraOAuth(): Promise<void> {
-    // Guard against a double-click starting a second (orphaned) device flow.
+    // Guard against a double-click starting a second (orphaned) flow.
     if (this.oauthPending) return;
 
-    const generation = ++this.entraGeneration;
+    this.entraFlowGeneration = ++this.entraGeneration;
     this.oauthPending = true;
     this.error = null;
-    this.deviceCode = null;
 
-    try {
-      const start = await oauthService.startDeviceCode('azure', oauthService.getClientId('azure'));
-      if (generation !== this.entraGeneration) {
-        // Cancelled/closed while starting: abandonPendingEntraFlow ran before we
-        // knew the flow id, so cancel the now-orphaned backend flow here.
-        void oauthService.cancelDeviceCode(start.flowId);
-        return;
-      }
-      this.deviceFlowId = start.flowId;
-      this.deviceCode = { userCode: start.userCode, verificationUri: start.verificationUri };
+    // Fire-and-forget: startOAuth opens the browser and drives the loopback
+    // callback → code exchange, then dispatches `oauth-complete`. Errors surface
+    // through the onOAuthStateChange subscription registered in connectedCallback.
+    await oauthService.startOAuth('azure', oauthService.getClientId('azure'));
+  }
 
-      // Open the verification page so the user only has to enter the code.
-      openExternalUrl(start.verificationUri);
-
-      // Blocks until the user completes sign-in (or it is cancelled / times out).
-      const tokens = await oauthService.pollDeviceCode(start.flowId);
-
-      // The user may have cancelled (or started a new flow) while we waited.
-      if (generation !== this.entraGeneration) return;
-
-      this.deviceCode = null;
-      this.deviceFlowId = null;
-      // resolveOrgAndFinalize owns the loading/error/oauthPending state from here.
-      await this.resolveOrgAndFinalize(
-        {
-          accessToken: tokens.accessToken,
-          refreshToken: tokens.refreshToken,
-          expiresIn: tokens.expiresIn,
-        },
-        generation,
-      );
-    } catch (err) {
-      // A cancel/close races the poll rejection; only surface if still current.
-      if (generation !== this.entraGeneration) return;
-      this.error = err instanceof Error ? err.message : 'Microsoft sign-in failed';
-      showToast(this.error, 'error');
-      this.deviceCode = null;
-      this.deviceFlowId = null;
-      this.oauthPending = false;
-    }
+  /**
+   * Handle a completed interactive Entra sign-in: route the exchanged tokens into
+   * org resolution + finalize. Ignores a callback for a flow the dialog already
+   * abandoned (the user cancelled/closed or switched accounts mid-flow).
+   */
+  private async handleOAuthComplete(tokens: OAuthTokenResponse): Promise<void> {
+    const generation = this.entraFlowGeneration;
+    if (generation !== this.entraGeneration) return;
+    // resolveOrgAndFinalize owns the loading/error/oauthPending state from here.
+    await this.resolveOrgAndFinalize(
+      {
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        expiresIn: tokens.expiresIn,
+      },
+      generation,
+    );
   }
 
   /**
@@ -1335,10 +1371,11 @@ export class LvAzureDevOpsDialog extends LitElement {
   }
 
   /**
-   * Cancel a pending Entra ID device-code sign-in.
+   * Cancel a pending Entra ID sign-in.
    *
-   * Clearing `deviceFlowId` first makes the in-flight poll's result be ignored
-   * (see handleStartEntraOAuth), and cancelDeviceCode stops the server-side poll.
+   * Bumping the generation makes any in-flight `oauth-complete` callback be
+   * ignored (see handleOAuthComplete), and cancelOAuth tears down the loopback
+   * server / pending flow in the OAuth service.
    */
   private handleCancelEntraOAuth(): void {
     this.abandonPendingEntraFlow();
@@ -1346,17 +1383,15 @@ export class LvAzureDevOpsDialog extends LitElement {
 
   /**
    * Abandon any in-flight Entra sign-in: bump the generation so async
-   * continuations (poll/finalize) bail, cancel the backend device flow, and
+   * continuations (oauth-complete/finalize) bail, cancel the loopback flow, and
    * clear all transient sign-in UI state. Safe to call when no flow is active.
    * MUST be called before anything that changes the target account
    * (selectedAccountId) mid-flow, or a completing flow would write to the wrong
    * account.
    */
   private abandonPendingEntraFlow(): void {
+    const wasPending = this.oauthPending;
     this.entraGeneration++;
-    const flowId = this.deviceFlowId;
-    this.deviceFlowId = null;
-    this.deviceCode = null;
     this.oauthPending = false;
     // Bumping the generation makes resolveOrgAndFinalize's finally skip its own
     // reset, so clear isLoading here too — otherwise cancelling during
@@ -1365,8 +1400,8 @@ export class LvAzureDevOpsDialog extends LitElement {
     this.needsOrgSelection = false;
     this.pendingTokens = null;
     this.availableOrgs = [];
-    if (flowId) {
-      void oauthService.cancelDeviceCode(flowId);
+    if (wasPending) {
+      oauthService.cancelOAuth('azure');
     }
   }
 
@@ -1374,11 +1409,11 @@ export class LvAzureDevOpsDialog extends LitElement {
    * Switch between the "Sign in with Microsoft" and PAT tabs. Abandons any
    * in-flight Entra sign-in so it can't complete underneath the other view, and
    * when entering the OAuth tab without a selected account or detected repo,
-   * drops any org left over from the PAT form so device-code sign-in goes through
+   * drops any org left over from the PAT form so OAuth sign-in goes through
    * org detection/listing instead of silently reusing a stray value.
    */
   private setAuthMethod(method: 'oauth' | 'pat'): void {
-    if (this.oauthPending || this.deviceCode || this.needsOrgSelection) {
+    if (this.oauthPending || this.needsOrgSelection) {
       this.abandonPendingEntraFlow();
     }
     if (method === 'oauth' && !this.selectedAccountId && !this.detectedRepo) {
@@ -1842,26 +1877,11 @@ export class LvAzureDevOpsDialog extends LitElement {
         </div>
 
         ${this.authMethod === 'oauth' ? html`
-          <!-- Entra ID OAuth (device-code flow) -->
-          ${this.deviceCode ? html`
-            <div class="form-group">
-              <label>Sign in with Microsoft</label>
-              <p class="help-text">
-                Open
-                <a class="help-link" href=${this.deviceCode.verificationUri} @click=${handleExternalLink}>${this.deviceCode.verificationUri}</a>
-                (it should open automatically) and enter this code:
-              </p>
-              <div class="device-code" aria-label="Device code">${this.deviceCode.userCode}</div>
-              <div style="display:flex;align-items:center;gap:8px;padding-top:8px;color:var(--color-text-secondary)">
-                <div style="width:16px;height:16px;border:2px solid var(--color-border);border-top-color:var(--color-accent);border-radius:50%;animation:spin 0.8s linear infinite"></div>
-                Waiting for you to sign in...
-                <button class="btn" @click=${this.handleCancelEntraOAuth}>Cancel</button>
-              </div>
-            </div>
-          ` : this.oauthPending ? html`
+          <!-- Entra ID OAuth (interactive authorization-code + loopback flow) -->
+          ${this.oauthPending ? html`
             <div style="display:flex;align-items:center;gap:8px;padding:12px;color:var(--color-text-secondary)">
               <div style="width:16px;height:16px;border:2px solid var(--color-border);border-top-color:var(--color-accent);border-radius:50%;animation:spin 0.8s linear infinite"></div>
-              Connecting to Azure DevOps...
+              Complete sign-in in your browser...
               <button class="btn" @click=${this.handleCancelEntraOAuth}>Cancel</button>
             </div>
           ` : this.needsOrgSelection ? html`
@@ -1883,10 +1903,17 @@ export class LvAzureDevOpsDialog extends LitElement {
           ` : html`
             <div class="btn-row">
               <button
-                class="btn btn-primary"
+                class="ms-signin-btn"
                 @click=${this.handleStartEntraOAuth}
                 ?disabled=${this.isLoading || this.oauthPending}
+                aria-label="Sign in with Microsoft"
               >
+                <svg width="21" height="21" viewBox="0 0 21 21" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <rect x="1" y="1" width="9" height="9" fill="#f25022" />
+                  <rect x="1" y="11" width="9" height="9" fill="#00a4ef" />
+                  <rect x="11" y="1" width="9" height="9" fill="#7fba00" />
+                  <rect x="11" y="11" width="9" height="9" fill="#ffb900" />
+                </svg>
                 Sign in with Microsoft
               </button>
             </div>

--- a/src/services/__tests__/oauth.service.test.ts
+++ b/src/services/__tests__/oauth.service.test.ts
@@ -56,9 +56,6 @@ import {
   isPendingOAuth,
   getPendingProvider,
   exchangeCode,
-  startDeviceCode,
-  pollDeviceCode,
-  cancelDeviceCode,
 } from '../oauth.service.ts';
 import type { OAuthFlowState } from '../../types/oauth.types.ts';
 
@@ -233,105 +230,6 @@ describe('oauth.service - Provider Types', () => {
   it('should handle bitbucket provider type', () => {
     const provider = 'bitbucket' as const;
     expect(provider).to.equal('bitbucket');
-  });
-});
-
-describe('oauth.service - device-code flow (Azure DevOps)', () => {
-  const defaultMock = mockInvoke;
-  afterEach(() => {
-    mockInvoke = defaultMock;
-  });
-
-  it('startDeviceCode returns the flow details and sends provider/clientId', async () => {
-    let captured: Record<string, unknown> | undefined;
-    mockInvoke = (command, args) => {
-      if (command === 'oauth_start_device_code') {
-        captured = args as Record<string, unknown>;
-        return Promise.resolve({
-          flowId: 'flow-1',
-          userCode: 'ABCD-EFGH',
-          verificationUri: 'https://microsoft.com/devicelogin',
-          expiresIn: 900,
-          interval: 5,
-          message: 'Enter the code',
-        });
-      }
-      return Promise.resolve(null);
-    };
-
-    const res = await startDeviceCode('azure', 'client-abc');
-    expect(res.flowId).to.equal('flow-1');
-    expect(res.userCode).to.equal('ABCD-EFGH');
-    expect(res.verificationUri).to.equal('https://microsoft.com/devicelogin');
-    expect(captured!.provider).to.equal('azure');
-    expect(captured!.clientId).to.equal('client-abc');
-  });
-
-  it('startDeviceCode throws when the backend returns failure', async () => {
-    mockInvoke = (command) => {
-      if (command === 'oauth_start_device_code') return Promise.resolve(null); // null → failure
-      return Promise.resolve(null);
-    };
-    let threw = false;
-    try {
-      await startDeviceCode('azure', 'client-abc');
-    } catch {
-      threw = true;
-    }
-    expect(threw).to.be.true;
-  });
-
-  it('pollDeviceCode normalizes snake_case token fields to camelCase', async () => {
-    mockInvoke = (command, args) => {
-      if (command === 'oauth_poll_device_code') {
-        expect((args as Record<string, unknown>).flowId).to.equal('flow-1');
-        return Promise.resolve({ access_token: 'tok', refresh_token: 'ref', expires_in: 3600 });
-      }
-      return Promise.resolve(null);
-    };
-    const tokens = await pollDeviceCode('flow-1');
-    expect(tokens.accessToken).to.equal('tok');
-    expect(tokens.refreshToken).to.equal('ref');
-    expect(tokens.expiresIn).to.equal(3600);
-  });
-
-  it('pollDeviceCode accepts camelCase token fields', async () => {
-    mockInvoke = (command) => {
-      if (command === 'oauth_poll_device_code') {
-        return Promise.resolve({ accessToken: 'tok2', tokenType: 'bearer' });
-      }
-      return Promise.resolve(null);
-    };
-    const tokens = await pollDeviceCode('flow-1');
-    expect(tokens.accessToken).to.equal('tok2');
-    expect(tokens.tokenType).to.equal('bearer');
-  });
-
-  it('pollDeviceCode throws when the backend returns failure (cancelled/expired)', async () => {
-    mockInvoke = (command) => {
-      if (command === 'oauth_poll_device_code') return Promise.resolve(null);
-      return Promise.resolve(null);
-    };
-    let threw = false;
-    try {
-      await pollDeviceCode('flow-1');
-    } catch {
-      threw = true;
-    }
-    expect(threw).to.be.true;
-  });
-
-  it('cancelDeviceCode invokes the cancel command with the flow id', async () => {
-    let captured: Record<string, unknown> | undefined;
-    mockInvoke = (command, args) => {
-      if (command === 'oauth_cancel_device_code') {
-        captured = args as Record<string, unknown>;
-        return Promise.resolve(null);
-      }
-      return Promise.resolve(null);
-    };
-    await cancelDeviceCode('flow-9');
-    expect(captured!.flowId).to.equal('flow-9');
   });
 });
 

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -314,6 +314,17 @@ async function pollLoopbackCallback(provider: OAuthProvider, port: number): Prom
     // Server derives verifier/redirect/instance from the stored flow keyed by state.
     const tokens = await exchangeCode(provider, state, code);
 
+    // The user may have cancelled — or cancelled AND restarted — during the token
+    // exchange network round-trip (after the pre-exchange re-check above). If the
+    // pending flow for this provider is gone (cancelled) or has been replaced by a
+    // newer flow (different state), do NOT dispatch: otherwise this abandoned
+    // flow's tokens would surface as if they belonged to the current flow. Only
+    // delete our own entry (the still-current flow below); leave a newer one alone.
+    const afterExchange = pendingAuthByProvider.get(provider);
+    if (!afterExchange || afterExchange.state !== state) {
+      return;
+    }
+
     notifyStateChange({
       status: 'success',
       provider,

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -2,8 +2,7 @@
  * OAuth service for provider authentication
  *
  * Handles OAuth authentication flows for GitHub, GitLab, Azure DevOps, and Bitbucket.
- * - GitHub, GitLab, Bitbucket use a loopback server (127.0.0.1:port) for the callback.
- * - Azure DevOps uses the device-code flow (no redirect); see startDeviceCode/pollDeviceCode.
+ * All providers (including Azure DevOps) use a loopback server (127.0.0.1:port) for the callback.
  */
 
 import { onOpenUrl, getCurrent } from '@tauri-apps/plugin-deep-link';
@@ -27,9 +26,9 @@ import type {
 const OAUTH_CLIENT_IDS: Partial<Record<OAuthProvider, string>> = {
   github: 'Ov23liQxX14fxt3fRq4u',
   gitlab: '90d3d02fefb79e0303aaa54e8c6794bf806e9e8a1de7526bebc4f14288e12fec',
-  // Well-known Visual Studio public client ID: multi-tenant and pre-authorized for
-  // Azure DevOps, so Entra sign-in works out-of-the-box with no per-user app registration.
-  azure: '872cd9fa-d31f-45e0-9eab-6e460a02d1f1',
+  // Registered Leviathan multi-tenant Entra app (public client, loopback redirect
+  // http://localhost/callback, Azure DevOps user_impersonation).
+  azure: 'a1b13ec5-3f32-4ec7-b07f-5dfc5acbd2a8',
   bitbucket: 'Tv5UjEqLKK7GSYjAJn',
 };
 
@@ -389,73 +388,6 @@ export async function exchangeCode(
 }
 
 /**
- * Response from starting a device-code flow.
- */
-export interface StartDeviceCodeResponse {
-  flowId: string;
-  userCode: string;
-  verificationUri: string;
-  expiresIn: number;
-  interval: number;
-  message: string;
-}
-
-/**
- * Start an OAuth 2.0 device-code flow (used by Azure DevOps / Entra ID).
- *
- * Returns the user code + verification URL to display. The device_code secret
- * stays server-side, keyed by the returned `flowId`, which is passed to
- * {@link pollDeviceCode}. Needs no redirect URI, so it works with the embedded
- * public client whose registered redirects we don't control.
- */
-export async function startDeviceCode(
-  provider: OAuthProvider,
-  clientId: string,
-  instanceUrl?: string
-): Promise<StartDeviceCodeResponse> {
-  const result = await invokeCommand<StartDeviceCodeResponse>('oauth_start_device_code', {
-    provider,
-    clientId,
-    instanceUrl,
-  });
-  if (!result.success || !result.data) {
-    throw new Error(result.error?.message ?? 'Failed to start device sign-in');
-  }
-  return result.data;
-}
-
-/**
- * Poll a device-code flow until the user finishes signing in (or it is cancelled
- * or times out). The backend blocks on the provider's poll interval, so this
- * resolves once with the tokens.
- */
-export async function pollDeviceCode(flowId: string): Promise<OAuthTokenResponse> {
-  const result = await invokeCommand<OAuthTokenResponse>('oauth_poll_device_code', { flowId });
-  if (!result.success || !result.data) {
-    throw new Error(result.error?.message ?? 'Device sign-in failed');
-  }
-
-  // Normalize snake_case/camelCase like exchangeCode (serde serialization edge case).
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const raw = result.data as any;
-  return {
-    accessToken: raw.accessToken || raw.access_token,
-    refreshToken: raw.refreshToken || raw.refresh_token,
-    expiresIn: raw.expiresIn || raw.expires_in,
-    tokenType: raw.tokenType || raw.token_type,
-    scope: raw.scope,
-    idToken: raw.idToken || raw.id_token,
-  };
-}
-
-/**
- * Cancel an in-flight device-code flow so its server-side poll stops.
- */
-export async function cancelDeviceCode(flowId: string): Promise<void> {
-  await invokeCommand<void>('oauth_cancel_device_code', { flowId });
-}
-
-/**
  * Refresh an OAuth token
  */
 export async function refreshToken(
@@ -475,7 +407,7 @@ export async function refreshToken(
     throw new Error(result.error?.message ?? 'Failed to refresh OAuth token');
   }
 
-  // Normalize snake_case/camelCase like exchangeCode/pollDeviceCode (serde edge case),
+  // Normalize snake_case/camelCase like exchangeCode (serde edge case),
   // so callers reliably read accessToken/refreshToken/expiresIn.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const raw = result.data as any;


### PR DESCRIPTION
## Summary

The one-click "Sign in with Microsoft" for Azure DevOps shipped in v0.5.0 (#253) used the OAuth **device-code** flow. That flow is blocked by some tenants' **Conditional Access** policies (users see "You cannot access this right now" and can never complete sign-in).

This PR switches Azure DevOps sign-in to the **interactive authorization-code + loopback** flow already used by GitHub / GitLab / Bitbucket — an interactive browser sign-in satisfies the Conditional Access that device-code cannot — while keeping everything added since #253 (org detection/picker, on-demand token refresh, generation-guard/abandon safety, verified keyring sync). The button stays a single "Sign in with Microsoft".

Backed by a **registered multi-tenant Entra public client** (loopback redirect, Azure DevOps `user_impersonation`), so it still works out of the box with no per-user app registration.

## Changes

**Backend (Rust)**
- Re-add `OAuthConfig::azure(client_id, tenant_id, redirect_port)` (authorize/token at `login.microsoftonline.com/{tenant}`, tenant defaults to `organizations`, ADO `user_impersonation` + `offline_access`/`openid`/`profile`, `http://127.0.0.1:{port}/callback`).
- `oauth_get_authorize_url` gains an Azure loopback branch (mirrors GitLab).
- Remove the device-code implementation (`oauth_start_device_code` / `oauth_poll_device_code` / `oauth_cancel_device_code` and their helpers/tests) and unregister the commands.
- Redeem the code at the **same authority segment** the authorize URL was built with (`organizations`, via a new `azure_token_url` helper) — not `common`.

**OAuth service (TS)**
- Azure client id set to the registered Leviathan app; drop the device-code functions; keep refresh-token snake/camel normalization.
- `pollLoopbackCallback` re-checks the pending flow **after** the code exchange, so a flow cancelled (or cancelled and restarted) mid-exchange can't dispatch a stale `oauth-complete` under a newer flow's identity.

**Dialog**
- "Sign in with Microsoft" now starts the loopback flow (`startOAuth('azure', …)`) and finalizes on the global `oauth-complete` event, guarded by an `entraGeneration`/`entraFlowGeneration` counter so an abandoned flow (cancel / close / account switch / tab switch / manage-accounts) can never silently connect.
- Official Microsoft-branded button; phase-aware spinner ("Complete sign-in in your browser…" → "Connecting to Azure DevOps…").
- All device-code state/UI removed. Org picker, refresh-aware token, keyring sync, and the PAT tab are unchanged.

## Setup (maintainer)

Register the Entra app as a **multi-tenant public client** with redirect **`http://127.0.0.1/callback`** (Entra ignores the loopback port), enable "Allow public client flows", add Azure DevOps → `user_impersonation` (admin-consented). The Application (client) ID is embedded in `OAUTH_CLIENT_IDS.azure`.

## Testing

- **Rust:** `OAuthConfig::azure` (default/specific tenant, 127.0.0.1 redirect), Azure authorize-URL, `azure_token_url` default/specific tenant; `cargo fmt`, `clippy -D warnings`, and the oauth suite all green (87 passed).
- **TypeScript:** interactive start/complete, org picker, cancel/close/account-switch/tab-switch/manage-accounts abandonment (late `oauth-complete` blocked by the generation guard), error-on-start, PAT round-trip; full unit suite green (3528 passed).
- Reviewed with the repo's recursive multi-model review (Opus/Sonnet/Haiku); round-1 findings (loopback host, Entra authority mismatch, completion race, spinner copy) fixed.

Supersedes the device-code approach from #253 (already merged); this is a follow-up change on a fresh branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ)_