### PR TITLE
fix(credentials): chunk large OAuth tokens to fit the Windows Credential Manager cap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leviathan",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A fully-featured, open-source, cross-platform Git GUI client",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2927,7 +2927,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leviathan"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leviathan"
-version = "0.5.1"
+version = "0.5.2"
 description = "A fully-featured, open-source, cross-platform Git GUI client"
 authors = ["Leviathan Contributors"]
 edition = "2021"

--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -703,10 +703,9 @@ pub async fn store_keyring_token(key: String, value: String) -> Result<()> {
 
     #[cfg(not(target_os = "macos"))]
     {
-        let entry = keyring::Entry::new(INTEGRATION_SERVICE, &key)
-            .map_err(|e| LeviathanError::OperationFailed(format!("Keyring error: {e}")))?;
-        entry
-            .set_password(&value)
+        // Chunk transparently: Windows Credential Manager caps a secret at 2560
+        // bytes, which large Entra tokens exceed.
+        crate::services::keyring_util::set(INTEGRATION_SERVICE, &key, &value)
             .map_err(|e| LeviathanError::OperationFailed(format!("Failed to store token: {e}")))?;
     }
 
@@ -746,15 +745,8 @@ pub async fn get_keyring_token(key: String) -> Result<Option<String>> {
 
     #[cfg(not(target_os = "macos"))]
     {
-        let entry = keyring::Entry::new(INTEGRATION_SERVICE, &key)
-            .map_err(|e| LeviathanError::OperationFailed(format!("Keyring error: {e}")))?;
-        match entry.get_password() {
-            Ok(password) => Ok(Some(password)),
-            Err(keyring::Error::NoEntry) => Ok(None),
-            Err(e) => Err(LeviathanError::OperationFailed(format!(
-                "Failed to get token: {e}"
-            ))),
-        }
+        crate::services::keyring_util::get(INTEGRATION_SERVICE, &key)
+            .map_err(|e| LeviathanError::OperationFailed(format!("Failed to get token: {e}")))
     }
 }
 
@@ -776,17 +768,9 @@ pub async fn delete_keyring_token(key: String) -> Result<()> {
 
     #[cfg(not(target_os = "macos"))]
     {
-        let entry = keyring::Entry::new(INTEGRATION_SERVICE, &key)
-            .map_err(|e| LeviathanError::OperationFailed(format!("Keyring error: {e}")))?;
-        match entry.delete_credential() {
-            Ok(()) => (),
-            Err(keyring::Error::NoEntry) => (),
-            Err(e) => {
-                return Err(LeviathanError::OperationFailed(format!(
-                    "Failed to delete token: {e}"
-                )))
-            }
-        }
+        // Removes the primary entry and any chunk entries a large token created.
+        crate::services::keyring_util::delete(INTEGRATION_SERVICE, &key)
+            .map_err(|e| LeviathanError::OperationFailed(format!("Failed to delete token: {e}")))?;
     }
 
     tracing::debug!("Deleted keyring token for key: {}", key);

--- a/src-tauri/src/services/credentials_service.rs
+++ b/src-tauri/src/services/credentials_service.rs
@@ -4,8 +4,6 @@
 //! via the `security` CLI tool (avoids permission prompts that the keyring crate triggers).
 
 use git2::{Cred, CredentialType, RemoteCallbacks};
-#[cfg(not(target_os = "macos"))]
-use keyring::Entry;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Instant;
@@ -93,8 +91,10 @@ fn keyring_get(service: &str, account: &str) -> Option<String> {
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let entry = Entry::new(service, account).ok()?;
-        entry.get_password().ok()
+        // Reassembles a chunked secret (large Entra token) transparently.
+        crate::services::keyring_util::get(service, account)
+            .ok()
+            .flatten()
     }
 }
 
@@ -162,11 +162,9 @@ fn keyring_set(service: &str, account: &str, password: &str) -> bool {
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let entry = match Entry::new(service, account) {
-            Ok(e) => e,
-            Err(_) => return false,
-        };
-        entry.set_password(password).is_ok()
+        // Chunk transparently so a large Entra token doesn't exceed the Windows
+        // Credential Manager 2560-byte per-secret limit.
+        crate::services::keyring_util::set(service, account, password).is_ok()
     }
 }
 
@@ -182,11 +180,7 @@ fn keyring_delete(service: &str, account: &str) -> bool {
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let entry = match Entry::new(service, account) {
-            Ok(e) => e,
-            Err(_) => return false,
-        };
-        entry.delete_credential().is_ok()
+        crate::services::keyring_util::delete(service, account).is_ok()
     }
 }
 

--- a/src-tauri/src/services/keyring_util.rs
+++ b/src-tauri/src/services/keyring_util.rs
@@ -108,19 +108,26 @@ fn delete_quietly(service: &str, account: &str) {
     }
 }
 
