### PR TITLE
ci: fold CMake version into the Windows build cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,12 +96,23 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # llama-cpp-sys-2 builds a native library via CMake and caches its CMake
+      # build directory inside target/. That directory hard-codes the runner's
+      # CMake module paths (…/share/cmake-X.Y/…), so when GitHub bumps CMake in
+      # place on a runner image, a restored cache points at the old version's
+      # modules and the incremental reconfigure fails ("… cmake-4.3/Modules/…
+      # does not exist"). Fold the CMake version into the rust-cache key so any
+      # CMake bump invalidates the cache instead of poisoning the build.
+      - name: Capture CMake version for cache key
+        shell: bash
+        run: echo "CMAKE_VERSION=$(cmake --version | head -n1)" >> "$GITHUB_ENV"
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
           cache-on-failure: true
-          env-vars: ImageOS
+          env-vars: ImageOS CMAKE_VERSION
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'


### PR DESCRIPTION
## Problem

The `build (windows-latest, …)` job started failing while building `llama-cpp-sys-2` (the native on-device-AI dependency) via CMake:

```
CMake Error: File C:/Program Files/CMake/share/cmake-4.3/Modules/CMakeSystem.cmake.in does not exist.
Unknown CMake command "CMAKE_DETERMINE_COMPILER_ID".
CMake Configure step failed. Build files cannot be regenerated correctly.
thread 'main' panicked at cmake-0.1.57/src/lib.rs:1132
```

`llama-cpp-sys-2` caches its native CMake **build directory** inside `target/` (via `Swatinem/rust-cache`), and that directory hard-codes the runner's CMake module paths (`…/share/cmake-X.Y/…`). GitHub bumped CMake **in place** on the `windows-latest` image (4.3 → 4.4), so a restored cache still pointed at the old `cmake-4.3` modules and the incremental reconfigure failed. macOS and Linux — which happened to get fresh caches — built the same commit fine.

Two things made it sticky: the rust-cache key didn't include the CMake version (so the bump didn't invalidate it), and `cache-on-failure: true` re-saved the poisoned build directory, so a plain re-run kept failing until the cache was cleared by hand.

## Fix

Capture the CMake version into `$GITHUB_ENV` and add `CMAKE_VERSION` to `Swatinem/rust-cache`'s `env-vars`, so the cache key includes it. Any future CMake bump on a runner now produces a fresh key and a clean build instead of restoring a stale, version-mismatched CMake build directory.

- One workflow file changed; no change to the app or its build otherwise.
- Applies to all three platforms (all build `llama-cpp-sys-2` via CMake), so a CMake bump on any runner self-invalidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Nw79koz8Wk29mB6nJV6mF)_