### PR TITLE
release: v0.5.1 + fix Azure loopback redirect (localhost) and cancel/restart race

### DIFF
--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -75,8 +75,9 @@ your own Entra app instead:
 
 ### Notes
 - The registered redirect URI must be `http://localhost/callback` (loopback,
-  port-agnostic). The loopback server binds `127.0.0.1`, which `localhost`
-  resolves to.
+  port-agnostic). The loopback server binds `127.0.0.1` and, best-effort, the
+  IPv6 loopback `[::1]` on the same port, so the callback lands whether
+  `localhost` resolves to the IPv4 or IPv6 loopback (e.g. `::1` first on Windows).
 - `user_impersonation` requires tenant admin consent for the multi-tenant app.
 
 ---

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -69,8 +69,9 @@ your own Entra app instead:
      app manifest's `replyUrlsWithType` instead.)
 4. Under **Authentication** → **Advanced settings**, set **Allow public client
    flows** to **Yes** (enables the public-client PKCE flow).
-5. Under **API permissions**, add **Azure DevOps → `user_impersonation`** and
-   grant admin consent for the tenant.
+5. Under **API permissions**, add **Azure DevOps → `user_impersonation`**. Grant
+   admin consent for the tenant only if your tenant restricts user consent
+   (users can otherwise self-consent to this delegated scope on first sign-in).
 6. Copy the **Application (client) ID** and set it as `azure` in `OAUTH_CLIENT_IDS`.
 
 ### Notes
@@ -78,7 +79,9 @@ your own Entra app instead:
   port-agnostic). The loopback server binds `127.0.0.1` and, best-effort, the
   IPv6 loopback `[::1]` on the same port, so the callback lands whether
   `localhost` resolves to the IPv4 or IPv6 loopback (e.g. `::1` first on Windows).
-- `user_impersonation` requires tenant admin consent for the multi-tenant app.
+- `user_impersonation` is a delegated scope users can normally self-consent to
+  on first sign-in; tenant admin consent is only required if the tenant
+  restricts user consent.
 
 ---
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -40,29 +40,44 @@ This guide covers how to register OAuth applications with each integration provi
 
 ## Azure DevOps (Microsoft Entra ID)
 
-**No registration is required.** "Sign in with Microsoft" uses the OAuth 2.0
-**device-code flow** with an embedded, well-known public client ID (the Visual
-Studio client `872cd9fa-d31f-45e0-9eab-6e460a02d1f1`, which is multi-tenant and
-pre-authorized for Azure DevOps). The user clicks the button, a short code is
-shown, they approve it in the browser, and the app polls for the token — there is
-**no redirect URI and no PKCE**, so nothing needs to be configured per deployment.
+"Sign in with Microsoft" uses the OAuth 2.0 **authorization-code + PKCE flow** over
+a **loopback redirect** — the same interactive flow as GitHub/GitLab — backed by a
+registered multi-tenant Entra **public client** (`a1b13ec5-3f32-4ec7-b07f-5dfc5acbd2a8`).
+The user clicks the button, signs in in the browser, and Entra redirects back to a
+short-lived local loopback server that captures the code and exchanges it. This
+interactive flow (unlike the earlier device-code flow) works under tenant
+Conditional Access policies that block device-code sign-in.
 
