### PR TITLE
fix(azure-devops): use Visual Studio first-party client (no admin consent, no app registration)

### DIFF
--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -40,48 +40,37 @@ This guide covers how to register OAuth applications with each integration provi
 
 ## Azure DevOps (Microsoft Entra ID)
 
-"Sign in with Microsoft" uses the OAuth 2.0 **authorization-code + PKCE flow** over
-a **loopback redirect** — the same interactive flow as GitHub/GitLab — backed by a
-registered multi-tenant Entra **public client** (`a1b13ec5-3f32-4ec7-b07f-5dfc5acbd2a8`).
-The user clicks the button, signs in in the browser, and Entra redirects back to a
-short-lived local loopback server that captures the code and exchanges it. This
-interactive flow (unlike the earlier device-code flow) works under tenant
-Conditional Access policies that block device-code sign-in.
+**No registration is required.** "Sign in with Microsoft" uses the OAuth 2.0
+**authorization-code + PKCE flow** over a **loopback redirect** — the same
+interactive flow as GitHub/GitLab — with Microsoft's **Visual Studio first-party
+public client** (`872cd9fa-d31f-45e0-9eab-6e460a02d1f1`). The user clicks the
+button, signs in in the browser, and Entra redirects back to a short-lived local
+loopback server that captures the code and exchanges it.
+
+This is the same client Microsoft's own **Git Credential Manager** embeds for
+Azure DevOps. Because the Azure DevOps resource **pre-authorizes** it, sign-in
+raises **no consent prompt** — no per-tenant **admin consent** and no app
+registration — while the interactive browser flow (unlike device-code) still
+satisfies tenant **Conditional Access** policies.
 
 The app requests the Azure DevOps `user_impersonation` scope (resource
 `499b84ac-1321-427f-aa17-267ca6975798`) plus `offline_access` (for refresh) under