-/// Best-effort sweep of the contiguous chunk entries of `slot` starting at index
-/// `from`, stopping at the first missing index (or on error). Chunks are always
-/// written 0..N contiguously, so this removes a whole (or leftover) generation.
-fn sweep_chunks(service: &str, account: &str, slot: u8, from: usize) {
+/// Sweep the contiguous chunk entries of `slot` starting at index `from`,
+/// stopping at the first missing index. Chunks are always written 0..N
+/// contiguously, so this removes a whole (or leftover) generation. Returns the
+/// first backend error encountered (callers decide whether to propagate or log).
+fn sweep_chunks(service: &str, account: &str, slot: u8, from: usize) -> Result<(), Error> {
     for i in from..MAX_CHUNKS {
         match delete_one(service, &chunk_account(account, slot, i)) {
             Ok(true) => {}
-            Ok(false) => break, // no more chunks in this slot
-            Err(e) => {
-                tracing::warn!("keyring: failed sweeping chunk {slot}/{i} of {account}: {e}");
-                break;
-            }
+            Ok(false) => return Ok(()), // no more chunks in this slot
+            Err(e) => return Err(e),
         }
+    }
+    Ok(())
+}
+
+/// Best-effort sweep for post-commit cleanup: the store already succeeded, so a
+/// leftover-chunk removal failure is logged, not surfaced.
+fn sweep_chunks_logged(service: &str, account: &str, slot: u8, from: usize) {
+    if let Err(e) = sweep_chunks(service, account, slot, from) {
+        tracing::warn!("keyring: failed sweeping chunks {slot} of {account}: {e}");
     }
 }
 
@@ -149,14 +156,22 @@ pub fn set(service: &str, account: &str, secret: &str) -> Result<(), Error> {
         // that delete MUST succeed, else reads keep returning the old chunked value.
         entry(service, account)?.set_password(secret)?;
         if old.is_some() {
+            // Committed chunked value: reads check meta first, so deleting it is the
+            // real COMMIT of the switch to plain — it MUST succeed.
             match entry(service, &meta_account(account))?.delete_credential() {
                 Ok(()) | Err(Error::NoEntry) => {}
                 Err(e) => return Err(e),
             }
-            // Now committed to plain; best-effort remove both generations' chunks.
-            sweep_chunks(service, account, 0, 0);
-            sweep_chunks(service, account, 1, 0);
+        } else {
+            // No committed metadata, but a prior chunked write that failed before
+            // committing could have left a stray meta/chunks — tidy them up.
+            delete_quietly(service, &meta_account(account));
         }
+        // Always sweep orphan chunks (both generations) — cheap when none exist
+        // (breaks on the first missing index). This also collects fragments left
+        // by a previously-failed, never-committed chunked write.
+        sweep_chunks_logged(service, account, 0, 0);
+        sweep_chunks_logged(service, account, 1, 0);
         return Ok(());
     }
 
@@ -174,13 +189,13 @@ pub fn set(service: &str, account: &str, secret: &str) -> Result<(), Error> {
     // COMMIT — from here reads resolve to the new generation.
     entry(service, &meta_account(account))?.set_password(&format_meta(chunks.len(), new_slot))?;
 
-    // Best-effort cleanup: any stale plain primary, the previous generation, and
-    // any leftover higher-index chunks in the reused slot.
+    // Best-effort cleanup (store already committed): any stale plain primary, the
+    // previous generation, and any leftover higher-index chunks in the reused slot.
     delete_quietly(service, account);
     if let Some((_, old_slot)) = old {
-        sweep_chunks(service, account, old_slot, 0);
+        sweep_chunks_logged(service, account, old_slot, 0);
     }
-    sweep_chunks(service, account, new_slot, chunks.len());
+    sweep_chunks_logged(service, account, new_slot, chunks.len());
     Ok(())
 }
 
@@ -209,14 +224,26 @@ pub fn get(service: &str, account: &str) -> Result<Option<String>, Error> {
 
 /// Delete a secret and every chunk/metadata entry it could own. Sweeps BOTH
 /// generations so a partially-failed prior rotation can't leave token fragments
-/// behind in the OS credential store.
+/// behind. Attempts every removal and, if any failed, returns the first error —
+/// so a caller is never told the secret is gone while fragments remain.
 pub fn delete(service: &str, account: &str) -> Result<(), Error> {
-    sweep_chunks(service, account, 0, 0);
-    sweep_chunks(service, account, 1, 0);
-    delete_quietly(service, &meta_account(account));
-    match entry(service, account)?.delete_credential() {
-        Ok(()) | Err(Error::NoEntry) => Ok(()),
-        Err(e) => Err(e),
+    let mut first_err: Option<Error> = None;
+    let mut record = |result: Result<(), Error>| {
+        if let Err(e) = result {
+            if first_err.is_none() {
+                first_err = Some(e);
+            }
+        }
+    };
+
+    record(sweep_chunks(service, account, 0, 0));
+    record(sweep_chunks(service, account, 1, 0));
+    record(delete_one(service, &meta_account(account)).map(|_| ()));
+    record(delete_one(service, account).map(|_| ()));
+
+    match first_err {
+        Some(e) => Err(e),
+        None => Ok(()),
     }
 }
 

--- a/src-tauri/src/services/keyring_util.rs
+++ b/src-tauri/src/services/keyring_util.rs
@@ -12,6 +12,17 @@
 //! Short secrets (PATs, small tokens) are stored verbatim under the original key,
 //! so existing entries keep working unchanged.
 //!
+//! ## Layout
+//! - A separate metadata entry `"{account}__lvmeta"` holds `"{count}:{slot}"` when
+//!   the secret is chunked, and is ABSENT for a plain (unchunked) secret. Keeping
+//!   the chunk marker out-of-band means a plain secret can never be misread as a
+//!   marker, no matter its contents (relevant for the arbitrary git-password path).
+//! - Chunks live under `"{account}__lvchunk{slot}_{i}"`. `slot` (0/1) alternates
+//!   on each rewrite so a new generation is written to fresh keys, leaving the old
+//!   generation fully intact until the metadata write commits the switch. A write
+//!   failure mid-sequence therefore preserves the previously-stored value rather
+//!   than destroying it.
+//!
 //! macOS is handled separately by the callers (via the `security` CLI, which
 //! reads the secret from stdin and has no such small limit), so this module is
 //! only compiled for non-macOS targets.
@@ -19,167 +30,235 @@
 
 use keyring::{Entry, Error};
 
-/// Maximum characters per keyring entry. Windows measures the UTF-16 length of
-/// the secret; our secrets are ASCII (base64url JWTs, alphanumeric PATs, JSON),
-/// i.e. one UTF-16 code unit per char, so 1000 chars stays comfortably under the
-/// 2560 limit whether the backend counts code units (1000) or bytes (2000).
-const MAX_CHARS_PER_ENTRY: usize = 1000;
+/// Maximum UTF-16 code units per keyring entry. Windows measures the secret's
+/// UTF-16 length against the 2560-byte (1280-unit) cap; budgeting by UTF-16 units
+/// — not Rust `char`s — keeps each chunk safely under it even for astral-plane
+/// characters (2 units each), which matters because the arbitrary git-password
+/// path shares this code. 1200 units = 2400 bytes, comfortably below 2560.
+const MAX_UTF16_UNITS_PER_ENTRY: usize = 1200;
 
-/// Prefix written (with the chunk count appended) under the primary key when a
-/// secret was chunked. The `|` guarantees no collision with a real secret: it is
-/// absent from the base64url alphabet (JWTs / most tokens), and our JSON bundles
-/// start with `{` — so no value we store can equal `<MARKER><digits>`.
-const CHUNK_MARKER: &str = "__LV_CHUNKED_V1__|";
-
-/// Build a distinct keyring account name for chunk `i` of `account`.
-fn chunk_account(account: &str, i: usize) -> String {
-    format!("{account}__lvchunk{i}")
+/// Keyring account name of the out-of-band chunk metadata for `account`.
+fn meta_account(account: &str) -> String {
+    format!("{account}__lvmeta")
 }
 
-/// Split `secret` into `MAX_CHARS_PER_ENTRY`-sized pieces on char boundaries
-/// (never mid-UTF-8-sequence). Pure — unit-tested below.
+/// Keyring account name for chunk `i` of generation `slot` of `account`.
+fn chunk_account(account: &str, slot: u8, i: usize) -> String {
+    format!("{account}__lvchunk{slot}_{i}")
+}
+
+/// Split `secret` into pieces each within `MAX_UTF16_UNITS_PER_ENTRY` UTF-16
+/// units, never splitting a `char`. Pure — unit-tested below.
 fn split_into_chunks(secret: &str) -> Vec<String> {
-    secret
-        .chars()
-        .collect::<Vec<char>>()
-        .chunks(MAX_CHARS_PER_ENTRY)
-        .map(|c| c.iter().collect())
-        .collect()
+    let mut chunks: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut units = 0usize;
+    for ch in secret.chars() {
+        let ch_units = ch.len_utf16();
+        if units + ch_units > MAX_UTF16_UNITS_PER_ENTRY && !current.is_empty() {
+            chunks.push(std::mem::take(&mut current));
+            units = 0;
+        }
+        current.push(ch);
+        units += ch_units;
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
 }
 
-/// The marker value written under the primary key for an `n`-chunk secret.
-fn marker_for(n: usize) -> String {
-    format!("{CHUNK_MARKER}{n}")
+/// Format the metadata value for a `count`-chunk secret in generation `slot`.
+fn format_meta(count: usize, slot: u8) -> String {
+    format!("{count}:{slot}")
 }
 
-/// If `value` is a chunk marker, return the chunk count it encodes. Pure.
-fn parse_marker(value: &str) -> Option<usize> {
-    value
-        .strip_prefix(CHUNK_MARKER)
-        .and_then(|n| n.parse().ok())
+/// Parse a metadata value into `(count, slot)`. Pure.
+fn parse_meta(value: &str) -> Option<(usize, u8)> {
+    let (count, slot) = value.split_once(':')?;
+    Some((count.parse().ok()?, slot.parse().ok()?))
 }
 
 fn entry(service: &str, account: &str) -> Result<Entry, Error> {
     Entry::new(service, account)
 }
 
-/// Store `secret`, chunking transparently when it exceeds one entry's capacity.
-pub fn set(service: &str, account: &str, secret: &str) -> Result<(), Error> {
-    // Clear any prior value (chunked or not) first, so a shrink from N chunks to
-    // a plain value — or to fewer chunks — never leaves orphaned chunk entries.
-    let _ = delete(service, account);
+/// Best-effort delete of a single credential (missing is fine).
+fn delete_quietly(service: &str, account: &str) {
+    if let Ok(e) = entry(service, account) {
+        let _ = e.delete_credential();
+    }
+}
 
-    if secret.chars().count() <= MAX_CHARS_PER_ENTRY {
-        return entry(service, account)?.set_password(secret);
+/// Read the chunk metadata for `account`, if present.
+fn read_meta(service: &str, account: &str) -> Option<(usize, u8)> {
+    let value = entry(service, &meta_account(account))
+        .ok()?
+        .get_password()
+        .ok()?;
+    parse_meta(&value)
+}
+
+/// Store `secret`, chunking transparently when it exceeds one entry's capacity.
+///
+/// Failure-atomic: the previously-stored value stays readable until the switch is
+/// committed (metadata write for a chunked secret; primary overwrite for a plain
+/// one), so a mid-sequence keyring error never leaves the account without a token.
+pub fn set(service: &str, account: &str, secret: &str) -> Result<(), Error> {
+    let old = read_meta(service, account);
+
+    if secret.encode_utf16().count() <= MAX_UTF16_UNITS_PER_ENTRY {
+        // Plain: overwrite the primary key atomically (in-place replace). Only
+        // AFTER that succeeds do we drop any prior chunked generation, so a
+        // failure here leaves the old value intact.
+        entry(service, account)?.set_password(secret)?;
+        if let Some((count, slot)) = old {
+            delete_quietly(service, &meta_account(account));
+            for i in 0..count {
+                delete_quietly(service, &chunk_account(account, slot, i));
+            }
+        }
+        return Ok(());
     }
 
+    // Chunked: write the new generation to the OTHER slot so the old generation is
+    // untouched, then commit by writing the metadata. A failure before the commit
+    // leaves the old metadata + old chunks fully intact.
+    let new_slot = match old {
+        Some((_, 0)) => 1,
+        _ => 0,
+    };
     let chunks = split_into_chunks(secret);
     for (i, chunk) in chunks.iter().enumerate() {
-        entry(service, &chunk_account(account, i))?.set_password(chunk)?;
+        entry(service, &chunk_account(account, new_slot, i))?.set_password(chunk)?;
     }
-    // Write the marker LAST, so a reader that sees the marker is guaranteed all
-    // chunks it points at are already present.
-    entry(service, account)?.set_password(&marker_for(chunks.len()))
+    // COMMIT — from here reads resolve to the new generation.
+    entry(service, &meta_account(account))?.set_password(&format_meta(chunks.len(), new_slot))?;
+
+    // Best-effort cleanup of the previous generation and any stale plain primary.
+    delete_quietly(service, account);
+    if let Some((count, slot)) = old {
+        for i in 0..count {
+            delete_quietly(service, &chunk_account(account, slot, i));
+        }
+    }
+    Ok(())
 }
 
 /// Read a secret, reassembling chunks when present. `Ok(None)` if absent.
 pub fn get(service: &str, account: &str) -> Result<Option<String>, Error> {
-    let head = match entry(service, account)?.get_password() {
-        Ok(v) => v,
-        Err(Error::NoEntry) => return Ok(None),
-        Err(e) => return Err(e),
-    };
-
-    let Some(n) = parse_marker(&head) else {
-        return Ok(Some(head)); // plain (non-chunked) secret
-    };
-
-    let mut out = String::new();
-    for i in 0..n {
-        match entry(service, &chunk_account(account, i))?.get_password() {
-            Ok(part) => out.push_str(&part),
-            // A missing chunk means a partial/corrupt write — treat the whole
-            // secret as absent rather than returning a truncated token.
-            Err(Error::NoEntry) => return Ok(None),
-            Err(e) => return Err(e),
-        }
-    }
-    Ok(Some(out))
-}
-
-/// Delete a secret and any chunk entries it owns.
-pub fn delete(service: &str, account: &str) -> Result<(), Error> {
-    let head = match entry(service, account)?.get_password() {
-        Ok(v) => Some(v),
-        Err(Error::NoEntry) => None,
-        Err(e) => return Err(e),
-    };
-
-    if let Some(head) = &head {
-        if let Some(n) = parse_marker(head) {
-            for i in 0..n {
-                if let Ok(e) = entry(service, &chunk_account(account, i)) {
-                    let _ = e.delete_credential();
-                }
+    if let Some((count, slot)) = read_meta(service, account) {
+        let mut out = String::new();
+        for i in 0..count {
+            match entry(service, &chunk_account(account, slot, i))?.get_password() {
+                Ok(part) => out.push_str(&part),
+                // A missing chunk means a partial/corrupt write — treat the whole
+                // secret as absent rather than returning a truncated token.
+                Err(Error::NoEntry) => return Ok(None),
+                Err(e) => return Err(e),
             }
         }
-        let _ = entry(service, account)?.delete_credential();
+        return Ok(Some(out));
     }
-    Ok(())
+
+    match entry(service, account)?.get_password() {
+        Ok(value) => Ok(Some(value)),
+        Err(Error::NoEntry) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Delete a secret and any chunk/metadata entries it owns.
+pub fn delete(service: &str, account: &str) -> Result<(), Error> {
+    if let Some((count, slot)) = read_meta(service, account) {
+        for i in 0..count {
+            delete_quietly(service, &chunk_account(account, slot, i));
+        }
+        delete_quietly(service, &meta_account(account));
+    }
+    match entry(service, account)?.delete_credential() {
+        Ok(()) | Err(Error::NoEntry) => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_split_short_secret_is_single_chunk() {
-        let chunks = split_into_chunks("short-token");
-        assert_eq!(chunks, vec!["short-token".to_string()]);
+    fn utf16_len(s: &str) -> usize {
+        s.encode_utf16().count()
     }
 
     #[test]
-    fn test_split_respects_max_chars_and_roundtrips() {
+    fn test_split_short_secret_is_single_chunk() {
+        assert_eq!(
+            split_into_chunks("short-token"),
+            vec!["short-token".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_split_ascii_respects_budget_and_roundtrips() {
         let secret: String = "a".repeat(2500);
         let chunks = split_into_chunks(&secret);
-        assert_eq!(chunks.len(), 3); // 1000 + 1000 + 500
+        assert_eq!(chunks.len(), 3); // 1200 + 1200 + 100
         assert!(chunks
             .iter()
-            .all(|c| c.chars().count() <= MAX_CHARS_PER_ENTRY));
+            .all(|c| utf16_len(c) <= MAX_UTF16_UNITS_PER_ENTRY));
         assert_eq!(chunks.concat(), secret);
     }
 
     #[test]
+    fn test_split_astral_chars_budgets_by_utf16_units_not_chars() {
+        // Each 😀 is 2 UTF-16 code units. 700 of them = 1400 units > one entry,
+        // and a naive char-count split (1000) would put 1000*2=2000 units in a
+        // chunk, overflowing the cap. Budgeting by units must not.
+        let secret: String = "😀".repeat(700);
+        let chunks = split_into_chunks(&secret);
+        assert!(chunks.len() >= 2);
+        assert!(
+            chunks
+                .iter()
+                .all(|c| utf16_len(c) <= MAX_UTF16_UNITS_PER_ENTRY),
+            "every chunk must stay within the UTF-16 unit budget"
+        );
+        assert_eq!(chunks.concat(), secret); // no char was split
+    }
+
+    #[test]
     fn test_split_boundary_exact_multiple() {
-        let secret: String = "x".repeat(MAX_CHARS_PER_ENTRY * 2);
+        let secret: String = "x".repeat(MAX_UTF16_UNITS_PER_ENTRY * 2);
         let chunks = split_into_chunks(&secret);
         assert_eq!(chunks.len(), 2);
         assert_eq!(chunks.concat(), secret);
     }
 
     #[test]
-    fn test_marker_roundtrips() {
-        assert_eq!(parse_marker(&marker_for(4)), Some(4));
-        assert_eq!(parse_marker(&marker_for(1)), Some(1));
+    fn test_meta_roundtrips() {
+        assert_eq!(parse_meta(&format_meta(4, 0)), Some((4, 0)));
+        assert_eq!(parse_meta(&format_meta(1, 1)), Some((1, 1)));
     }
 
     #[test]
-    fn test_parse_marker_ignores_real_secrets() {
-        // A base64url JWT, a JSON bundle, and a PAT must never look like a marker.
-        assert_eq!(
-            parse_marker("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.abc"),
-            None
-        );
-        assert_eq!(parse_marker("{\"accessToken\":\"eyJ...\"}"), None);
-        assert_eq!(parse_marker("abcdef0123456789ABCDEF"), None);
-        // The marker prefix without a valid count is not a marker either.
-        assert_eq!(parse_marker(CHUNK_MARKER), None);
-        assert_eq!(parse_marker(&format!("{CHUNK_MARKER}notanumber")), None);
+    fn test_parse_meta_rejects_junk() {
+        // A real secret in the primary key is never parsed as metadata (metadata
+        // lives under a separate account), but parse_meta must still be strict.
+        assert_eq!(parse_meta("eyJhbGciOiJSUzI1NiJ9.abc"), None);
+        assert_eq!(parse_meta("{\"accessToken\":\"x\"}"), None);
+        assert_eq!(parse_meta("3"), None); // no slot
+        assert_eq!(parse_meta("3:x"), None); // non-numeric slot
+        assert_eq!(parse_meta("x:0"), None); // non-numeric count
+        assert_eq!(parse_meta(""), None);
     }
 
     #[test]
-    fn test_chunk_account_is_distinct_and_indexed() {
-        assert_eq!(chunk_account("acct", 0), "acct__lvchunk0");
-        assert_ne!(chunk_account("acct", 0), chunk_account("acct", 1));
+    fn test_chunk_and_meta_accounts_are_distinct() {
+        assert_eq!(chunk_account("acct", 0, 0), "acct__lvchunk0_0");
+        assert_eq!(chunk_account("acct", 1, 2), "acct__lvchunk1_2");
+        assert_ne!(chunk_account("acct", 0, 0), chunk_account("acct", 1, 0));
+        assert_ne!(chunk_account("acct", 0, 0), chunk_account("acct", 0, 1));
+        assert_eq!(meta_account("acct"), "acct__lvmeta");
+        assert_ne!(meta_account("acct"), chunk_account("acct", 0, 0));
     }
 }

--- a/src-tauri/src/services/keyring_util.rs
+++ b/src-tauri/src/services/keyring_util.rs
@@ -14,14 +14,15 @@
 //!
 //! ## Layout
 //! - A separate metadata entry `"{account}__lvmeta"` holds `"{count}:{slot}"` when
-//!   the secret is chunked, and is ABSENT for a plain (unchunked) secret. Keeping
-//!   the chunk marker out-of-band means a plain secret can never be misread as a
-//!   marker, no matter its contents (relevant for the arbitrary git-password path).
+//!   the secret is chunked, and is ABSENT for a plain (unchunked) secret. Reads
+//!   consult it first, so removing/writing it is the atomic COMMIT point of a
+//!   store. Keeping the chunk marker out-of-band also means a plain secret can
+//!   never be misread as a marker, whatever its contents (the arbitrary
+//!   git-password path shares this code).
 //! - Chunks live under `"{account}__lvchunk{slot}_{i}"`. `slot` (0/1) alternates
 //!   on each rewrite so a new generation is written to fresh keys, leaving the old
 //!   generation fully intact until the metadata write commits the switch. A write
-//!   failure mid-sequence therefore preserves the previously-stored value rather
-//!   than destroying it.
+//!   failure before the commit therefore preserves the previously-stored value.
 //!
 //! macOS is handled separately by the callers (via the `security` CLI, which
 //! reads the secret from stdin and has no such small limit), so this module is
@@ -36,6 +37,10 @@ use keyring::{Entry, Error};
 /// characters (2 units each), which matters because the arbitrary git-password
 /// path shares this code. 1200 units = 2400 bytes, comfortably below 2560.
 const MAX_UTF16_UNITS_PER_ENTRY: usize = 1200;
+
+/// Upper bound on chunk indices swept during cleanup — a safety stop so a corrupt
+/// state can never spin forever. 4096 chunks is ~4 MB, far beyond any real token.
+const MAX_CHUNKS: usize = 4096;
 
 /// Keyring account name of the out-of-band chunk metadata for `account`.
 fn meta_account(account: &str) -> String {
@@ -83,40 +88,74 @@ fn entry(service: &str, account: &str) -> Result<Entry, Error> {
     Entry::new(service, account)
 }
 
-/// Best-effort delete of a single credential (missing is fine).
-fn delete_quietly(service: &str, account: &str) {
-    if let Ok(e) = entry(service, account) {
-        let _ = e.delete_credential();
+/// Delete one credential, reporting whether it existed. `Ok(false)` = already
+/// absent; a real backend error propagates.
+fn delete_one(service: &str, account: &str) -> Result<bool, Error> {
+    match entry(service, account)?.delete_credential() {
+        Ok(()) => Ok(true),
+        Err(Error::NoEntry) => Ok(false),
+        Err(e) => Err(e),
     }
 }
 
-/// Read the chunk metadata for `account`, if present.
-fn read_meta(service: &str, account: &str) -> Option<(usize, u8)> {
-    let value = entry(service, &meta_account(account))
-        .ok()?
-        .get_password()
-        .ok()?;
-    parse_meta(&value)
+/// Best-effort delete used only for non-critical cleanup (orphan/old-generation
+/// entries). A real failure is logged — never silently swallowed — but does not
+/// abort the operation, since reads no longer depend on these entries.
+fn delete_quietly(service: &str, account: &str) {
+    match delete_one(service, account) {
+        Ok(_) => {}
+        Err(e) => tracing::warn!("keyring: failed to delete stale entry {account}: {e}"),
+    }
+}
+
+/// Best-effort sweep of the contiguous chunk entries of `slot` starting at index
+/// `from`, stopping at the first missing index (or on error). Chunks are always
+/// written 0..N contiguously, so this removes a whole (or leftover) generation.
+fn sweep_chunks(service: &str, account: &str, slot: u8, from: usize) {
+    for i in from..MAX_CHUNKS {
+        match delete_one(service, &chunk_account(account, slot, i)) {
+            Ok(true) => {}
+            Ok(false) => break, // no more chunks in this slot
+            Err(e) => {
+                tracing::warn!("keyring: failed sweeping chunk {slot}/{i} of {account}: {e}");
+                break;
+            }
+        }
+    }
+}
+
+/// Read the chunk metadata for `account`. `Ok(None)` when absent (plain secret);
+/// a real backend error propagates rather than masquerading as "not chunked".
+fn read_meta(service: &str, account: &str) -> Result<Option<(usize, u8)>, Error> {
+    match entry(service, &meta_account(account))?.get_password() {
+        Ok(value) => Ok(parse_meta(&value)),
+        Err(Error::NoEntry) => Ok(None),
+        Err(e) => Err(e),
+    }
 }
 
 /// Store `secret`, chunking transparently when it exceeds one entry's capacity.
 ///
-/// Failure-atomic: the previously-stored value stays readable until the switch is
-/// committed (metadata write for a chunked secret; primary overwrite for a plain
-/// one), so a mid-sequence keyring error never leaves the account without a token.
+/// Failure-atomic: reads resolve via the metadata entry, so the previously-stored
+/// value stays readable until that metadata write/delete commits the switch. A
+/// mid-sequence keyring error before the commit leaves the old value intact, and a
+/// failed commit is propagated as `Err` (never silently leaving reads stale).
 pub fn set(service: &str, account: &str, secret: &str) -> Result<(), Error> {
-    let old = read_meta(service, account);
+    let old = read_meta(service, account)?;
 
     if secret.encode_utf16().count() <= MAX_UTF16_UNITS_PER_ENTRY {
-        // Plain: overwrite the primary key atomically (in-place replace). Only
-        // AFTER that succeeds do we drop any prior chunked generation, so a
-        // failure here leaves the old value intact.
+        // Plain: overwrite the primary key in place (atomic). If the old value was
+        // chunked, the COMMIT is deleting its metadata (reads check meta first) —
+        // that delete MUST succeed, else reads keep returning the old chunked value.
         entry(service, account)?.set_password(secret)?;
-        if let Some((count, slot)) = old {
-            delete_quietly(service, &meta_account(account));
-            for i in 0..count {
-                delete_quietly(service, &chunk_account(account, slot, i));
+        if old.is_some() {
+            match entry(service, &meta_account(account))?.delete_credential() {
+                Ok(()) | Err(Error::NoEntry) => {}
+                Err(e) => return Err(e),
             }
+            // Now committed to plain; best-effort remove both generations' chunks.
+            sweep_chunks(service, account, 0, 0);
+            sweep_chunks(service, account, 1, 0);
         }
         return Ok(());
     }
@@ -135,19 +174,19 @@ pub fn set(service: &str, account: &str, secret: &str) -> Result<(), Error> {
     // COMMIT — from here reads resolve to the new generation.
     entry(service, &meta_account(account))?.set_password(&format_meta(chunks.len(), new_slot))?;
 
-    // Best-effort cleanup of the previous generation and any stale plain primary.
+    // Best-effort cleanup: any stale plain primary, the previous generation, and
+    // any leftover higher-index chunks in the reused slot.
     delete_quietly(service, account);
-    if let Some((count, slot)) = old {
-        for i in 0..count {
-            delete_quietly(service, &chunk_account(account, slot, i));
-        }
+    if let Some((_, old_slot)) = old {
+        sweep_chunks(service, account, old_slot, 0);
     }
+    sweep_chunks(service, account, new_slot, chunks.len());
     Ok(())
 }
 
 /// Read a secret, reassembling chunks when present. `Ok(None)` if absent.
 pub fn get(service: &str, account: &str) -> Result<Option<String>, Error> {
-    if let Some((count, slot)) = read_meta(service, account) {
+    if let Some((count, slot)) = read_meta(service, account)? {
         let mut out = String::new();
         for i in 0..count {
             match entry(service, &chunk_account(account, slot, i))?.get_password() {
@@ -168,14 +207,13 @@ pub fn get(service: &str, account: &str) -> Result<Option<String>, Error> {
     }
 }
 
-/// Delete a secret and any chunk/metadata entries it owns.
+/// Delete a secret and every chunk/metadata entry it could own. Sweeps BOTH
+/// generations so a partially-failed prior rotation can't leave token fragments
+/// behind in the OS credential store.
 pub fn delete(service: &str, account: &str) -> Result<(), Error> {
-    if let Some((count, slot)) = read_meta(service, account) {
-        for i in 0..count {
-            delete_quietly(service, &chunk_account(account, slot, i));
-        }
-        delete_quietly(service, &meta_account(account));
-    }
+    sweep_chunks(service, account, 0, 0);
+    sweep_chunks(service, account, 1, 0);
+    delete_quietly(service, &meta_account(account));
     match entry(service, account)?.delete_credential() {
         Ok(()) | Err(Error::NoEntry) => Ok(()),
         Err(e) => Err(e),
@@ -242,8 +280,6 @@ mod tests {
 
     #[test]
     fn test_parse_meta_rejects_junk() {
-        // A real secret in the primary key is never parsed as metadata (metadata
-        // lives under a separate account), but parse_meta must still be strict.
         assert_eq!(parse_meta("eyJhbGciOiJSUzI1NiJ9.abc"), None);
         assert_eq!(parse_meta("{\"accessToken\":\"x\"}"), None);
         assert_eq!(parse_meta("3"), None); // no slot

--- a/src-tauri/src/services/keyring_util.rs
+++ b/src-tauri/src/services/keyring_util.rs
@@ -1,0 +1,185 @@
+//! Chunked keyring storage (non-macOS backends).
+//!
+//! The Windows Credential Manager caps a single credential's secret at 2560
+//! bytes (`CRED_MAX_CREDENTIAL_BLOB_SIZE`), which the `keyring` crate surfaces as
+//! *"Attribute 'password encoded as UTF-16' is longer than platform limit of 2560
+//! chars"*. Microsoft Entra access tokens (JWTs) — especially in large tenants
+//! whose tokens carry many group claims — routinely exceed this, so storing an
+//! OAuth token or an OAuth bundle (access + refresh + expiry JSON) fails outright.
+//!
+//! This module transparently splits an oversized secret across several keyring
+//! entries and reassembles it on read, so callers can store a secret of any size.
+//! Short secrets (PATs, small tokens) are stored verbatim under the original key,
+//! so existing entries keep working unchanged.
+//!
+//! macOS is handled separately by the callers (via the `security` CLI, which
+//! reads the secret from stdin and has no such small limit), so this module is
+//! only compiled for non-macOS targets.
+#![cfg(not(target_os = "macos"))]
+
+use keyring::{Entry, Error};
+
+/// Maximum characters per keyring entry. Windows measures the UTF-16 length of
+/// the secret; our secrets are ASCII (base64url JWTs, alphanumeric PATs, JSON),
+/// i.e. one UTF-16 code unit per char, so 1000 chars stays comfortably under the
+/// 2560 limit whether the backend counts code units (1000) or bytes (2000).
+const MAX_CHARS_PER_ENTRY: usize = 1000;
+
+/// Prefix written (with the chunk count appended) under the primary key when a
+/// secret was chunked. The `|` guarantees no collision with a real secret: it is
+/// absent from the base64url alphabet (JWTs / most tokens), and our JSON bundles
+/// start with `{` — so no value we store can equal `<MARKER><digits>`.
+const CHUNK_MARKER: &str = "__LV_CHUNKED_V1__|";
+
+/// Build a distinct keyring account name for chunk `i` of `account`.
+fn chunk_account(account: &str, i: usize) -> String {
+    format!("{account}__lvchunk{i}")
+}
+
+/// Split `secret` into `MAX_CHARS_PER_ENTRY`-sized pieces on char boundaries
+/// (never mid-UTF-8-sequence). Pure — unit-tested below.
+fn split_into_chunks(secret: &str) -> Vec<String> {
+    secret
+        .chars()
+        .collect::<Vec<char>>()
+        .chunks(MAX_CHARS_PER_ENTRY)
+        .map(|c| c.iter().collect())
+        .collect()
+}
+
+/// The marker value written under the primary key for an `n`-chunk secret.
+fn marker_for(n: usize) -> String {
+    format!("{CHUNK_MARKER}{n}")
+}
+
+/// If `value` is a chunk marker, return the chunk count it encodes. Pure.
+fn parse_marker(value: &str) -> Option<usize> {
+    value
+        .strip_prefix(CHUNK_MARKER)
+        .and_then(|n| n.parse().ok())
+}
+
+fn entry(service: &str, account: &str) -> Result<Entry, Error> {
+    Entry::new(service, account)
+}
+
+/// Store `secret`, chunking transparently when it exceeds one entry's capacity.
+pub fn set(service: &str, account: &str, secret: &str) -> Result<(), Error> {
+    // Clear any prior value (chunked or not) first, so a shrink from N chunks to
+    // a plain value — or to fewer chunks — never leaves orphaned chunk entries.
+    let _ = delete(service, account);
+
+    if secret.chars().count() <= MAX_CHARS_PER_ENTRY {
+        return entry(service, account)?.set_password(secret);
+    }
+
+    let chunks = split_into_chunks(secret);
+    for (i, chunk) in chunks.iter().enumerate() {
+        entry(service, &chunk_account(account, i))?.set_password(chunk)?;
+    }
+    // Write the marker LAST, so a reader that sees the marker is guaranteed all
+    // chunks it points at are already present.
+    entry(service, account)?.set_password(&marker_for(chunks.len()))
+}
+
+/// Read a secret, reassembling chunks when present. `Ok(None)` if absent.
+pub fn get(service: &str, account: &str) -> Result<Option<String>, Error> {
+    let head = match entry(service, account)?.get_password() {
+        Ok(v) => v,
+        Err(Error::NoEntry) => return Ok(None),
+        Err(e) => return Err(e),
+    };
+
+    let Some(n) = parse_marker(&head) else {
+        return Ok(Some(head)); // plain (non-chunked) secret
+    };
+
+    let mut out = String::new();
+    for i in 0..n {
+        match entry(service, &chunk_account(account, i))?.get_password() {
+            Ok(part) => out.push_str(&part),
+            // A missing chunk means a partial/corrupt write — treat the whole
+            // secret as absent rather than returning a truncated token.
+            Err(Error::NoEntry) => return Ok(None),
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(Some(out))
+}
+
+/// Delete a secret and any chunk entries it owns.
+pub fn delete(service: &str, account: &str) -> Result<(), Error> {
+    let head = match entry(service, account)?.get_password() {
+        Ok(v) => Some(v),
+        Err(Error::NoEntry) => None,
+        Err(e) => return Err(e),
+    };
+
+    if let Some(head) = &head {
+        if let Some(n) = parse_marker(head) {
+            for i in 0..n {
+                if let Ok(e) = entry(service, &chunk_account(account, i)) {
+                    let _ = e.delete_credential();
+                }
+            }
+        }
+        let _ = entry(service, account)?.delete_credential();
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_short_secret_is_single_chunk() {
+        let chunks = split_into_chunks("short-token");
+        assert_eq!(chunks, vec!["short-token".to_string()]);
+    }
+
+    #[test]
+    fn test_split_respects_max_chars_and_roundtrips() {
+        let secret: String = "a".repeat(2500);
+        let chunks = split_into_chunks(&secret);
+        assert_eq!(chunks.len(), 3); // 1000 + 1000 + 500
+        assert!(chunks
+            .iter()
+            .all(|c| c.chars().count() <= MAX_CHARS_PER_ENTRY));
+        assert_eq!(chunks.concat(), secret);
+    }
+
+    #[test]
+    fn test_split_boundary_exact_multiple() {
+        let secret: String = "x".repeat(MAX_CHARS_PER_ENTRY * 2);
+        let chunks = split_into_chunks(&secret);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks.concat(), secret);
+    }
+
+    #[test]
+    fn test_marker_roundtrips() {
+        assert_eq!(parse_marker(&marker_for(4)), Some(4));
+        assert_eq!(parse_marker(&marker_for(1)), Some(1));
+    }
+
+    #[test]
+    fn test_parse_marker_ignores_real_secrets() {
+        // A base64url JWT, a JSON bundle, and a PAT must never look like a marker.
+        assert_eq!(
+            parse_marker("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.abc"),
+            None
+        );
+        assert_eq!(parse_marker("{\"accessToken\":\"eyJ...\"}"), None);
+        assert_eq!(parse_marker("abcdef0123456789ABCDEF"), None);
+        // The marker prefix without a valid count is not a marker either.
+        assert_eq!(parse_marker(CHUNK_MARKER), None);
+        assert_eq!(parse_marker(&format!("{CHUNK_MARKER}notanumber")), None);
+    }
+
+    #[test]
+    fn test_chunk_account_is_distinct_and_indexed() {
+        assert_eq!(chunk_account("acct", 0), "acct__lvchunk0");
+        assert_ne!(chunk_account("acct", 0), chunk_account("acct", 1));
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -11,6 +11,8 @@ pub mod credentials_service;
 pub mod embedding;
 pub mod git_service;
 pub mod github_app;
+#[cfg(not(target_os = "macos"))]
+pub mod keyring_util;
 pub mod loopback_server;
 pub mod oauth;
 pub mod update_service;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Leviathan",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "identifier": "io.github.hegsie.leviathan",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## Summary

After a **successful** Azure DevOps (Entra) sign-in on Windows, storing the token failed:

> Operation failed: Failed to store token: Attribute 'password encoded as UTF-16' is longer than platform limit of 2560 chars

Windows Credential Manager caps a single secret at 2560 bytes (`CRED_MAX_CREDENTIAL_BLOB_SIZE`). Microsoft Entra access tokens (JWTs) — especially in large tenants whose tokens carry many group claims — routinely exceed it, so the OAuth account bundle (and the git credential) could not be stored. PATs are short and never hit this; the large OAuth token did.

This adds transparent **chunking** so a secret of any size can be stored, and reassembles it on read.

## Changes

- New `src-tauri/src/services/keyring_util.rs` (non-macOS): `set` / `get` / `delete` that split an oversized secret into UTF-16-budgeted chunks and reassemble on read. Short secrets stay stored verbatim under the original key (existing entries unchanged).
- Wired into **both** storage paths that hit the cap:
  - `commands::credentials` `store_/get_/delete_keyring_token` — the OAuth account bundle and the GitHub App key.
  - `services::credentials_service` keyring get/set/delete — the git push/pull credential.
- macOS is untouched (its `security` CLI reads the secret from stdin and has no such cap).

## Robustness (hardened over the multi-model review)

- **Failure-atomic:** chunk metadata is out-of-band (`{account}__lvmeta`); a new generation is written to an alternating slot and only the metadata write/delete commits the switch. A keyring error mid-rotation (e.g. during the hourly token refresh) leaves the **previous** token intact, and a failed commit surfaces as an error — never a silent stale read.
- **UTF-16-budgeted chunks** (not char count), so non-ASCII secrets can't overflow the cap.
- **No fragment leaks:** orphaned chunks from a partial/failed rotation are swept on store and on delete; `delete()` reports if any removal failed. Cleanup failures are logged, not swallowed.
- Out-of-band metadata also removes any marker-collision risk for the arbitrary git-password path.

## Testing

- Pure chunk/metadata helpers unit-tested (ASCII + astral-plane/UTF-16 budgeting, marker parsing, key derivation). The live keyring round-trip needs a real OS backend (unavailable in CI), matching the existing `credentials_service` test approach.
- `cargo fmt` / `clippy -D warnings` / oauth + credentials + keyring_util tests green.
- Reviewed to convergence by the recursive multi-model review (Opus/Sonnet/Haiku).

Follow-up to the Azure DevOps interactive sign-in work (#256); ships in **v0.5.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ)_