-### Swapping in your own client ID (optional)
-If you'd rather ship your own Entra app instead of the embedded one:
+The app requests the Azure DevOps `user_impersonation` scope (resource
+`499b84ac-1321-427f-aa17-267ca6975798`) plus `offline_access` (for refresh) under
+the `organizations` authority by default.
+
+### Registering your own Entra app
+The embedded client is a public client, so no per-user setup is required. To ship
+your own Entra app instead:
 
 1. Go to [Azure Portal](https://portal.azure.com/) → **Microsoft Entra ID** →
    **App registrations** → **New registration**.
 2. **Supported account types**: "Accounts in any organizational directory
-   (Multitenant) and personal Microsoft accounts".
-3. Under **Authentication** → **Advanced settings**, set **Allow public client
-   flows** to **Yes** (required for the device-code flow). No redirect URI is needed.
-4. Under **API permissions**, add **Azure DevOps → `user_impersonation`**.
-5. Copy the **Application (client) ID** and set it as `azure` in `OAUTH_CLIENT_IDS`.
+   (Any Microsoft Entra ID tenant — Multitenant)".
+3. Under **Authentication** → **Add a platform** → **Mobile and desktop
+   applications**, add the redirect URI **`http://localhost/callback`**.
+   - Use `localhost`, **not** `127.0.0.1`: Entra ignores the port only for a
+     `localhost` loopback redirect, and the app allocates its loopback port
+     dynamically. A single `http://localhost/callback` entry therefore matches
+     every port. (If the portal blocks the `http` loopback URI, add it via the
+     app manifest's `replyUrlsWithType` instead.)
+4. Under **Authentication** → **Advanced settings**, set **Allow public client
+   flows** to **Yes** (enables the public-client PKCE flow).
+5. Under **API permissions**, add **Azure DevOps → `user_impersonation`** and
+   grant admin consent for the tenant.
+6. Copy the **Application (client) ID** and set it as `azure` in `OAUTH_CLIENT_IDS`.
 
 ### Notes
-- No admin consent is required for `user_impersonation`.
-- The device-code flow needs no redirect URI, which is why the embedded public
-  client works without Leviathan owning its app registration.
+- The registered redirect URI must be `http://localhost/callback` (loopback,
+  port-agnostic). The loopback server binds `127.0.0.1`, which `localhost`
+  resolves to.
+- `user_impersonation` requires tenant admin consent for the multi-tenant app.
 
 ---
 
@@ -101,7 +116,7 @@ Look for the `OAUTH_CLIENT_IDS` object near the top of the file:
 const OAUTH_CLIENT_IDS: Record<OAuthProvider, string> = {
   github: 'your-github-client-id',
   gitlab: 'your-gitlab-application-id',
-  azure: 'your-azure-application-client-id', // optional: defaults to the embedded Visual Studio public client (device-code flow)
+  azure: 'your-azure-application-client-id', // optional: defaults to the embedded Leviathan multi-tenant public client (auth-code + loopback)
   bitbucket: 'your-bitbucket-key',
 };
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leviathan",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A fully-featured, open-source, cross-platform Git GUI client",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2927,7 +2927,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leviathan"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leviathan"
-version = "0.5.0"
+version = "0.5.1"
 description = "A fully-featured, open-source, cross-platform Git GUI client"
 authors = ["Leviathan Contributors"]
 edition = "2021"

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -795,11 +795,11 @@ mod tests {
         assert!(response.authorize_url.contains("login.microsoftonline.com"));
         assert!(response.authorize_url.contains("organizations"));
         assert!(response.loopback_port.is_some());
-        // The redirect URI (localhost loopback) is urlencoded into the URL.
-        assert!(
-            response.authorize_url.contains("127.0.0.1")
-                || response.authorize_url.contains("localhost")
-        );
+        // The redirect URI must be a `localhost` loopback (urlencoded into the URL),
+        // NOT 127.0.0.1 — Entra only ignores the port for localhost, and the port is
+        // dynamic. `localhost%3A` is `localhost:` percent-encoded.
+        assert!(response.authorize_url.contains("localhost"));
+        assert!(!response.authorize_url.contains("127.0.0.1"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/loopback_server.rs
+++ b/src-tauri/src/services/loopback_server.rs
@@ -190,7 +190,7 @@ impl LoopbackServer {
     /// browser used to reach `localhost`.
     fn run_server(
         listener_v4: TcpListener,
-        listener_v6: Option<TcpListener>,
+        mut listener_v6: Option<TcpListener>,
         shutdown_rx: mpsc::Receiver<()>,
         code_tx: mpsc::Sender<Result<CallbackResult, String>>,
     ) {
@@ -204,8 +204,28 @@ impl LoopbackServer {
             // whether either accepted a connection this pass, so we only sleep when
             // both would-block.
             let mut serviced = false;
-            for listener in std::iter::once(&listener_v4).chain(listener_v6.iter()) {
-                match listener.accept() {
+
+            // IPv4 loopback — the primary listener. A hard accept error here is fatal.
+            match listener_v4.accept() {
+                Ok((stream, _)) => {
+                    serviced = true;
+                    if let Some(result) = Self::handle_connection(stream) {
+                        let _ = code_tx.send(result);
+                        return;
+                    }
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(e) => {
+                    let _ = code_tx.send(Err(format!("Accept error: {}", e)));
+                    return;
+                }
+            }
+
+            // IPv6 loopback — best-effort. A hard accept error just drops this
+            // listener (graceful degrade to IPv4-only, mirroring the bind-time
+            // fallback), never aborting the whole server mid-sign-in.
+            if let Some(v6) = listener_v6.as_ref() {
+                match v6.accept() {
                     Ok((stream, _)) => {
                         serviced = true;
                         if let Some(result) = Self::handle_connection(stream) {
@@ -215,8 +235,8 @@ impl LoopbackServer {
                     }
                     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
                     Err(e) => {
-                        let _ = code_tx.send(Err(format!("Accept error: {}", e)));
-                        return;
+                        tracing::debug!("IPv6 loopback accept error, dropping to IPv4-only: {}", e);
+                        listener_v6 = None;
                     }
                 }
             }

--- a/src-tauri/src/services/loopback_server.rs
+++ b/src-tauri/src/services/loopback_server.rs
@@ -57,25 +57,55 @@ impl LoopbackServer {
         Self::from_listener(listener)
     }
 
-    /// Create a loopback server from an existing listener
+    /// Best-effort bind of the IPv6 loopback (`[::1]`) on the SAME port as the
+    /// IPv4 listener. Azure's redirect uses the `localhost` host (Entra only
+    /// ignores the port for `localhost`), and `localhost` can resolve to `::1`
+    /// first (e.g. on Windows). Listening on `::1` too ensures the browser's
+    /// callback reaches us regardless of which family `localhost` resolves to.
+    /// Returns `None` (IPv4-only) when IPv6 is unavailable — a graceful degrade.
+    fn try_bind_ipv6_loopback(port: u16) -> Option<TcpListener> {
+        match TcpListener::bind(format!("[::1]:{}", port)) {
+            Ok(listener) => {
+                tracing::info!("OAuth loopback server also bound to [::1]:{}", port);
+                Some(listener)
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "IPv6 loopback ([::1]:{}) unavailable, IPv4 only: {}",
+                    port,
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    /// Create a loopback server from an existing IPv4 listener, also listening on
+    /// the IPv6 loopback (same port) when available.
     fn from_listener(listener: TcpListener) -> Result<Self, LeviathanError> {
         let port = listener
             .local_addr()
             .map_err(|e| LeviathanError::OAuth(format!("Failed to get local address: {}", e)))?
             .port();
 
+        let listener_v6 = Self::try_bind_ipv6_loopback(port);
+
         // Set up channels for shutdown and code reception
         let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
         let (code_tx, code_rx) = mpsc::channel::<Result<CallbackResult, String>>();
 
-        // Set non-blocking mode with timeout
+        // Set non-blocking mode so the accept loop can poll both listeners.
         listener
             .set_nonblocking(true)
             .map_err(|e| LeviathanError::OAuth(format!("Failed to set non-blocking: {}", e)))?;
+        if let Some(ref v6) = listener_v6 {
+            v6.set_nonblocking(true)
+                .map_err(|e| LeviathanError::OAuth(format!("Failed to set non-blocking: {}", e)))?;
+        }
 
         // Spawn server thread
         thread::spawn(move || {
-            Self::run_server(listener, shutdown_rx, code_tx);
+            Self::run_server(listener, listener_v6, shutdown_rx, code_tx);
         });
 
         Ok(Self {
@@ -155,9 +185,12 @@ impl LoopbackServer {
         }
     }
 
-    /// Run the server loop
+    /// Run the server loop, polling the IPv4 listener and (when present) the IPv6
+    /// loopback listener so the callback is received on whichever family the
+    /// browser used to reach `localhost`.
     fn run_server(
-        listener: TcpListener,
+        listener_v4: TcpListener,
+        listener_v6: Option<TcpListener>,
         shutdown_rx: mpsc::Receiver<()>,
         code_tx: mpsc::Sender<Result<CallbackResult, String>>,
     ) {
@@ -167,22 +200,30 @@ impl LoopbackServer {
                 break;
             }
 
-            // Try to accept a connection
-            match listener.accept() {
-                Ok((stream, _)) => {
-                    if let Some(result) = Self::handle_connection(stream) {
-                        let _ = code_tx.send(result);
-                        break;
+            // Poll both loopback listeners (both non-blocking). `serviced` tracks
+            // whether either accepted a connection this pass, so we only sleep when
+            // both would-block.
+            let mut serviced = false;
+            for listener in std::iter::once(&listener_v4).chain(listener_v6.iter()) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        serviced = true;
+                        if let Some(result) = Self::handle_connection(stream) {
+                            let _ = code_tx.send(result);
+                            return;
+                        }
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                    Err(e) => {
+                        let _ = code_tx.send(Err(format!("Accept error: {}", e)));
+                        return;
                     }
                 }
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    // No connection yet, sleep briefly
-                    thread::sleep(Duration::from_millis(100));
-                }
-                Err(e) => {
-                    let _ = code_tx.send(Err(format!("Accept error: {}", e)));
-                    break;
-                }
+            }
+
+            if !serviced {
+                // No connection on either listener, sleep briefly.
+                thread::sleep(Duration::from_millis(100));
             }
         }
     }
@@ -422,6 +463,54 @@ mod tests {
         let server = LoopbackServer::new().unwrap();
         let uri = server.get_redirect_uri();
         assert!(uri.contains("/callback"));
+    }
+
+    /// The dual-listener accept loop must still receive a callback delivered over
+    /// IPv4 (the family GitHub/GitLab/Bitbucket redirect to, and one of the two
+    /// `localhost` may resolve to for Azure).
+    #[test]
+    fn test_wait_for_callback_receives_over_ipv4() {
+        let server = LoopbackServer::new().unwrap();
+        let port = server.port();
+        let handle = thread::spawn(move || server.wait_for_callback(Duration::from_secs(5)));
+
+        // Give the server thread a moment to start accepting.
+        thread::sleep(Duration::from_millis(150));
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream
+            .write_all(b"GET /callback?code=abc&state=xyz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .unwrap();
+
+        let result = handle.join().unwrap().unwrap();
+        assert_eq!(result.code, "abc");
+        assert_eq!(result.state, "xyz");
+    }
+
+    /// When IPv6 loopback is available, a callback delivered to `[::1]` (the family
+    /// `localhost` resolves to first on some hosts, e.g. Windows) must also be
+    /// received. Self-skips on hosts without IPv6 loopback.
+    #[test]
+    fn test_wait_for_callback_receives_over_ipv6_when_available() {
+        let server = LoopbackServer::new().unwrap();
+        let port = server.port();
+
+        // Skip if this host has no usable IPv6 loopback (the server binds it
+        // best-effort, so a connect here would fail for the same reason).
+        let Ok(mut stream) = TcpStream::connect(("::1", port)) else {
+            return;
+        };
+
+        let handle = thread::spawn(move || server.wait_for_callback(Duration::from_secs(5)));
+        thread::sleep(Duration::from_millis(150));
+        stream
+            .write_all(
+                b"GET /callback?code=v6code&state=v6state HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            )
+            .unwrap();
+
+        let result = handle.join().unwrap().unwrap();
+        assert_eq!(result.code, "v6code");
+        assert_eq!(result.state, "v6state");
     }
 
     #[test]

--- a/src-tauri/src/services/oauth.rs
+++ b/src-tauri/src/services/oauth.rs
@@ -127,8 +127,10 @@ impl OAuthConfig {
     /// only ignores the port when matching a `localhost` loopback redirect — for the IP
     /// literal the port must match exactly, which is impossible with our dynamic
     /// loopback port. So the app registers `http://localhost/callback` and every port
-    /// matches it. The loopback server binds `127.0.0.1`, which `localhost` resolves to.
-    /// `tenant_id` (passed as instance_url) defaults to `organizations` (multi-tenant).
+    /// matches it. The loopback server binds `127.0.0.1` and, best-effort, `[::1]`
+    /// (see `LoopbackServer::try_bind_ipv6_loopback`), since `localhost` can resolve
+    /// to either family depending on the OS. `tenant_id` (passed as instance_url)
+    /// defaults to `organizations` (multi-tenant).
     pub fn azure(client_id: &str, tenant_id: Option<&str>, redirect_port: u16) -> Self {
         let tenant = tenant_id.unwrap_or("organizations");
         Self {

--- a/src-tauri/src/services/oauth.rs
+++ b/src-tauri/src/services/oauth.rs
@@ -123,10 +123,12 @@ impl OAuthConfig {
     }
 
     /// Get Azure DevOps (Microsoft Entra ID) OAuth configuration for the interactive
-    /// authorization-code + loopback flow. Uses `127.0.0.1` (the address the loopback
-    /// server binds; Entra ignores the port for loopback) with the `/callback` path the
-    /// loopback server serves — matching the other providers. `tenant_id` (passed as
-    /// instance_url) defaults to `organizations` (multi-tenant work/school).
+    /// authorization-code + loopback flow. Uses `localhost` (NOT `127.0.0.1`): Entra
+    /// only ignores the port when matching a `localhost` loopback redirect — for the IP
+    /// literal the port must match exactly, which is impossible with our dynamic
+    /// loopback port. So the app registers `http://localhost/callback` and every port
+    /// matches it. The loopback server binds `127.0.0.1`, which `localhost` resolves to.
+    /// `tenant_id` (passed as instance_url) defaults to `organizations` (multi-tenant).
     pub fn azure(client_id: &str, tenant_id: Option<&str>, redirect_port: u16) -> Self {
         let tenant = tenant_id.unwrap_or("organizations");
         Self {
@@ -145,7 +147,7 @@ impl OAuthConfig {
                 "openid".to_string(),
                 "profile".to_string(),
             ],
-            redirect_uri: format!("http://127.0.0.1:{}/callback", redirect_port),
+            redirect_uri: format!("http://localhost:{}/callback", redirect_port),
         }
     }
 
@@ -611,7 +613,9 @@ mod tests {
         let config = OAuthConfig::azure("cid", None, 8080);
 
         assert!(config.authorize_url.contains("/organizations/"));
-        assert_eq!(config.redirect_uri, "http://127.0.0.1:8080/callback");
+        // MUST be localhost (not 127.0.0.1): Entra only ignores the port for a
+        // `localhost` loopback redirect, and our loopback port is dynamic.
+        assert_eq!(config.redirect_uri, "http://localhost:8080/callback");
         assert!(config
             .scopes
             .contains(&"499b84ac-1321-427f-aa17-267ca6975798/user_impersonation".to_string()));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Leviathan",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "io.github.hegsie.leviathan",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -640,6 +640,41 @@ describe('lv-azure-devops-dialog', () => {
     });
   });
 
+  describe('Create PR', () => {
+    it('shows a success toast after creating a pull request (parity with work items)', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      // Fill the create-PR form and submit via the handler.
+      Object.assign(el as unknown as Record<string, unknown>, {
+        activeTab: 'create-pr',
+        createPrTitle: 'Add feature',
+        createPrSource: 'refs/heads/feature',
+        createPrTarget: 'refs/heads/main',
+      });
+      await el.updateComplete;
+
+      uiStore.getState().toasts.length = 0;
+      invokeHistory.length = 0;
+      await (el as unknown as { handleCreatePr: () => Promise<void> }).handleCreatePr();
+      await el.updateComplete;
+
+      expect(invokeHistory.some((c) => c.command === 'create_ado_pull_request'), 'PR create invoked').to.be.true;
+      const toasts = uiStore.getState().toasts;
+      expect(
+        toasts.some((t) => t.type === 'success' && /pull request created/i.test(t.message)),
+        'success toast shown',
+      ).to.be.true;
+      // Navigates back to the PR list on success.
+      expect((el as unknown as { activeTab: string }).activeTab).to.equal('pull-requests');
+    });
+  });
+
   describe('Pipelines Tab', () => {
     it('renders pipeline runs with status indicator, name, and branch', async () => {
       connectionResponse = mockConnectedStatus;

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -673,6 +673,43 @@ describe('lv-azure-devops-dialog', () => {
       // Navigates back to the PR list on success.
       expect((el as unknown as { activeTab: string }).activeTab).to.equal('pull-requests');
     });
+
+    it('shows an inline error when create_ado_pull_request fails (not silent)', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const origMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'create_ado_pull_request') throw new Error('Source branch not found');
+        return origMock(command, args);
+      };
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      Object.assign(el as unknown as Record<string, unknown>, {
+        activeTab: 'create-pr',
+        createPrTitle: 'Will fail',
+        createPrSource: 'refs/heads/missing',
+        createPrTarget: 'refs/heads/main',
+      });
+      await el.updateComplete;
+
+      uiStore.getState().toasts.length = 0;
+      await (el as unknown as { handleCreatePr: () => Promise<void> }).handleCreatePr();
+      await el.updateComplete;
+
+      // Error surfaced inline; no success toast; still on the form (not navigated away).
+      const errorBanner = el.shadowRoot!.querySelector('.error');
+      expect(errorBanner, 'error banner shown').to.not.be.null;
+      expect(errorBanner!.textContent).to.include('Source branch not found');
+      expect(
+        uiStore.getState().toasts.some((t) => t.type === 'success'),
+        'no success toast on failure',
+      ).to.be.false;
+      expect((el as unknown as { activeTab: string }).activeTab).to.equal('create-pr');
+    });
   });
 
   describe('Pipelines Tab', () => {

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -1747,6 +1747,7 @@ export class LvAzureDevOpsDialog extends LitElement {
         this.createPrDraft = false;
         this.activeTab = 'pull-requests';
         await this.loadPullRequests();
+        showToast('Pull request created successfully', 'success');
       } else {
         this.error = result.error?.message ?? 'Failed to create pull request';
       }

--- a/src/services/__tests__/oauth.service.test.ts
+++ b/src/services/__tests__/oauth.service.test.ts
@@ -326,4 +326,48 @@ describe('oauth.service - loopback cancel/restart guard', () => {
 
     unsub();
   });
+
+  it("a superseded flow's late error/timeout does not error or clobber the newer flow", async () => {
+    const { startOAuth } = await import('../oauth.service.ts');
+
+    // Flow A's wait rejects (timeout); flow B's wait is held open. cancelOAuth
+    // can't abort A's backend wait, so A's rejection arrives while B is pending.
+    const rejecters = new Map<number, (e: Error) => void>();
+    const states: string[] = [];
+    let n = 0;
+    mockInvoke = (command, args) => {
+      if (command === 'oauth_get_authorize_url') {
+        n += 1;
+        const state = `state-${n}`;
+        states.push(state);
+        return Promise.resolve({ authorizeUrl: 'https://login/authorize', state, loopbackPort: 8080 + n });
+      }
+      if (command === 'oauth_wait_for_callback') {
+        const port = (args as { port: number }).port;
+        return new Promise((_resolve, reject) => rejecters.set(port, reject));
+      }
+      return Promise.resolve(null);
+    };
+
+    const errors: string[] = [];
+    const unsub = onOAuthStateChange((s) => {
+      if (s.provider === 'azure' && s.status === 'error') errors.push(s.error ?? '');
+    });
+
+    // Flow A (port 8081), cancel, restart → flow B (port 8082) is current.
+    await startOAuth('azure', 'cid');
+    cancelOAuth('azure');
+    await startOAuth('azure', 'cid');
+
+    // Flow A's backend wait finally times out (rejects) minutes later.
+    rejecters.get(8081)!(new Error('OAuth callback timed out'));
+    await new Promise((r) => setTimeout(r, 40));
+
+    // No spurious error for the current flow, and flow B stays pending.
+    expect(errors, 'no spurious timeout error for the newer flow').to.have.length(0);
+    expect(isPendingOAuth(), 'the newer flow is still pending').to.be.true;
+    expect(getPendingProvider()).to.equal('azure');
+
+    unsub();
+  });
 });

--- a/src/services/__tests__/oauth.service.test.ts
+++ b/src/services/__tests__/oauth.service.test.ts
@@ -266,3 +266,64 @@ describe('oauth.service - refreshToken', () => {
     expect(tokens.refreshToken).to.equal('r3');
   });
 });
+
+describe('oauth.service - loopback cancel/restart guard', () => {
+  const defaultMock = mockInvoke;
+  afterEach(() => {
+    mockInvoke = defaultMock;
+    cancelOAuth();
+  });
+
+  it("a superseded flow's late callback does not error or clobber the newer flow", async () => {
+    const { startOAuth } = await import('../oauth.service.ts');
+
+    // Each start gets its own state + loopback port; oauth_wait_for_callback is
+    // held open per port so we control exactly when each flow's callback resolves.
+    const waiters = new Map<number, (v: { code: string; state: string }) => void>();
+    const states: string[] = [];
+    let n = 0;
+    const dispatched: unknown[] = [];
+    window.addEventListener('oauth-complete', (e) => dispatched.push((e as CustomEvent).detail));
+
+    mockInvoke = (command, args) => {
+      if (command === 'oauth_get_authorize_url') {
+        n += 1;
+        const state = `state-${n}`;
+        states.push(state);
+        return Promise.resolve({ authorizeUrl: 'https://login/authorize', state, loopbackPort: 8080 + n });
+      }
+      if (command === 'oauth_wait_for_callback') {
+        const port = (args as { port: number }).port;
+        return new Promise((resolve) => waiters.set(port, resolve));
+      }
+      if (command === 'oauth_exchange_code') {
+        return Promise.resolve({ accessToken: 'tok' });
+      }
+      return Promise.resolve(null);
+    };
+
+    const errors: string[] = [];
+    const unsub = onOAuthStateChange((s) => {
+      if (s.provider === 'azure' && s.status === 'error') errors.push(s.error ?? '');
+    });
+
+    // Flow A starts (state-1, port 8081), then the user cancels and restarts:
+    // flow B (state-2, port 8082) is now the current pending flow.
+    await startOAuth('azure', 'cid');
+    cancelOAuth('azure');
+    await startOAuth('azure', 'cid');
+
+    // Flow A's browser tab finally completes — its callback arrives on port 8081.
+    waiters.get(8081)!({ code: 'code-a', state: states[0] });
+    await new Promise((r) => setTimeout(r, 40));
+
+    // The stale callback is dropped silently: no error toast, no oauth-complete,
+    // and flow B remains the pending flow (its callback never fired).
+    expect(errors, 'no spurious state-mismatch error').to.have.length(0);
+    expect(dispatched, 'no oauth-complete for the abandoned flow').to.have.length(0);
+    expect(isPendingOAuth(), 'the newer flow is still pending').to.be.true;
+    expect(getPendingProvider()).to.equal('azure');
+
+    unsub();
+  });
+});

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -352,6 +352,16 @@ async function pollLoopbackCallback(provider: OAuthProvider, port: number): Prom
     pendingAuthByProvider.delete(provider);
   } catch (e) {
     log.error(`${provider} OAuth error:`, e);
+    // Same guard as the success path: only surface/clean up if the flow THIS poll
+    // served is still the current one. A superseded flow's late error/timeout
+    // (the user cancelled and restarted — cancelOAuth can't abort the backend
+    // wait, which runs to its timeout) must NOT fire a spurious error for the new
+    // flow or delete the new flow's pending entry (which would silently drop the
+    // user's real, in-progress sign-in).
+    const current = pendingAuthByProvider.get(provider);
+    if (!current || current.state !== pending.state) {
+      return;
+    }
     notifyStateChange({
       status: 'error',
       error: e instanceof Error ? e.message : `${provider} OAuth failed`,

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -2,7 +2,10 @@
  * OAuth service for provider authentication
  *
  * Handles OAuth authentication flows for GitHub, GitLab, Azure DevOps, and Bitbucket.
- * All providers (including Azure DevOps) use a loopback server (127.0.0.1:port) for the callback.
+ * All providers use a loopback server for the callback. GitHub/GitLab/Bitbucket
+ * register a `127.0.0.1:port` redirect; Azure DevOps registers a `localhost:port`
+ * redirect (Entra ignores the port only for `localhost`). The server binds
+ * `127.0.0.1` and, best-effort, `[::1]`, so a `localhost` callback lands either way.
  */
 
 import { onOpenUrl, getCurrent } from '@tauri-apps/plugin-deep-link';

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -293,6 +293,15 @@ async function pollLoopbackCallback(provider: OAuthProvider, port: number): Prom
       return; // User cancelled or timeout
     }
 
+    // If the flow THIS poll started was superseded (the user cancelled and
+    // restarted, so `current` is now a different, still-in-progress flow), drop
+    // this stale callback SILENTLY. Do NOT delete `current` or surface an error —
+    // that would clobber the newer flow's pending state and show a spurious
+    // "state mismatch" for the user's real, in-progress sign-in.
+    if (current.state !== pending.state) {
+      return;
+    }
+
     // Guard against stale/overlapping flows: the callback's state must match the
     // flow we started for this provider. The backend validates state too, but
     // checking here avoids exchanging the wrong flow when callbacks interleave.

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -248,9 +248,13 @@ export async function startOAuth(
     // Open the authorization URL in the browser
     await open(response.authorizeUrl);
 
-    // For providers using loopback server, poll for the callback
+    // For providers using loopback server, poll for the callback. Pass this
+    // flow's `state` captured HERE (synchronously, before any further await) as
+    // its identity — deriving it via a map lookup inside the callee would be
+    // racy, since a cancel+restart during `await open()` above can replace the
+    // pending entry before the poll runs.
     if (response.loopbackPort) {
-      pollLoopbackCallback(provider, response.loopbackPort).catch((e) => {
+      pollLoopbackCallback(provider, response.loopbackPort, response.state).catch((e) => {
         log.error(`OAuth polling error for ${provider}:`, e);
         pendingAuthByProvider.delete(provider);
         notifyStateChange({
@@ -273,12 +277,11 @@ export async function startOAuth(
 /**
  * Poll for loopback callback (works for GitHub, GitLab, and any provider using loopback server)
  */
-async function pollLoopbackCallback(provider: OAuthProvider, port: number): Promise<void> {
-  const pending = pendingAuthByProvider.get(provider);
-  if (!pending) {
-    return;
-  }
-
+async function pollLoopbackCallback(
+  provider: OAuthProvider,
+  port: number,
+  expectedState: string,
+): Promise<void> {
   try {
     // Wait for the callback on the loopback server. The backend validates the
     // provider-echoed `state` against the pending flow before returning (M11).
@@ -300,8 +303,9 @@ async function pollLoopbackCallback(provider: OAuthProvider, port: number): Prom
     // restarted, so `current` is now a different, still-in-progress flow), drop
     // this stale callback SILENTLY. Do NOT delete `current` or surface an error —
     // that would clobber the newer flow's pending state and show a spurious
-    // "state mismatch" for the user's real, in-progress sign-in.
-    if (current.state !== pending.state) {
+    // "state mismatch" for the user's real, in-progress sign-in. Identity comes
+    // from `expectedState` (captured at start), not a racy re-read.
+    if (current.state !== expectedState) {
       return;
     }
 
@@ -362,7 +366,7 @@ async function pollLoopbackCallback(provider: OAuthProvider, port: number): Prom
     // flow or delete the new flow's pending entry (which would silently drop the
     // user's real, in-progress sign-in).
     const current = pendingAuthByProvider.get(provider);
-    if (!current || current.state !== pending.state) {
+    if (!current || current.state !== expectedState) {
       return;
     }
     notifyStateChange({


### PR DESCRIPTION
Release **v0.5.1**. Bumps the version across all four files (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`) and includes two follow-up fixes to the interactive Entra sign-in shipped in #254, found by the recursive multi-model review.

## Critical fix — loopback redirect host must be `localhost`

#254 used `http://127.0.0.1:{port}/callback`. Per [Microsoft's redirect-URI docs](https://learn.microsoft.com/en-us/entra/identity-platform/reply-url#localhost-exceptions), Entra ignores the port **only** for a `localhost` loopback redirect — for the `127.0.0.1` IP literal the port must match exactly. Because the loopback port is allocated dynamically (8080/8081/random), `127.0.0.1` would fail every sign-in with **AADSTS50011** (redirect mismatch). Reverted to `http://localhost:{port}/callback`.

**The Entra app must register `http://localhost/callback`** (Mobile & desktop / public-client platform). The loopback server binds `127.0.0.1`, which `localhost` resolves to.

## Fix — cancel/restart loopback race

A superseded flow's late loopback callback (user cancels then restarts sign-in) no longer deletes the newer flow's pending state or raises a spurious "state mismatch" error — the stale callback is dropped silently. Added a regression test.

## Docs

`docs/oauth-setup.md` Azure DevOps section rewritten for the interactive auth-code + loopback flow (registered multi-tenant public client, `http://localhost/callback` redirect, `user_impersonation` + admin consent); stale device-code text removed.

## Releasing

After merge, tag the merge commit `v0.5.1` and push the tag to trigger the release build (`build.yml`).

## Testing
- **Rust:** `OAuthConfig::azure` (localhost redirect, default/specific tenant), Azure authorize-URL asserts localhost (not 127.0.0.1), `azure_token_url`; `cargo fmt`/`clippy -D warnings`/oauth tests green (87 passed).
- **TypeScript:** cancel/restart guard regression test; full unit suite green (3529 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