-the `organizations` authority by default.
-
-### Registering your own Entra app
-The embedded client is a public client, so no per-user setup is required. To ship
-your own Entra app instead:
-
-1. Go to [Azure Portal](https://portal.azure.com/) → **Microsoft Entra ID** →
-   **App registrations** → **New registration**.
-2. **Supported account types**: "Accounts in any organizational directory
-   (Any Microsoft Entra ID tenant — Multitenant)".
-3. Under **Authentication** → **Add a platform** → **Mobile and desktop
-   applications**, add the redirect URI **`http://localhost/callback`**.
-   - Use `localhost`, **not** `127.0.0.1`: Entra ignores the port only for a
-     `localhost` loopback redirect, and the app allocates its loopback port
-     dynamically. A single `http://localhost/callback` entry therefore matches
-     every port. (If the portal blocks the `http` loopback URI, add it via the
-     app manifest's `replyUrlsWithType` instead.)
-4. Under **Authentication** → **Advanced settings**, set **Allow public client
-   flows** to **Yes** (enables the public-client PKCE flow).
-5. Under **API permissions**, add **Azure DevOps → `user_impersonation`**. Grant
-   admin consent for the tenant only if your tenant restricts user consent
-   (users can otherwise self-consent to this delegated scope on first sign-in).
-6. Copy the **Application (client) ID** and set it as `azure` in `OAUTH_CLIENT_IDS`.
+the `organizations` authority. **Work or school accounts only** — this client
+rejects personal Microsoft accounts (the `/consumers` authority).
 
 ### Notes
-- The registered redirect URI must be `http://localhost/callback` (loopback,
-  port-agnostic). The loopback server binds `127.0.0.1` and, best-effort, the
-  IPv6 loopback `[::1]` on the same port, so the callback lands whether
-  `localhost` resolves to the IPv4 or IPv6 loopback (e.g. `::1` first on Windows).
-- `user_impersonation` is a delegated scope users can normally self-consent to
-  on first sign-in; tenant admin consent is only required if the tenant
-  restricts user consent.
+- The redirect URI is `http://localhost:<dynamic-port>/` at the **root path** —
+  the Visual Studio client registers bare `http://localhost`, and Entra matches
+  the path (so `/callback` would not match) while ignoring the port for
+  `localhost`. The loopback server therefore accepts the callback on `/` (it
+  identifies the callback by its `code`/`error` query, not a fixed path).
+- The loopback server binds `127.0.0.1` and, best-effort, the IPv6 loopback
+  `[::1]` on the same port, so the callback lands whether `localhost` resolves to
+  the IPv4 or IPv6 loopback (e.g. `::1` first on Windows).
+- If a tenant blocks OAuth outright, use the **Personal Access Token** tab as a
+  fallback (as Git Credential Manager and GitKraken also do).
+- Reusing the Visual Studio client is the Git Credential Manager pattern; it is
+  not a contractual guarantee, so the PAT fallback is kept for resilience.
 
 ---
 
@@ -120,7 +109,7 @@ Look for the `OAUTH_CLIENT_IDS` object near the top of the file:
 const OAUTH_CLIENT_IDS: Record<OAuthProvider, string> = {
   github: 'your-github-client-id',
   gitlab: 'your-gitlab-application-id',
-  azure: 'your-azure-application-client-id', // optional: defaults to the embedded Leviathan multi-tenant public client (auth-code + loopback)
+  azure: 'your-azure-application-client-id', // optional: defaults to Microsoft's Visual Studio first-party client (no registration / admin consent)
   bitbucket: 'your-bitbucket-key',
 };
 ```

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -212,7 +212,8 @@ pub async fn oauth_get_authorize_url(
         }
         OAuthProvider::Azure => {
             // Azure DevOps (Entra ID): interactive auth-code + loopback (like GitHub/GitLab),
-            // using the embedded registered public client. instance_url carries the optional tenant.
+            // using Microsoft's Visual Studio first-party public client (no admin consent /
+            // app registration). instance_url carries the optional tenant.
             let server = LoopbackServer::new()?;
             let port = server.port();
             let config = OAuthConfig::azure(&client_id, instance_url.as_deref(), port);

--- a/src-tauri/src/services/loopback_server.rs
+++ b/src-tauri/src/services/loopback_server.rs
@@ -279,11 +279,13 @@ impl LoopbackServer {
         // Identify the OAuth callback by its query, not a fixed path: providers
         // differ in the redirect PATH they register — GitHub/GitLab/Bitbucket use
         // `/callback`, while Azure DevOps rides Microsoft's Visual Studio client
-        // whose registered redirect is bare `http://localhost` (root `/`). Gating
-        // on the presence of `code`/`error` accepts both and ignores incidental
-        // requests (e.g. `/favicon.ico`, or a bare `/` with no query) rather than
-        // mis-parsing them as a failed callback.
-        if !(query.contains("code=") || query.contains("error=")) {
+        // whose registered redirect is bare `http://localhost` (root `/`). Match on
+        // an EXACT `code`/`error` query KEY (see `query_is_callback`; a raw
+        // substring would also match `zipcode=`/`errorcode=`/… and mis-handle an
+        // unrelated request as a failed callback, tearing down the listener).
+        // Incidental requests (`/favicon.ico`, or a bare `/` with no query) are
+        // ignored.
+        if !query_is_callback(query) {
             Self::send_error_response(&mut stream, "Not found");
             return None; // Continue listening
         }
@@ -419,6 +421,18 @@ fn url_decode_component(s: &str) -> String {
         // Fall back to the raw value if it isn't valid percent-encoding.
         Err(_) => s,
     }
+}
+
+/// True if `query` carries an OAuth callback — i.e. it has an EXACT `code` or
+/// `error` parameter key. Used to distinguish the real redirect from incidental
+/// loopback requests (favicon, a bare `/`) regardless of the request path, so
+/// both the `/callback` path (GitHub/GitLab/Bitbucket) and the root `/` path
+/// (Azure's Visual Studio client) work. Matching the parsed key (not a raw
+/// substring) avoids false positives from keys like `zipcode`/`errorcode`.
+fn query_is_callback(query: &str) -> bool {
+    query
+        .split('&')
+        .any(|pair| matches!(pair.split('=').next(), Some("code") | Some("error")))
 }
 
 /// Parse and validate an OAuth callback query string.
@@ -596,6 +610,24 @@ mod tests {
         let result = parse_callback_query("code=abc123&state=xyz789").unwrap();
         assert_eq!(result.code, "abc123");
         assert_eq!(result.state, "xyz789");
+    }
+
+    #[test]
+    fn test_query_is_callback_matches_exact_key_only() {
+        // Real callbacks (any key order) are recognised.
+        assert!(query_is_callback("code=abc&state=xyz"));
+        assert!(query_is_callback("state=xyz&code=abc"));
+        assert!(query_is_callback(
+            "error=access_denied&error_description=nope"
+        ));
+        // Substrings inside unrelated keys must NOT be treated as a callback,
+        // otherwise a stray request would tear down the listener.
+        assert!(!query_is_callback("zipcode=90210"));
+        assert!(!query_is_callback("barcode=1&errorcode=200"));
+        assert!(!query_is_callback("decode=1"));
+        // No query / unrelated query is ignored.
+        assert!(!query_is_callback(""));
+        assert!(!query_is_callback("state=only"));
     }
 
     #[test]

--- a/src-tauri/src/services/loopback_server.rs
+++ b/src-tauri/src/services/loopback_server.rs
@@ -274,9 +274,16 @@ impl LoopbackServer {
         }
 
         let path = parts[1];
+        let query = path.split('?').nth(1).unwrap_or("");
 
-        // Check if this is the callback path
-        if !path.starts_with("/callback") {
+        // Identify the OAuth callback by its query, not a fixed path: providers
+        // differ in the redirect PATH they register — GitHub/GitLab/Bitbucket use
+        // `/callback`, while Azure DevOps rides Microsoft's Visual Studio client
+        // whose registered redirect is bare `http://localhost` (root `/`). Gating
+        // on the presence of `code`/`error` accepts both and ignores incidental
+        // requests (e.g. `/favicon.ico`, or a bare `/` with no query) rather than
+        // mis-parsing them as a failed callback.
+        if !(query.contains("code=") || query.contains("error=")) {
             Self::send_error_response(&mut stream, "Not found");
             return None; // Continue listening
         }
@@ -285,7 +292,6 @@ impl LoopbackServer {
         // (pure, unit-tested below) BEFORE we tell the browser anything, so a
         // callback missing its `state` shows a failure page rather than a
         // misleading "Authorization Successful".
-        let query = path.split('?').nth(1).unwrap_or("");
         match parse_callback_query(query) {
             Ok(result) => {
                 Self::send_success_response(&mut stream);
@@ -504,6 +510,26 @@ mod tests {
         let result = handle.join().unwrap().unwrap();
         assert_eq!(result.code, "abc");
         assert_eq!(result.state, "xyz");
+    }
+
+    /// Azure DevOps rides Microsoft's Visual Studio client, whose registered
+    /// redirect is bare `http://localhost` — so the callback lands on the ROOT
+    /// path `/`, not `/callback`. The server must still recognise it.
+    #[test]
+    fn test_wait_for_callback_receives_on_root_path() {
+        let server = LoopbackServer::new().unwrap();
+        let port = server.port();
+        let handle = thread::spawn(move || server.wait_for_callback(Duration::from_secs(5)));
+
+        thread::sleep(Duration::from_millis(150));
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream
+            .write_all(b"GET /?code=rootcode&state=rootstate HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .unwrap();
+
+        let result = handle.join().unwrap().unwrap();
+        assert_eq!(result.code, "rootcode");
+        assert_eq!(result.state, "rootstate");
     }
 
     /// When IPv6 loopback is available, a callback delivered to `[::1]` (the family

--- a/src-tauri/src/services/oauth.rs
+++ b/src-tauri/src/services/oauth.rs
@@ -123,14 +123,19 @@ impl OAuthConfig {
     }
 
     /// Get Azure DevOps (Microsoft Entra ID) OAuth configuration for the interactive
-    /// authorization-code + loopback flow. Uses `localhost` (NOT `127.0.0.1`): Entra
-    /// only ignores the port when matching a `localhost` loopback redirect — for the IP
-    /// literal the port must match exactly, which is impossible with our dynamic
-    /// loopback port. So the app registers `http://localhost/callback` and every port
-    /// matches it. The loopback server binds `127.0.0.1` and, best-effort, `[::1]`
-    /// (see `LoopbackServer::try_bind_ipv6_loopback`), since `localhost` can resolve
-    /// to either family depending on the OS. `tenant_id` (passed as instance_url)
-    /// defaults to `organizations` (multi-tenant).
+    /// authorization-code + loopback flow, using Microsoft's Visual Studio first-party
+    /// public client (pre-authorized for Azure DevOps — no admin consent, no app
+    /// registration; the same client Git Credential Manager uses).
+    ///
+    /// The redirect is `http://localhost:{port}/` at the ROOT path — that VS client
+    /// registers bare `http://localhost`, and Entra matches the path (so `/callback`
+    /// would NOT match) while ignoring the port for `localhost`. Host must be
+    /// `localhost` (not `127.0.0.1`): Entra only ignores the port for `localhost`, and
+    /// that is what VS registered. The loopback server binds `127.0.0.1` and,
+    /// best-effort, `[::1]` (see `LoopbackServer::try_bind_ipv6_loopback`), since
+    /// `localhost` can resolve to either family. `tenant_id` (passed as instance_url)
+    /// defaults to `organizations` (work/school accounts; personal MSAs are rejected
+    /// by this client).
     pub fn azure(client_id: &str, tenant_id: Option<&str>, redirect_port: u16) -> Self {
         let tenant = tenant_id.unwrap_or("organizations");
         Self {
@@ -149,7 +154,7 @@ impl OAuthConfig {
                 "openid".to_string(),
                 "profile".to_string(),
             ],
-            redirect_uri: format!("http://localhost:{}/callback", redirect_port),
+            redirect_uri: format!("http://localhost:{}/", redirect_port),
         }
     }
 
@@ -615,9 +620,10 @@ mod tests {
         let config = OAuthConfig::azure("cid", None, 8080);
 
         assert!(config.authorize_url.contains("/organizations/"));
-        // MUST be localhost (not 127.0.0.1): Entra only ignores the port for a
-        // `localhost` loopback redirect, and our loopback port is dynamic.
-        assert_eq!(config.redirect_uri, "http://localhost:8080/callback");
+        // MUST be localhost (not 127.0.0.1) at the ROOT path: the Visual Studio
+        // client registers bare `http://localhost`; Entra matches the path and
+        // ignores the port only for `localhost`.
+        assert_eq!(config.redirect_uri, "http://localhost:8080/");
         assert!(config
             .scopes
             .contains(&"499b84ac-1321-427f-aa17-267ca6975798/user_impersonation".to_string()));

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -212,7 +212,7 @@ function setupMockInvoke(): void {
     if (command === 'oauth_get_authorize_url') {
       return {
         authorizeUrl:
-          'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?client_id=x&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback',
+          'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?client_id=x&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2F',
         state: 'state-xyz',
         loopbackPort: 8080,
       };

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -1131,8 +1131,9 @@ export class LvAzureDevOpsDialog extends LitElement {
    * authorization-code + loopback flow (the same path GitHub/GitLab use). Opens
    * the Microsoft sign-in page in the browser; the OAuth service waits on the
    * loopback callback, exchanges the code, and dispatches a global
-   * `oauth-complete` event that `handleOAuthComplete` picks up. Uses the embedded
-   * registered public client — no per-user app registration.
+   * `oauth-complete` event that `handleOAuthComplete` picks up. Uses Microsoft's
+   * Visual Studio first-party public client — no per-user app registration and no
+   * admin consent.
    */
   private async handleStartEntraOAuth(): Promise<void> {
     // Guard against a double-click starting a second (orphaned) flow.

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -29,9 +29,13 @@ import type {
 const OAUTH_CLIENT_IDS: Partial<Record<OAuthProvider, string>> = {
   github: 'Ov23liQxX14fxt3fRq4u',
   gitlab: '90d3d02fefb79e0303aaa54e8c6794bf806e9e8a1de7526bebc4f14288e12fec',
-  // Registered Leviathan multi-tenant Entra app (public client, loopback redirect
-  // http://localhost/callback, Azure DevOps user_impersonation).
-  azure: 'a1b13ec5-3f32-4ec7-b07f-5dfc5acbd2a8',
+  // Microsoft's Visual Studio first-party public client. It is pre-authorized for
+  // the Azure DevOps resource in every tenant, so interactive sign-in needs NO
+  // per-tenant admin consent and NO app registration — the same client Microsoft's
+  // own Git Credential Manager embeds (redirect http://localhost, root path). Work
+  // or school accounts only (the /organizations authority; personal MSAs are not
+  // supported by this client).
+  azure: '872cd9fa-d31f-45e0-9eab-6e460a02d1f1',
   bitbucket: 'Tv5UjEqLKK7GSYjAJn',
 };
 


### PR DESCRIPTION
## Summary

v0.5.1 shipped interactive Entra sign-in with our **own** registered multi-tenant Entra app. In locked-down tenants that **restrict user consent**, that unverified third-party app triggers **"Need admin approval"**, blocking any user without admin rights (real-world case: a SEFE tenant).

This switches Azure DevOps sign-in to Microsoft's **Visual Studio first-party public client** (`872cd9fa-d31f-45e0-9eab-6e460a02d1f1`) — the same client Microsoft's own **Git Credential Manager** embeds. Because the Azure DevOps resource **pre-authorizes** this client, sign-in raises **no consent prompt at all**: no admin consent, and no app registration. The interactive auth-code + loopback flow still satisfies Conditional Access (the reason we left device-code).

## Changes

- **`oauth.service.ts`**: embed the Visual Studio client id for `azure` (work/school accounts only — the `/organizations` authority; personal MSAs are rejected by this client).
- **`OAuthConfig::azure`** (`oauth.rs`): redirect is now `http://localhost:{port}/` at the **root path** — that client registers bare `http://localhost`; Entra matches the path (so `/callback` would not match) and ignores the port only for `localhost` (not `127.0.0.1`).
- **Loopback server** (`loopback_server.rs`): identify the callback by an **exact `code`/`error` query key** (`query_is_callback`) rather than a fixed `/callback` path, so it accepts both `/callback` (GitHub/GitLab/Bitbucket) and root `/` (Azure) while ignoring incidental requests. State/CSRF binding is still enforced in `parse_callback_query`. Still binds `127.0.0.1` + best-effort `[::1]`.
- **Docs**: `docs/oauth-setup.md` Azure section rewritten — zero-config first-party client, PAT tab retained as fallback.

## Zero-config

No Entra app registration is required anymore; the PAT tab remains as a fallback for tenants that block OAuth outright (as GitKraken and Git Credential Manager also do).

## Trade-off (called out honestly)

This reuses Microsoft's Visual Studio client id. It's the Git-Credential-Manager-proven pattern for Azure DevOps and very likely to keep working, but it isn't a contractual guarantee; the PAT fallback is the safety net if Microsoft ever tightens first-party reuse.

## Testing

- **Rust:** `OAuthConfig::azure` (root-path localhost redirect, tenant), `azure_token_url`, loopback root-path callback + `query_is_callback` exact-key matching (incl. `zipcode=`/`errorcode=` negatives) + IPv4/IPv6 accept; `cargo fmt`/`clippy -D warnings`/oauth+loopback tests green.
- **TypeScript:** typecheck/lint + full unit suite green.
- Reviewed to convergence by the recursive multi-model review (Opus/Sonnet/Haiku).

Follow-up to #254/#255; ships as **v0.5.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ)_