### PR TITLE
chore(release): bump version to 0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leviathan",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A fully-featured, open-source, cross-platform Git GUI client",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2927,7 +2927,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leviathan"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leviathan"
-version = "0.5.2"
+version = "0.5.3"
 description = "A fully-featured, open-source, cross-platform Git GUI client"
 authors = ["Leviathan Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Leviathan",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "identifier": "io.github.hegsie.leviathan",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Release **v0.5.3**.

Bumps the version to `0.5.3` across all four files (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`).

### What's in this release
Everything needed for Azure DevOps sign-in to work end-to-end in locked-down tenants:
- **Interactive Microsoft (Entra ID) sign-in via the Visual Studio first-party client (#256)** — no admin consent, no app registration; the interactive loopback flow satisfies Conditional Access.
- **Windows Credential Manager token chunking (#258)** — large Entra access tokens (which exceed the 2560-byte per-secret cap) are transparently split across keyring entries and reassembled, with failure-atomic rotation and orphan-fragment sweeping.

### Releasing
After merge, tag the merge commit `v0.5.3` and push the tag to trigger the release build (`build.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ)_