### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leviathan",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leviathan",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@lit-labs/context": "^0.5.0",
         "@tauri-apps/api": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leviathan",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A fully-featured, open-source, cross-platform Git GUI client",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2927,7 +2927,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leviathan"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leviathan"
-version = "0.6.0"
+version = "0.7.0"
 description = "A fully-featured, open-source, cross-platform Git GUI client"
 authors = ["Leviathan Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Leviathan",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "identifier": "io.github.hegsie.leviathan",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Minor release. Bumps the version to **0.7.0** across `package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json` (same 5-file pattern as prior releases).

## What ships in 0.7.0

**Rewritten conflicts workflow (#275)** — a marker-free merge editor:
- Structured ours/theirs segments with per-block **Use Ours / Theirs / Both**, in-place editing, per-block reset, and AI-assisted resolution. Raw git conflict markers (`<<<<<<<` / `=======` / `>>>>>>>`) are now an internal representation only — they never render in the UI and never round-trip to disk as a resolution (Mark Resolved stays disabled until every block is resolved).
- LCS-aligned three-way panes with bidirectional scroll sync; a failed working-dir read shows a Retry error state instead of a fabricated merge.
- Complete terminal states for every conflict shape: binary, symlink, submodule/gitlink, type-change, delete/modify, add/add, non-UTF-8 path, and read-failure.
- Replay-verified marker-size detection hardened against quoted-marker, stale/reverted-attribute, and hand-broken-structure files (never leaks a raw marker to the pane or disk).
- Multi-repo operation pinning across every mutating handler and all six dialogs — operation, refresh, and self-close — so an operation started on one repo can't act on or refresh the wrong one after a tab switch.
- Conflicted files redirect to the merge editor from the diff view; state-clean stash conflicts have a way back into resolution.

**Windows CI cache-key fix (#276)** — folds the CMake version into the rust-cache key so a runner CMake bump self-invalidates instead of poisoning the Windows build.

## Releasing

After merge, trigger the **Build & Release** workflow via `workflow_dispatch` with `release: true` — `tauri-action` then tags `v0.7.0` from `tauri.conf.json` and creates the draft release with the built artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Nw79koz8Wk29mB6nJV6mF)_